### PR TITLE
Show student evaluated answers for a fallback in the attempts table

### DIFF
--- a/lib/WeBWorK/HTML/AttemptsTable.pm
+++ b/lib/WeBWorK/HTML/AttemptsTable.pm
@@ -254,12 +254,16 @@ sub formatAnswerRow ($self, $rh_answer, $ans_id, $answerNumber) {
 	);
 
 	return $c->c(
-		$self->showAnswerNumbers   ? $c->tag('td', $answerNumber)                                               : '',
-		$self->showAttemptAnswers  ? $c->tag('td', dir => 'auto', $self->nbsp($answerString))                   : '',
-		$self->showAttemptPreviews ? $self->formatToolTip($answerString, $answerPreview)                        : '',
-		$self->showAttemptResults  ? $attemptResults                                                            : '',
-		$self->showCorrectAnswers  ? $self->formatToolTip($correctAnswer, $correctAnswerPreview)                : '',
-		$self->showMessages        ? $c->tag('td', class => $feedbackMessageClass, $self->nbsp($answerMessage)) : ''
+		$self->showAnswerNumbers  ? $c->tag('td', $answerNumber)                             : '',
+		$self->showAttemptAnswers ? $c->tag('td', dir => 'auto', $self->nbsp($answerString)) : '',
+		$self->showAttemptPreviews
+		? ($answerPreview || $self->showAttemptAnswers
+			? $self->formatToolTip($answerString, $answerPreview)
+			: $c->tag('td', dir => 'auto', $self->nbsp($answerString)))
+		: '',
+		$self->showAttemptResults ? $attemptResults                                                            : '',
+		$self->showCorrectAnswers ? $self->formatToolTip($correctAnswer, $correctAnswerPreview)                : '',
+		$self->showMessages       ? $c->tag('td', class => $feedbackMessageClass, $self->nbsp($answerMessage)) : ''
 	)->join('');
 }
 


### PR DESCRIPTION
When the `$pg{options}{showEvaluatedAnswers}` option is false and parsing of the student answer fails, then show the evaluated answer in the "Answer Preview" column instead of showing nothing.  This is what would be shown in the "Entered" column if `$pg{options}{showEvaluatedAnswers}` were true.