### PR TITLE
move definition of pgmlPercent to within pgmlSetup

### DIFF
--- a/conf/snippets/hardcopyThemes/common/PGML.tex
+++ b/conf/snippets/hardcopyThemes/common/PGML.tex
@@ -5,10 +5,10 @@
 \newdimen\pgmlPixels
 
 \pgmlPixels=.5pt
-\pgmlPercent=.01\hsize
 
 {\catcode`\^^M=\active%
   \gdef\pgmlSetup{%
+    \pgmlPercent=.01\hsize%
     \parskip=0pt%
     \def\par{\ifmmode\else\endgraf\fi\ignorespaces}%
     \catcode`\^^M=\active%


### PR DESCRIPTION
The way `\pgmlPercent` is currently defined, one "pgmlPercent" is defined before the file may have entered two-column mode. So for example something like this in a set's first problem
```
BEGIN_PGML
Text
====
More text
END_PGML
```
will make a horizontal rule that overflows into the second column.

This changes `\pgmlPercent` to be redefined every time `pgmlSetup` is invoked, so it's based on the actual local line width. 