### PR TITLE
Restructure the PG error messages in Problem.pm

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -703,24 +703,19 @@ sub warnings ($c) {
 			$c->tag(
 				'div',
 				$c->c(
-					$c->tag('h3', style => 'color:red;', $c->maketext('PG question processing error messages')),
-					@pgdebug ? $c->tag(
-						'p',
-						$c->c($c->tag('h3', $c->maketext('PG debug messages')),
-							$c->c(@pgdebug)->join($c->tag('br')))->join('')
-					) : '',
-					@pgwarning ? $c->tag(
-						'p',
-						$c->c($c->tag('h3', $c->maketext('PG warning messages')),
-							$c->c(@pgwarning)->join($c->tag('br')))->join('')
-					) : '',
-					@pginternalerrors ? $c->tag(
-						'p',
-						$c->c(
-							$c->tag('h3', $c->maketext('PG internal errors')),
-							$c->c(@pginternalerrors)->join($c->tag('br'))
-						)->join('')
-					) : ''
+					$c->tag('h2', $c->maketext('PG question processing error messages')),
+					@pgdebug ? $c->c(
+						$c->tag('h3', $c->maketext('PG debug messages')),
+						$c->tag('p',  $c->c(@pgdebug)->join($c->tag('br')))
+					)->join('') : '',
+					@pgwarning ? $c->c(
+						$c->tag('h3', $c->maketext('PG warning messages')),
+						$c->tag('p',  $c->c(@pgwarning)->join($c->tag('br')))
+					)->join('') : '',
+					@pginternalerrors ? $c->c(
+						$c->tag('h3', $c->maketext('PG internal errors')),
+						$c->tag('p',  $c->c(@pginternalerrors)->join($c->tag('br')))
+					)->join('') : ''
 				)->join('')
 			)
 		);


### PR DESCRIPTION
You can not have an `h3` in a `p` tag.

Make the first header for these warnings an `h2` tag since there aren't any tags between this and the page title `h1`.  Also remove the `style="color:red;"` from this, as that does not satisfy accessibility contrast requirements with the background color here.