### PR TITLE
Fix the raw output format for FormatRenderedProblem.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -211,7 +211,7 @@ sub formatRenderedProblem {
 		$output->{input}      = $ws->{input};
 
 		# The following could be constructed from the above, but this is a convenience
-		$output->{answerTemplate}  = $answerTemplate if ($answerTemplate);
+		$output->{answerTemplate}  = $answerTemplate->to_string if $answerTemplate;
 		$output->{lang}            = $PROBLEM_LANG_AND_DIR{lang};
 		$output->{dir}             = $PROBLEM_LANG_AND_DIR{dir};
 		$output->{extra_css_files} = \@extra_css_files;


### PR DESCRIPTION
The AttemptsTable::answerTemplate now returns a ByteStream object instead of a string.  That needs to be converted to a string before being passed to be encode into JSON.  Otherwise JSON's encode method fails because that is a blessed object.

This should fix #2042.