### PR TITLE
Show non fatal warnings in the PG problem editor.

### DIFF
--- a/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/apps/PGProblemEditor/pgproblemeditor.js
@@ -283,7 +283,8 @@
 			showFooter: 0,
 			displayMode: document.getElementById('action_view_displayMode_id')?.value ?? 'MathJax',
 			language: document.querySelector('input[name="hidden_language"]')?.value ?? 'en',
-			send_pg_flags: 1
+			send_pg_flags: 1,
+			view_problem_debugging_info: 1
 		})).then(() => resolve());
 	});
 


### PR DESCRIPTION
These warnings are shown when generating a hardcopy in the problem editor, but not when directly rendering the problem.  These warnings are shown when you view the problem in the set for instructors, and should certainly be shown for problem authors.  This was an oversight that this parameter was not added to begin with.