### PR TITLE
alternate pathway to user detail

### DIFF
--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -89,6 +89,33 @@
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
 			% # Class list editor
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
+			% # User Assignments
+			% if (defined $eUserID && $eUserID ne $userID || defined $urlUserID) {
+				<li class="list-group-item nav-item">
+					<ul class="nav flex-column">
+						% if (defined $urlUserID) {
+							<li class="nav-item">
+								<%= $makelink->(
+									'instructor_user_detail',
+									text       => $urlUserID,
+									captures   => { userID => $urlUserID },
+									link_attrs => { dir => 'ltr' }
+								); %>
+							</li>
+						% }
+						% if ($userID ne $eUserID && (!defined $urlUserID || $urlUserID ne $eUserID)) {
+							<li class="nav-item">
+								<%= $makelink->(
+									'instructor_user_detail',
+									text       => $eUserID,
+									captures   => { userID => $eUserID },
+									link_attrs => { dir => 'ltr' }
+								); %>
+							</li>
+						% }
+					</ul>
+				</li>
+			% }
 			% # Homework Set Editor
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_list') %></li>
 			% # Editor link.  Only shown for non-versioned sets

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -163,6 +163,7 @@
 								'instructor_user_statistics',
 								text     => $urlUserID,
 								captures => { userID => $urlUserID },
+								link_attrs => { dir => 'ltr' }
 							) %>
 						</li>
 					% }
@@ -173,7 +174,8 @@
 								text     => $eUserID,
 								captures => { userID => $eUserID },
 								active   => current_route eq 'instructor_user_statistics'
-									&& !defined $urlUserID
+									&& !defined $urlUserID,
+								link_attrs => { dir => 'ltr' }
 							) %>
 						</li>
 					% }
@@ -216,6 +218,7 @@
 									'instructor_user_progress',
 									text     => $urlUserID,
 									captures => { userID => $urlUserID },
+									link_attrs => { dir => 'ltr' }
 								) %>
 							</li>
 						% }
@@ -226,7 +229,8 @@
 									text     => $eUserID,
 									captures => { userID => $eUserID },
 									active   => current_route eq 'instructor_user_progress'
-										&& !defined $urlUserID
+										&& !defined $urlUserID,
+									link_attrs => { dir => 'ltr' }
 								) %>
 							</li>
 						% }


### PR DESCRIPTION
This is one last (I hope) change I'd like to propose to sidebar navigation. With this, if you are acting as some user, then you have a direct link in the sidebar nav to see their user detail page (which has more details about all the sets assigned to them, including test versions).

The only current way (that I know of) to navigate here is to go to the Classlist Editor and click the link in the "Assigned Sets" column. That still works with this. But also now if you arrive at that page this way, you will see this is where you are in the sidebar nav.

If you are acting as user X and you go to Classlist Editor and click the link in the "Assigned Sets" column for user Y, you will see two links in the sidebar (assuming X ≠ Y). The one for Y is active, and the one for X is just visible because you are acting as X. Here is a screenshot with all of that going on, consistent with Statistics and Student Progress.

<img width="1550" alt="Screen Shot 2023-06-09 at 1 59 43 PM" src="https://github.com/openwebwork/webwork2/assets/4732672/2a4400db-4eed-42c9-8983-6e3fa5f073ef">

