### PR TITLE
Reorganize defaults.config to include localOverrides.conf before `$ConfigValues` is defined

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1382,6 +1382,14 @@ $pg{answersOpenAfterDueDate} = 2880;
 $pg{options}{enableProgressBar} = 1;
 
 ################################################################################
+# Site wide overrides are entered into the file localOverrides.conf
+################################################################################
+# This is loaded before the $ConfigValues definition, so that the if values of
+# $hardcopyThemes and $hardcopyThemeNames are overridden in localOverrides.conf,
+# then those values are used and shown in the course configuration.
+include("conf/localOverrides.conf");
+
+################################################################################
 # WeBWorK::ContentGenerator::Instructor::Config
 ################################################################################
 
@@ -2062,10 +2070,5 @@ $ConfigValues = [
 		},
 	],
 ];
-
-################################################################################
-# Site wide overrides are entered into the file localOverrides.conf
-################################################################################
-include("conf/localOverrides.conf");
 
 1; #final line of the file to reassure perl that it was read properly.


### PR DESCRIPTION
See https://github.com/openwebwork/webwork2/pull/2049#issuecomment-1590299262 for an explanation as to why this is done.