### PR TITLE
Fix POD generation for webwork2.

### DIFF
--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -64,11 +64,12 @@ $base_url = "/" if !$base_url;
 use IO::File;
 use File::Path qw(make_path remove_tree);
 use File::Basename qw(dirname);
+use Cwd qw(abs_path);
 
 use lib dirname(__FILE__);
 use PODtoHTML;
 
-my $webwork_root = dirname(dirname(dirname(__FILE__)));
+my $webwork_root = abs_path(dirname(dirname(dirname(__FILE__))));
 
 for my $dir ($webwork_root, $pg_root) {
 	next unless $dir && -d $dir;


### PR DESCRIPTION
The `generate-ww-pg-pod.pl` script needs to have absolute path to the webwork2 code (or really the path just needs to contain the last folder webwork2).  Currently if you run `./bin/dev_scripts/generate-ww-pg-pod.pl $webwork_root` in the script is set to `.`.  Since that doesn't have webwork2 in it, the script skips the directory.  This fixes that by calling abs_path after finding the webwork root directory from `__FILE__`.

Note that running `/opt/webwork/webwork2/bin/dev_scripts/generate-ww-pg-pod.pl` does work with the current code.  You can also use `../webwork2/bin/dev_scripts/generate-ww-pg-pod.pl` and that will work since the relative path contains webwork2, but that is an annoying extra step.