### PR TITLE
Do not html escape a link shown on the problem sets page (course home)

### DIFF
--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -3,7 +3,7 @@
 % unless ($authz->hasPermissions(param('user'), 'navigation_allowed')) {
 	<div class="alert alert-danger">
 		<b>
-			<%= maketext('You must access assignments from your Course Management System ([_1]).',
+			<%== maketext('You must access assignments from your Course Management System ([_1]).',
 				$ce->{LTI}{ $ce->{LTIVersion} }{LMS_url}
 					? link_to($ce->{LTI}{ $ce->{LTIVersion} }{LMS_name} => $ce->{LTI}{ $ce->{LTIVersion} }{LMS_url})
 					: $ce->{LTI}{ $ce->{LTIVersion} }{LMS_name}) =%>


### PR DESCRIPTION
The message that is shown to users that do not have the navigation_allowed permissions is currently html escaped.  That message can have a link to the LMS in it, and in that case the actual html for the link is shown instead of the html rendering of the link.  To fix this that message must not be html escaped of course.