### PR TITLE
Update the temporary directory comments and location.

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -356,15 +356,17 @@ $mail{feedbackRecipients}    = [
 # that is not backed up and is the recommended set up for most installations.
 # See http://webwork.maa.org/wiki/Store_WeBWorK%27s_temporary_files_in_a_separate_directory_or_partition
 # for more information.   Note that the wwtmp directory (or partition) should be
-# created under Apache's main server document root which is usually /var/www. If this
-# is in a different location on your system, edit the lines below accordingly.
+# created under Apache's main server document root which is usually
+# /var/www/html. If this is in a different location on your system, edit the
+# lines below accordingly.  Note that you will also need to ensure server user
+# has read and write permission for the directory.
 # To implement, uncomment the following 6 lines:
-#$webworkDirs{htdocs_temp}  =  '/var/www/wwtmp';
+#$webworkDirs{htdocs_temp}   = '/var/www/html/wwtmp';
 #$webworkURLs{htdocs_temp}   = '/wwtmp';
 #$webworkDirs{equationCache} = "$webworkDirs{htdocs_temp}/equations";
 #$webworkURLs{equationCache} = "$webworkURLs{htdocs_temp}/equations";
-#$courseDirs{html_temp}  =  "/var/www/wwtmp/$courseName";
-#$courseURLs{html_temp}   = "/wwtmp/$courseName";
+#$courseDirs{html_temp}      = "/var/www/html/wwtmp/$courseName";
+#$courseURLs{html_temp}      = "/wwtmp/$courseName";
 
 #####################
 # Additional PG modules


### PR DESCRIPTION
The comment is updated to state that the directory chosen must be have the correct permissions set.  Note the comment already states that the directory must be created.

The current comment about the system default for apache2's document root is incorrect.  On most systems that is `/var/www/html`, not `/var/www`.  So that comment is corrected, and the example settings adjusted.

This is to address what is left of issue #2047.