### PR TITLE
Fix proctor login after incorrect password

### DIFF
--- a/templates/ContentGenerator/LoginProctor.html.ep
+++ b/templates/ContentGenerator/LoginProctor.html.ep
@@ -42,7 +42,7 @@
 %= form_for current_route, method => 'POST', begin
 	% # Add the form data posted to the requested URI in hidden fields.
 	% my @fields_to_print =
-		% grep { !/^(user|effectiveUser|passwd|key|force_password_authen|proctor_user|proctor_key|proctor_password)$/ }
+		% grep { !/^(user|effectiveUser|passwd|key|force_password_authen|proctor_user|proctor_key|proctor_passwd)$/ }
 			% param;
 	% if (@fields_to_print) {
 		<%= $c->hidden_fields(@fields_to_print) %>


### PR DESCRIPTION
This is a new bug caused by a very old typo.  The grep that is now in templates/ContentGenerator/LoginProctor.html.ep should be filtering out the proctor_passwd input, but instead is skipping the non-existent proctor_password input, and adding a hidden input for the proctor_passwd input.  The typo traces back to 2007.

What happens as a result is that if you incorrectly type the proctor password on the first attempt, then all successive attemps are using the incorrect password in the hidden field instead of the newly entered password in the input shown on the screen.  Thus once you have a typo in entering the password, you can not sign in again without leaving the proctor authentication page and coming back.  I have not locked down how it somehow worked before, but I tested with webwork 2.17 and you can authenticate with the proctor user after a first incorrect attempt.  So this is probably something to do with Mojolicous autofilling input values or the rework of the params method.