### PR TITLE
Fix the LTI config tab.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -164,6 +164,4 @@ $LTIMassUpdateInterval = 86400;    #in seconds
 	#'debug_lti_parameters'
 );
 
-include('conf/LTIConfigValues.config');
-
 1;    # final line of the file to reassure perl that it was read properly.

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -2078,4 +2078,6 @@ $ConfigValues = [
 	],
 ];
 
+include('conf/LTIConfigValues.config');
+
 1; #final line of the file to reassure perl that it was read properly.


### PR DESCRIPTION
The LTIConfigvalues.config inclusion is moved to to the end of defaults.config, instead of the end of authen_LTI.conf.  This means that file is always included.  However, the config variables it defines are only added to the `$ConfigValues` array if there are uncommented entries in the `@LTIConfigVariables` array that is still defined in authen_LTI.conf.  So the behavior is the same as before.