### PR TITLE
Tweak the attempts table preview fallback when $pg{options}{showEvaluatedAnswers} is false.

### DIFF
--- a/lib/WeBWorK/HTML/AttemptsTable.pm
+++ b/lib/WeBWorK/HTML/AttemptsTable.pm
@@ -257,7 +257,7 @@ sub formatAnswerRow ($self, $rh_answer, $ans_id, $answerNumber) {
 		$self->showAnswerNumbers  ? $c->tag('td', $answerNumber)                             : '',
 		$self->showAttemptAnswers ? $c->tag('td', dir => 'auto', $self->nbsp($answerString)) : '',
 		$self->showAttemptPreviews
-		? ($answerPreview || $self->showAttemptAnswers
+		? (((defined $answerPreview && $answerPreview ne '') || $self->showAttemptAnswers)
 			? $self->formatToolTip($answerString, $answerPreview)
 			: $c->tag('td', dir => 'auto', $self->nbsp($answerString)))
 		: '',


### PR DESCRIPTION
It is possible in certain situations that an answer preview can be 0. If that is the case, then the preview should not fallback to showing the entered answer.

The only case that I know of that this can happen for the MathJax or images display modes is if a student enters 0 for an essay answer. Note that for standard answers an answer of 0 would either be wrapped in a script math/tex tag, or turned into an image.  So this can't happen for those.  So that brings us to the only other case I know of at all that this can happen.  That is when the plainText display mode is used and the answer is 0.

When would an essay answer be litterally 0?  Who uses the plainText display mode?  Okay, so this isn't a serious issue, but for correctness.