### PR TITLE
Fix the PG Problem Editor for files that have spaces in the filename.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -566,7 +566,7 @@ sub getFilePaths ($c) {
 
 sub getBackupTimes ($c) {
 	my $backupBasePath = $c->{backupBasePath};
-	my @files          = glob("$backupBasePath*");
+	my @files          = glob(qq("$backupBasePath*"));
 	return unless @files;
 	return reverse(map { $_ =~ s/$backupBasePath//r } @files);
 }


### PR DESCRIPTION
The glob in the `getBackupTimes` method needs special quoting to handle spaces in filenames.

To test this try to edit a pg problem with spaces in the filename.  On develop the editor won't open, and you get an exception screen.  With this pull request it will work of course.