### PR TITLE
Update the POD generation scripts and add POD routes.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -128,6 +128,8 @@ my @modulesList = qw(
 	PadWalker
 	Path::Class
 	PHP::Serialization
+	Pod::Simple::Search
+	Pod::Simple::XHTML
 	Pod::Usage
 	Pod::WSDL
 	Safe

--- a/bin/dev_scripts/PODtoHTML.pm
+++ b/bin/dev_scripts/PODtoHTML.pm
@@ -182,25 +182,25 @@ sub write_index {
 	my $date = strftime "%a %b %e %H:%M:%S %Z %Y", localtime;
 
 	my $fh = new IO::File($out_path, '>') or die "Failed to open index '$out_path' for writing: $!\n";
-	print $fh (get_header($title), $content_start, $content, "<p>Generated $date</p>", get_footer());
+	print $fh (get_header($title, $self->{dest_url}), $content_start, $content, "<p>Generated $date</p>", get_footer());
 }
 
 sub do_pod2html {
 	my $self = shift;
 	my %o    = @_;
-	my $psx  = new PODParser;
+	my $psx  = PODParser->new;
 	$psx->{source_root} = $self->{source_root};
 	$psx->{verbose}     = $self->{verbose};
 	$psx->{base_url}    = ($self->{dest_url} // "") . "/" . (($self->{source_root} // "") =~ s|^.*/||r);
 	$psx->output_string(\my $html);
-	$psx->html_header(get_header($o{pod_name}));
+	$psx->html_header(get_header($o{pod_name}, $psx->{base_url}));
 	$psx->html_footer(get_footer());
 	$psx->parse_file($o{pod_path});
 	return $html;
 }
 
 sub get_header {
-	my $title = shift;
+	my ($title, $base_url) = @_;
 	return <<EOF;
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
@@ -208,6 +208,7 @@ sub get_header {
 <meta charset='UTF-8'>
 <link rel="icon" href="/favicon.ico">
 <title>$title</title>
+<link href="$base_url/../css/pod.css" rel="stylesheet">
 </head>
 <body>
 <h1>$title</h1>
@@ -236,4 +237,3 @@ EOF
 }
 
 1;
-

--- a/bin/dev_scripts/PODtoHTML.pm
+++ b/bin/dev_scripts/PODtoHTML.pm
@@ -13,26 +13,24 @@
 # Artistic License for more details.
 ################################################################################
 
+package PODtoHTML;
+
 use strict;
 use warnings;
 
-package PODtoHTML;
-
-use File::Find qw(find);
+use Pod::Simple::Search;
 use File::Path qw(make_path);
 use IO::File;
-use Pod::Find qw(contains_pod);
 use POSIX qw(strftime);
-use PODParser;
+
+use WeBWorK::Utils::PODParser;
 
 our @sections = (
-	'/'     => "(root)",
-	bin     => "Scripts",
-	conf    => "Config Files",
-	doc     => "Documentation",
-	lib     => "Libraries",
-	macros  => "Macros",
-	clients => "Clients"
+	bin    => "Scripts",
+	conf   => "Config Files",
+	doc    => "Documentation",
+	lib    => "Libraries",
+	macros => "Macros"
 );
 
 sub new {
@@ -58,38 +56,17 @@ sub convert_pods {
 	my $source_root = $self->{source_root};
 	my $dest_root   = $self->{dest_root};
 
-	find({ wanted => $self->gen_pod_wanted, no_chdir => 1 }, $source_root);
+	my $regex = join('|', map {"^$_"} @{ $self->{section_order} });
+
+	(undef, my $podFiles) = Pod::Simple::Search->new->inc(0)->limit_re(qr!$regex!)->survey($self->{source_root});
+	for (keys %$podFiles) {
+		print "Processing file: $_\n" if $self->{verbose} > 1;
+		$self->process_pod($_);
+	}
+
 	$self->write_index("$dest_root/index.html");
-}
 
-sub gen_pod_wanted {
-	my $self = shift;
-	return sub {
-		my $path   = $File::Find::name;
-		my $dir    = $File::Find::dir;
-		my ($name) = $path =~ m|^$dir(?:/(.*))?$|;
-		$name = '' unless defined $name;
-
-		if ($name =~ /^\./) {
-			$File::Find::prune = 1;
-			return;
-		}
-		unless (-f $path or -d $path) {
-			$File::Find::prune = 1;
-			return;
-		}
-		if (-d _ and $name =~ /^(\.git|\.github|t|htdocs)$/) {
-			$File::Find::prune = 1;
-			return;
-		}
-
-		return if -d _;
-		return unless contains_pod($path);
-
-		print "Processing file: $path\n" if $self->{verbose} > 1;
-
-		$self->process_pod($path);
-	};
+	return;
 }
 
 sub process_pod {
@@ -135,13 +112,16 @@ sub process_pod {
 		pod_path => $pod_path,
 		pod_name => $pod_name
 	);
-	my $fh = new IO::File($html_path, '>')
+	my $fh = IO::File->new($html_path, '>')
 		or die "Failed to open file '$html_path' for writing: $!\n";
 	print $fh $html;
+
+	return;
 }
 
 sub update_index {
 	my ($self, $subdir, $html_rel_path, $pod_name) = @_;
+
 	$subdir =~ s|/.*$||;
 	my $idx      = $self->{idx};
 	my $sections = $self->{section_hash};
@@ -150,50 +130,47 @@ sub update_index {
 	} else {
 		warn "no section for subdir '$subdir'\n";
 	}
+
+	return;
 }
 
 sub write_index {
 	my ($self, $out_path) = @_;
-	my $idx           = $self->{idx};
-	my $sections      = $self->{section_hash};
-	my $section_order = $self->{section_order};
-	my $source_root   = $self->{source_root};
-	$source_root =~ s|^.*/||;
 
-	my $title         = "Index for $source_root";
-	my $content_start = "<ul>";
-	my $content       = "";
+	my $source_root = $self->{source_root} =~ s|^.*/||r;
+	my $title       = "Index for $source_root";
 
-	for my $section (@$section_order) {
-		next unless defined $idx->{$section};
-		my $section_name = $sections->{$section};
-		$content_start .= qq{<li><a href="#$section">$section_name</a></li>};
-		my @files = sort @{ $idx->{$section} };
-		$content .= qq{<a name="$section"></a>};
-		$content .= qq{<h2><a href="#_podtop_">$section_name</a></h2><ul>};
-		for my $file (sort { $a->[1] cmp $b->[1] } @files) {
-			my ($path, $name) = @$file;
-			$content .= qq{<li><a href="$path">$name</a></li>};
+	my $content_start = '<ul>';
+	my $content       = '';
+
+	for my $section (@{ $self->{section_order} }) {
+		next unless defined $self->{idx}{$section};
+		$content_start .= qq{<li><a href="#$section">$self->{section_hash}{$section}</a></li>};
+		$content       .= qq{<h2><a href="#_podtop_" id="$section">$self->{section_hash}{$section}</a></h2><ul>};
+		for my $file (sort { $a->[1] cmp $b->[1] } @{ $self->{idx}{$section} }) {
+			$content .= qq{<li><a href="$file->[0]">$file->[1]</a></li>};
 		}
-		$content .= "</ul>";
+		$content .= '</ul>';
 	}
 
-	$content_start .= "</ul>";
-	my $date = strftime "%a %b %e %H:%M:%S %Z %Y", localtime;
+	$content_start .= '</ul>';
+	my $date = strftime '%a %b %e %H:%M:%S %Z %Y', localtime;
 
-	my $fh = new IO::File($out_path, '>') or die "Failed to open index '$out_path' for writing: $!\n";
+	my $fh = IO::File->new($out_path, '>') or die "Failed to open index '$out_path' for writing: $!\n";
 	print $fh (get_header($title, $self->{dest_url}), $content_start, $content, "<p>Generated $date</p>", get_footer());
+
+	return;
 }
 
 sub do_pod2html {
-	my $self = shift;
-	my %o    = @_;
-	my $psx  = PODParser->new;
-	$psx->{source_root} = $self->{source_root};
-	$psx->{verbose}     = $self->{verbose};
-	$psx->{base_url}    = ($self->{dest_url} // "") . "/" . (($self->{source_root} // "") =~ s|^.*/||r);
+	my ($self, %o) = @_;
+	my $psx = WeBWorK::Utils::PODParser->new;
+	$psx->{source_root}     = $self->{source_root};
+	$psx->{verbose}         = $self->{verbose};
+	$psx->{assert_html_ext} = 1;
+	$psx->{base_url}        = ($self->{dest_url} // "") . "/" . (($self->{source_root} // "") =~ s|^.*/||r);
 	$psx->output_string(\my $html);
-	$psx->html_header(get_header($o{pod_name}, $psx->{base_url}));
+	$psx->html_header(get_header($o{pod_name}, "$psx->{base_url}/.."));
 	$psx->html_footer(get_footer());
 	$psx->parse_file($o{pod_path});
 	return $html;
@@ -201,25 +178,28 @@ sub do_pod2html {
 
 sub get_header {
 	my ($title, $base_url) = @_;
-	return <<EOF;
+	return << "EOF";
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
 <meta charset='UTF-8'>
 <link rel="icon" href="/favicon.ico">
 <title>$title</title>
-<link href="$base_url/../css/pod.css" rel="stylesheet">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap\@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+<link href="$base_url/css/pod.css" rel="stylesheet">
 </head>
 <body>
+<div class="container mt-3">
 <h1>$title</h1>
-<div style="margin-left:20px">Jump to: <a href="#column-one">Site Navigation</a></div>
+<hr>
+<div>Jump to: <a href="#column-one">Site Navigation</a></div>
 <hr>
 <div id="_podtop_">
 EOF
 }
 
 sub get_footer {
-	return <<'EOF';
+	return << 'EOF';
 </div>
 <hr>
 <div id="column-one">
@@ -229,6 +209,7 @@ sub get_footer {
 <li><a href="/pod">WeBWorK POD Home</a></li>
 <li><a href="http://webwork.maa.org/wiki/WeBWorK_Main_Page">WeBWorK Wiki</a></li>
 </ul>
+</div>
 </div>
 </div>
 </body>

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -62,6 +62,7 @@ pod2usage(2) unless $output_dir;
 $base_url = "/" if !$base_url;
 
 use IO::File;
+use File::Copy;
 use File::Path qw(make_path remove_tree);
 use File::Basename qw(dirname);
 use Cwd qw(abs_path);
@@ -77,9 +78,13 @@ for my $dir ($webwork_root, $pg_root) {
 	process_dir($dir);
 }
 
+make_path("$output_dir/css");
+copy("$webwork_root/bin/dev_scripts/pod.css", "$output_dir/css/pod.css");
+print "copying $webwork_root/bin/dev_scripts/pod.css to $output_dir/css/pod.css\n" if $verbose;
+
 my $index_fh = new IO::File("$output_dir/index.html", '>')
 	or die "failed to open '$output_dir/index.html' for writing: $!\n";
-write_index($index_fh);
+write_index($index_fh, $base_url);
 
 sub process_dir {
 	my $source_dir = shift;
@@ -92,7 +97,7 @@ sub process_dir {
 	remove_tree($dest_dir);
 	make_path($dest_dir);
 
-	my $htmldocs = new PODtoHTML(
+	my $htmldocs = PODtoHTML->new(
 		source_root => $source_dir,
 		dest_root   => $dest_dir,
 		dest_url    => $base_url,
@@ -102,13 +107,14 @@ sub process_dir {
 }
 
 sub write_index {
-	my $fh = shift;
+	my ($fh, $base_url) = @_;
 	print $fh <<EOF;
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
 <meta charset='UTF-8'>
 <link rel="shortcut icon" href="/favicon.ico">
+<link href="$base_url/css/pod.css" rel="stylesheet">
 <title>WeBWorK/PG POD</title>
 </head>
 <body>

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -43,6 +43,7 @@ Convert WeBWorK and PG POD into HTML form.
 
 use strict;
 use warnings;
+
 use Getopt::Long qw(:config bundling);
 use Pod::Usage;
 
@@ -67,7 +68,9 @@ use File::Path qw(make_path remove_tree);
 use File::Basename qw(dirname);
 use Cwd qw(abs_path);
 
+use lib dirname(dirname(dirname(__FILE__))) . '/lib';
 use lib dirname(__FILE__);
+
 use PODtoHTML;
 
 my $webwork_root = abs_path(dirname(dirname(dirname(__FILE__))));
@@ -78,13 +81,13 @@ for my $dir ($webwork_root, $pg_root) {
 	process_dir($dir);
 }
 
-make_path("$output_dir/css");
-copy("$webwork_root/bin/dev_scripts/pod.css", "$output_dir/css/pod.css");
-print "copying $webwork_root/bin/dev_scripts/pod.css to $output_dir/css/pod.css\n" if $verbose;
-
-my $index_fh = new IO::File("$output_dir/index.html", '>')
+my $index_fh = IO::File->new("$output_dir/index.html", '>')
 	or die "failed to open '$output_dir/index.html' for writing: $!\n";
 write_index($index_fh, $base_url);
+
+make_path("$output_dir/css");
+copy("$webwork_root/htdocs/js/PODViewer/podviewer.css", "$output_dir/css/pod.css");
+print "copying $webwork_root/htdocs/js/PODViewer/podviewer.css to $output_dir/css/pod.css\n" if $verbose;
 
 sub process_dir {
 	my $source_dir = shift;
@@ -104,20 +107,24 @@ sub process_dir {
 		verbose     => $verbose
 	);
 	$htmldocs->convert_pods;
+
+	return;
 }
 
 sub write_index {
 	my ($fh, $base_url) = @_;
-	print $fh <<EOF;
+	print $fh <<"EOF";
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
 <meta charset='UTF-8'>
 <link rel="shortcut icon" href="/favicon.ico">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap\@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
 <link href="$base_url/css/pod.css" rel="stylesheet">
 <title>WeBWorK/PG POD</title>
 </head>
 <body>
+<div class="container mt-3">
 <h1>WeBWorK/PG POD</h1>
 <h2>(Plain Old Documentation)</h2>
 <div>
@@ -127,7 +134,9 @@ EOF
 	print $fh q{<li><a href="pg">PG</a></li>}            if $pg_root;
 	print $fh q{<li><a href="webwork2">WeBWorK</a></li>} if $webwork_root;
 
-	print $fh "</ul></div></body></html>";
+	print $fh "</ul></div></div></body></html>";
+
+	return;
 }
 
 1;

--- a/bin/dev_scripts/pod.css
+++ b/bin/dev_scripts/pod.css
@@ -1,0 +1,5 @@
+body {
+  font-family: Arial, Helvetica, sans-serif;
+  padding-left: 10%;
+  padding-right: 10%;
+}

--- a/bin/dev_scripts/pod.css
+++ b/bin/dev_scripts/pod.css
@@ -1,5 +1,0 @@
-body {
-  font-family: Arial, Helvetica, sans-serif;
-  padding-left: 10%;
-  padding-right: 10%;
-}

--- a/htdocs/js/PODViewer/podviewer.css
+++ b/htdocs/js/PODViewer/podviewer.css
@@ -1,0 +1,6 @@
+#_podtop_ pre {
+	border: 1px solid #ccc;
+	border-radius: 5px;
+	background: #f6f6f6;
+	padding: 0.75rem;
+}

--- a/lib/WeBWorK/ContentGenerator/PODViewer.pm
+++ b/lib/WeBWorK/ContentGenerator/PODViewer.pm
@@ -1,0 +1,66 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package WeBWorK::ContentGenerator::PODViewer;
+use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
+
+=head1 NAME
+
+WeBWorK::ContentGenerator::PODViewer - display POD for PG macros.
+
+=cut
+
+use Pod::Simple::Search;
+
+use WeBWorK::Utils::PODParser;
+
+sub PODindex ($c) {
+	my $pgRoot = $c->ce->{pg_dir};
+
+	my $podFiles = Pod::Simple::Search->new->inc(0)->limit_re(qr/^doc|^lib|^macros/)->survey($pgRoot);
+
+	my $sections = {};
+	for (sort keys %$podFiles) {
+		my $section = $_ =~ s/::.*$//r;
+		push(@{ $sections->{$section} }, $podFiles->{$_} =~ s!^$pgRoot/$section/!!r);
+	}
+
+	return $c->render('ContentGenerator/PODViewer', sections => $sections);
+}
+
+sub renderPOD ($c) {
+	my $macroFile = $c->ce->{pg_dir} . '/' . $c->stash->{filePath};
+
+	if (-e $macroFile) {
+		my $parser = WeBWorK::Utils::PODParser->new;
+		$parser->{verbose}     = 0;
+		$parser->{source_root} = $c->ce->{pg_dir};
+		$parser->{base_url}    = $c->url_for('pod_index')->to_string;
+		$parser->html_header('');
+		$parser->html_footer('');
+		$parser->output_string(\my $html);
+
+		eval { $parser->parse_file($macroFile) };
+		if ($@) {
+			$c->stash->{podError} = $@;
+		} else {
+			$c->stash->{podHTML} = $html;
+		}
+	}
+
+	return $c->render('ContentGenerator/PODViewer/POD');
+}
+
+1;

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -36,6 +36,9 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
  ltiadvantage_launch                 /ltiadvantage/launch
  ltiadvantage_keys                   /ltiadvantage/keys
 
+ pod_index                           /pod
+ pod_viewer                          /pod/$filePath
+
  set_list                            /$courseID
 
  logout                              /$courseID/logout
@@ -133,8 +136,16 @@ my %routeParameters = (
 	root => {
 		title => 'WeBWorK',
 		# 'course_admin' is also a child of 'root' but that is a special case that is setup separately.
-		children =>
-			[qw(render_rpc html2xml instructor_rpc ltiadvantage_login ltiadvantage_launch ltiadvantage_keys set_list)],
+		children => [ qw(
+			render_rpc
+			html2xml
+			instructor_rpc
+			ltiadvantage_login
+			ltiadvantage_launch
+			ltiadvantage_keys
+			pod_index
+			set_list
+		) ],
 		module => 'Home',
 		path   => '/'
 	},
@@ -183,6 +194,21 @@ my %routeParameters = (
 		module => 'LTIAdvantage',
 		path   => '/ltiadvantage/keys',
 		action => 'keys'
+	},
+
+	pod_index => {
+		title    => x('POD Index'),
+		children => [qw(pod_viewer)],
+		module   => 'PODViewer',
+		path     => '/pod',
+		action   => 'PODindex'
+	},
+
+	pod_viewer => {
+		title  => x('POD Viewer'),
+		module => 'PODViewer',
+		path   => '/*filePath',
+		action => 'renderPOD'
 	},
 
 	set_list => {

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -87,12 +87,10 @@
 			title  => maketext('Wiki summary page for MathObjects'),
 			class  => 'reference-link btn btn-sm btn-info',
 			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # http://webwork.maa.org/pod/pg_TRUNK/
-		<%= link_to maketext('POD') => $ce->{webworkURLs}{PODHelpURL},
+		% # PG POD served locally
+		<%= link_to maketext('POD') => url_for('pod_index'),
 			target => 'pod_docs',
-			title  => maketext(
-				'Documentation from source code for PG modules and macro files. Often the most up-to-date information.'
-			),
+			title  => maketext('Documentation from source code for PG modules and macro files.'),
 			class  => 'reference-link btn btn-sm btn-info',
 			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
 		% # PGML lab problem rendered as an unattached problem in a new window.

--- a/templates/ContentGenerator/PODViewer.html.ep
+++ b/templates/ContentGenerator/PODViewer.html.ep
@@ -1,0 +1,47 @@
+% title maketext('PG POD');
+%
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= title %></title>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'theme', file => 'bootstrap.css' }) =%>
+	<link rel="icon" type="x-image/icon"
+		href="<%= $c->url({ type => 'webwork', name => 'htdocs', file => 'images/favicon.ico' }) %>">
+</head>
+%
+% my %section_names = (
+	% doc    => 'Documentation',
+	% lib    => 'Libraries',
+	% macros => 'Macros'
+% );
+%
+<body>
+	<div class="container" id="_podtop_">
+		<h1 class="mt-3"><%= title %></h1>
+		<hr>
+		% for my $section (sort keys %$sections) {
+			% content_for toc => begin
+				<li><a href="#<%= $section %>"><%= $section_names{$section} %></a></li>
+			% end
+			% content_for subjects => begin
+				<h2><a href="#_podtop_" id="<%= $section %>"><%= $section_names{$section} %></a></h2>
+				<ul>
+					% for (@{ $sections->{$section} }) {
+						<li>
+							% my $link_name = $_;
+							% $link_name = $1 =~ s!/!::!gr if $link_name =~ m/^(.*)\.pm$/;
+							<%= link_to $link_name => url_for('pod_viewer', filePath => "$section/$_") =%>
+						</li>
+					% }
+				</ul>
+			% end
+		% }
+		<ul><%= content 'toc' %></ul>
+		<%= content 'subjects' =%>
+	</div>
+</body>
+%
+</html>

--- a/templates/ContentGenerator/PODViewer/POD.html.ep
+++ b/templates/ContentGenerator/PODViewer/POD.html.ep
@@ -1,0 +1,35 @@
+% my $title = $filePath =~ s!^[^/]*/!!r;
+% $title = $1 =~ s!/!::!gr if $title =~ m/^(.*)\.pm$/;
+%
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= $title %></title>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'theme',  file => 'bootstrap.css' }) =%>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'htdocs', file => 'js/PODViewer/podviewer.css' }) =%>
+	<link rel="icon" type="x-image/icon"
+		href="<%= $c->url({ type => 'webwork', name => 'htdocs', file => 'images/favicon.ico' }) %>">
+</head>
+%
+<body>
+	<div class="container">
+		<h1 class="mt-3"><%= $title %></h1>
+		<hr>
+		<div><%= link_to "PG POD Home" => 'pod_index' %></div>
+		<hr>
+		<div id="_podtop_">
+			% if (stash('podHTML')) {
+				<%== stash('podHTML') =%>
+			% } elsif (stash('podError')) {
+				<%= maketext('Error generating POD for file [_1]: [_2]', $filePath, stash('podError')) =%>
+			% } else {
+				<%= maketext('Macro file [_1] not found.', $filePath) =%>
+			% }
+		</div>
+	</div>
+</body>
+%
+</html>


### PR DESCRIPTION
The webwork2 routes serve dynamically generated POD directly generated from the PG files on the server.  The advantage of this is that the link to the POD in the PG problem editor will always be to POD for PG that is for the currently installed PG version.

Also add bootstrap and the pod css to the pages generated by the generate-ww-pg-pod.pl script.
    
Remove POD::Find usage and use POD::Simple::Search instead.  POD::Find is deprecated, and recommends using POD::Simple::Search instead.

This builds on top of #2057.