### PR TITLE
tweaks to Library Browser

### DIFF
--- a/templates/ContentGenerator/Instructor/SetMaker/browse_course_sets_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_course_sets_panel.html.ep
@@ -8,7 +8,7 @@
 		<%= select_field library_sets => [
 				@$local_sets == 0 ? [ maketext('No sets in this course yet') => '' ]
 				: (
-					$selected_library eq '' ? [ maketext('Select a Homework Set') => '', selected => undef ] : (),
+					$selected_library eq '' ? [ maketext('Select a Homework Set') => '', selected => undef, disabled => 'disabled' ] : (),
 					map { [ format_set_name_display($_) => $_, $_ eq $selected_library ? (selected => undef) : () ] }
 					@$local_sets
 				)

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
@@ -6,17 +6,17 @@
 <div class="InfoPanel">
 	<div class="mb-2">
 		<%= label_for library_sets =>
-				maketext('[_1] Problems:', $lib eq '' ? maketext('Local') : $c->{problibs}{$lib}),
+				maketext('[_1] Problems:', $lib eq '' ? maketext('File Manager') : $c->{problibs}{$lib}),
 			class => 'col-form-label-sm' =%>
 		<%= select_field library_sets => [
 				@$prob_dirs == 0 ? [ maketext('Found no directories containing problems') => '' ]
 				: (
-					$selected_library eq '' ? [ maketext('Select a Problem Collection') => '', selected => undef ] : (),
+					$selected_library eq '' ? [ maketext('Select a Folder') => '', selected => undef, disabled => 'disabled' ] : (),
 					$lib ? (
 						map { [ $_ =~ s/^$lib\/(.*)$/$1/r => $_, $_ eq $selected_library ? (selected => undef) : () ] }
 						@$prob_dirs
 					) : (
-						map { [ $_ => $_, $_ eq $selected_library ? (selected => undef) : () ] }
+						map { [ $_ =~ s/^My Problems$/[TMPL]/r => $_, $_ eq $selected_library ? (selected => undef) : () ] }
 						@$prob_dirs
 					)
 				)

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
@@ -16,7 +16,7 @@
 						map { [ $_ =~ s/^$lib\/(.*)$/$1/r => $_, $_ eq $selected_library ? (selected => undef) : () ] }
 						@$prob_dirs
 					) : (
-						map { [ $_ =~ s/^My Problems$/[TMPL]/r => $_, $_ eq $selected_library ? (selected => undef) : () ] }
+						map { [ $_ =~ s/^My Problems$/[templates folder]/r => $_, $_ eq $selected_library ? (selected => undef) : () ] }
 						@$prob_dirs
 					)
 				)

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_setdef_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_setdef_panel.html.ep
@@ -15,7 +15,7 @@
 	<div class="mb-2">
 		<label class="col-form-label-sm"><%= maketext('Browse from:') %></label>
 		<%= select_field library_sets => [
-				$selected_library eq '' ? [ maketext('Select a Set Definition File') => '', selected => undef ] : (),
+				$selected_library eq '' ? [ maketext('Select a Set Definition File') => '', selected => undef, disabled => 'disabled' ] : (),
 				@list_of_set_defs
 			],
 			class => 'form-select form-select-sm d-inline w-auto' =%>

--- a/templates/ContentGenerator/Instructor/SetMaker/top_row.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/top_row.html.ep
@@ -42,10 +42,10 @@
 		<%= submit_button maketext('Open Problem Library'), name => 'browse_npl_library',
 			class => 'browse-lib-btn btn btn-secondary btn-sm mb-2 mx-1',
 			$browse_which eq 'browse_npl_library' ? (disabled => undef) : () =%>
-		<%= submit_button maketext('Local Problems'), name => 'browse_local',
+		<%= submit_button maketext('File Manager'), name => 'browse_local',
 			class => 'browse-lib-btn btn btn-secondary btn-sm mb-2 mx-1',
 			$browse_which eq 'browse_local' ? (disabled => undef) : () =%>
-		<%= submit_button maketext('From This Course'), name => 'browse_course_sets',
+		<%= submit_button maketext('Course Sets'), name => 'browse_course_sets',
 			class => 'browse-lib-btn btn btn-secondary btn-sm mb-2 mx-1',
 			$browse_which eq 'browse_course_sets' ? (disabled => undef) : () =%>
 		<%= submit_button maketext('Set Definition Files'), name => 'browse_setdefs',

--- a/templates/HelpFiles/InstructorSetMaker.html.ep
+++ b/templates/HelpFiles/InstructorSetMaker.html.ep
@@ -38,9 +38,9 @@
 			. q{haven't been vetted as thoroughly as OPL problems. If you want hints or solutions included while }
 			. 'browsing select the appropriate box.') =%>
 	</dd>
-	<dt><%= maketext('Local Problems') %></dt>
+	<dt><%= maketext('File Manager') %></dt>
 	<dd><%= maketext('This option shows all pg problems in the course directory structure.')%></dd>
-	<dt><%= maketext('From This Course') %></dt>
+	<dt><%= maketext('Course Sets') %></dt>
 	<dd><%= maketext('This option shows all problems in sets that have been created in the course.') %></dd>
 	<dt><%= maketext('Set Definition Files') %></dt>
 	<dd>


### PR DESCRIPTION
This clears up some things in the library Browser that can be confusing to the uninitiated.

It changes the `Local Problems` button to `File Manager`. There was some confusion here that `Local Problems` corresponded to the `local/` folder.

Related, the string `My Problems` is currently used to look at problems in the root `templates/` folder, but there has been confusion about what that means. Is there a folder called "My Problems"? No. Has WeBWorK actually tracked "my" problems that I have written? No. This changes that string to `[TMPL]`. (If there is something better, I'm happy to change it.)

This also changes the `From This Course` button to `Course Sets`. There has been confusion about what "From This Course" means. That could mean problem files in this course's File Manager, set definition files in this course's File Manager, or (what it really means) live sets in this course.

This changes the placeholder text `Select a Problem Collection` to `Select a Folder`, making it more clear what you are selecting. A "collection" might suggest some sort of formal data structure. for example, you are not selecting a "collection" like the full tree hierarchy of the OPL. You will just be looking at .pg files that are direct children of the folder you choose.

Lastly, this disables the placeholder text for several HTML select elements.