### PR TITLE
Fix hardcopy generation in the PG problem editor.

### DIFF
--- a/conf/snippets/hardcopyThemes/common/headandfoot.tex
+++ b/conf/snippets/hardcopyThemes/common/headandfoot.tex
@@ -1,5 +1,5 @@
 \pagestyle{headandfoot}
-\firstpageheader% 
+\firstpageheader%
 {{\large\bfseries Assignment \href{\webworkCourseURL/\webworkSetId}{\webworkPrettySetId{}}\\}\ifx\webworkReducedScoringDate\empty\else{full credit by \webworkReducedScoringDate, }\fi closes \webworkDueDate\\\href{\webworkCourseURL}{\scshape\webworkCourseTitle}}%
 {}%
 {{\large\bfseries\webworkFirstName{} \webworkLastName{} (\webworkUserId)\\}%

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -128,7 +128,7 @@ sub generate_hardcopy_tex {
 	# Copy the common tex files into the working directory
 	my $ce         = $ws->c->ce;
 	my $common_dir = path($ce->{webworkDirs}{texinputs_common});
-	for (qw{packages.tex CAPA.tex PGML.tex}) {
+	for (qw{packages.tex CAPA.tex PGML.tex headandfoot.tex copyright.tex webwork_logo.png}) {
 		eval { $common_dir->child($_)->copy_to($working_dir) };
 		push(@$errors, qq{Failed to copy "$ce->{webworkDirs}{texinputs_common}/$_" into directory "$working_dir": $@})
 			if $@;
@@ -210,7 +210,37 @@ sub write_tex {
 		. ($ws->{inputs_ref}{hardcopy_theme} // $ce->{hardcopyTheme});
 
 	write_tex_file($FH, $ce->{webworkFiles}{hardcopySnippets}{preamble} // "$themeDir/hardcopyPreamble.tex", $errors);
+
+	# Write dummy LaTeX macros to pacify any usage of these in the theme tex files.
+	for (qw(
+		CourseName
+		CourseTitle
+		CourseURL
+		UserId
+		StudentId
+		FirstName
+		LastName
+		EmailAddress
+		Section
+		Recitation
+		SetId
+		Description
+		OpenDate
+		ReducedScoringDate
+		DueDate
+		AnswerDate
+		PrettySetId
+	))
+	{
+		print $FH "\\def\\webwork${_}{}\n";
+	}
+
+	print $FH "\\firstpageheader{}{}{}\\footer{}{}{}";
+
+	write_tex_file($FH, $ce->{webworkFiles}{hardcopySnippets}{setTexHeader} // "$themeDir/hardcopySetHeader.tex",
+		$errors);
 	write_problem_tex($ws, $FH);
+	write_tex_file($FH, $ce->{webworkFiles}{hardcopySnippets}{setFooter} // "$themeDir/hardcopySetFooter.tex", $errors);
 	write_tex_file($FH, $ce->{webworkFiles}{hardcopySnippets}{postamble} // "$themeDir/hardcopyPostamble.tex", $errors);
 
 	return;


### PR DESCRIPTION
This just writes dummy empty TeX macros that are needed by the inclusion of headandfoot.tex.  Then it overrides the headers set by that file. Then it writes the hardcopySetHeader.tex file so that two column mode is started if that theme is selected.  After writing the problem TeX, it writes the hardcopySetFooter.tex file so that two column mode is appropriately ended.  Since that file includes the copyright.tex file, these files will now have the logo and copyright at the bottom.

All of the common files are also added to the zip file if TeX Source is selected or if PDF file generation fails.

Note that when a set header is being edited, you will not get values for the TeX macros.  So hardcopy generation is not quite complete for those.  This is just a quick fix to get things working again.