### PR TITLE
remove a tex comment when it has nothing to say

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1111,7 +1111,7 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $problemID = 0, $
 	if ($showCorrectAnswers || $printStudentAnswers) {
 		my %oldAnswers = decodeAnswers($MergedProblem->last_answer);
 		$formFields->{$_} = $oldAnswers{$_} foreach (keys %oldAnswers);
-		print $FH "%% decoded old answers, saved. (keys = " . join(',', keys(%oldAnswers)) . "\n";
+		print $FH "%% decoded old answers, saved. (keys = " . join(',', keys(%oldAnswers)) . ")\n" if %oldAnswers;
 	}
 
 	my $pg = await renderPG(


### PR DESCRIPTION
This is a small piece of clutter I noticed with recent things that have me looking at hardcopy tex files. It was printing

```
%% decoded old answers, saved. (keys = 
```

with nothing more. this closes thee paren, and prints nothing now if that hash is empty.