### PR TITLE
One column

### DIFF
--- a/conf/snippets/blankProblem.pg
+++ b/conf/snippets/blankProblem.pg
@@ -11,7 +11,6 @@ loadMacros("PG.pl",
 
 ## Do NOT show partial correct answers
 $showPartialCorrectAnswers = 0;
-TEXT(beginproblem());
 
 BEGIN_TEXT
 

--- a/conf/snippets/blankProblem2.pg
+++ b/conf/snippets/blankProblem2.pg
@@ -23,9 +23,6 @@ loadMacros(
    "PGcourse.pl",      # Customization file for the course
 );
 
-# Print problem number and point value (weight) for the problem
-TEXT(beginproblem());
-
 # Show which answers are correct and which ones are incorrect
 $showPartialCorrectAnswers = 1;
 

--- a/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
+++ b/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
@@ -12,7 +12,6 @@ loadMacros(
 $dateTime = $formatedDueDate;
 
 TEXT(EV2(<<EOT));
-$BEGIN_ONE_COLUMN
 \noindent {\large \bf $studentName}
 \hfill
 {\large \bf {\{protect_underbar($courseName)\}}}
@@ -23,7 +22,6 @@ This first set (set 0) is designed to acquaint you with using WeBWorK.
 {\bf Your score on this set will not be counted toward your final grade.}
 \par
 \noindent You may need to give 4 or 5 significant digits for some (floating point) numerical answers in order to have them accepted by the computer.
-$END_ONE_COLUMN
 EOT
 
 &ENDDOCUMENT;

--- a/courses.dist/modelCourse/templates/set0/prob1.pg
+++ b/courses.dist/modelCourse/templates/set0/prob1.pg
@@ -16,7 +16,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 $a = random(-10,-1,1);

--- a/courses.dist/modelCourse/templates/set0/prob1a.pg
+++ b/courses.dist/modelCourse/templates/set0/prob1a.pg
@@ -13,7 +13,6 @@ loadMacros(
 	"PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 

--- a/courses.dist/modelCourse/templates/set0/prob1b.pg
+++ b/courses.dist/modelCourse/templates/set0/prob1b.pg
@@ -14,7 +14,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 

--- a/courses.dist/modelCourse/templates/set0/prob2.pg
+++ b/courses.dist/modelCourse/templates/set0/prob2.pg
@@ -14,7 +14,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 TEXT(EV2(<<EOT));

--- a/courses.dist/modelCourse/templates/set0/prob3.pg
+++ b/courses.dist/modelCourse/templates/set0/prob3.pg
@@ -14,7 +14,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 0;
 
 

--- a/courses.dist/modelCourse/templates/set0/prob4/prob4.pg
+++ b/courses.dist/modelCourse/templates/set0/prob4/prob4.pg
@@ -16,7 +16,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 0;
 
 

--- a/courses.dist/modelCourse/templates/set0/prob5.pg
+++ b/courses.dist/modelCourse/templates/set0/prob5.pg
@@ -14,7 +14,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 0;
 
 

--- a/courses.dist/modelCourse/templates/setDemo/c4s5p2.pg
+++ b/courses.dist/modelCourse/templates/setDemo/c4s5p2.pg
@@ -12,7 +12,6 @@ loadMacros("PGbasicmacros.pl",
 			"PGauxiliaryFunctions.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 1;
 
 $n = random(3,6,1);

--- a/courses.dist/modelCourse/templates/setDemo/josephus.pg
+++ b/courses.dist/modelCourse/templates/setDemo/josephus.pg
@@ -146,8 +146,6 @@ parent.gameStatus.document.close()
 
 EOF
 
-
-TEXT(beginproblem());
 TEXT(MODES(
 TeX	 		=>	'',
 Latex2HTML	=> "\begin{rawhtml} <NOSCRIPT> This problem requires that Java

--- a/courses.dist/modelCourse/templates/setDemo/limits.pg
+++ b/courses.dist/modelCourse/templates/setDemo/limits.pg
@@ -8,7 +8,6 @@ loadMacros(
 	"PGauxiliaryFunctions.pl"
 );
 
-TEXT(&beginproblem);
 $showPartialCorrectAnswers = 1;
 
 $a=random(-3,3,1);

--- a/courses.dist/modelCourse/templates/setDemo/liteApplet1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/liteApplet1.pg
@@ -6,7 +6,6 @@ loadMacros("PGbasicmacros.pl",
 ); 
 
 $showPartialCorrectAnswers = 1;
-TEXT(beginproblem());
 
 # The link to the java applet is hard wired to use the java applet
 # served from the University of Rochester WeBWorK machine.

--- a/courses.dist/modelCourse/templates/setDemo/liteApplet2.pg
+++ b/courses.dist/modelCourse/templates/setDemo/liteApplet2.pg
@@ -6,8 +6,6 @@ loadMacros("PGbasicmacros.pl",
 ); 
 
 $showPartialCorrectAnswers = 1;
-TEXT(beginproblem());
-
 
 BEGIN_TEXT
 This is  a lite applet designed by Frank Wattenberg.

--- a/courses.dist/modelCourse/templates/setDemo/nsc2s10p2.pg
+++ b/courses.dist/modelCourse/templates/setDemo/nsc2s10p2.pg
@@ -13,7 +13,6 @@ loadMacros(
 	"PGgraphmacros.pl"
 );
 
-TEXT(beginproblem());
 $showPartialCorrectAnswers = 0;
 
 $a=random(0, 6.3, .1);

--- a/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
@@ -12,7 +12,6 @@ loadMacros(
 $dateTime = $formatedDueDate;
 
 TEXT(EV2(<<EOT));
-$BEGIN_ONE_COLUMN
 \noindent {\large \bf $studentName}
 \hfill
 \noindent {\large \bf MAA Minicourse San Diego January 2002}
@@ -25,7 +24,6 @@ that can be asked using WeBWorK.
 \par
 \noindent You may need to give 4 or 5 significant digits for some (floating point) 
 numerical answers in order to have them accepted by the computer.
-$END_ONE_COLUMN
 EOT
 
 &ENDDOCUMENT;

--- a/courses.dist/modelCourse/templates/setDemo/prob0837.pg
+++ b/courses.dist/modelCourse/templates/setDemo/prob0837.pg
@@ -8,8 +8,6 @@ loadMacros( "PGbasicmacros.pl",
 	             "PG_CAPAmacros.pl"
 );
 	 
-TEXT(beginproblem());
-	
 # machine translated from CAPA.  
 # This is probaly not a good model for elegant PG code.	
 ## **************************************

--- a/courses.dist/modelCourse/templates/setDemo/prob5.pg
+++ b/courses.dist/modelCourse/templates/setDemo/prob5.pg
@@ -49,8 +49,6 @@ return( $a*Math.pow(x,2) + $b*x +$c );}
 
 EOF
 
-
-TEXT(beginproblem());
 TEXT(MODES(
 TeX	 		=>	'',
 Latex2HTML	=> "\begin{rawhtml} <NOSCRIPT> This problem requires that Java

--- a/courses.dist/modelCourse/templates/setDemo/prob6b.pg
+++ b/courses.dist/modelCourse/templates/setDemo/prob6b.pg
@@ -27,8 +27,6 @@ END_TEXT
 $p = random(2,9,1);  # multiplier
 $p2 = ( $p % 2 == 0) ? 2*$p : $p;
 
-TEXT(beginproblem());
-
 # The link to the java applet is hard wired to use the java applet
 # served from the University of Rochester WeBWorK machine.
 # It is possible to set this up so that the java applet is served

--- a/courses.dist/modelCourse/templates/setDemo/s2_2_1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/s2_2_1.pg
@@ -11,7 +11,6 @@ loadMacros(
 	"PGauxiliaryFunctions.pl"
 );
 
-TEXT(&beginproblem);
 $showPartialCorrectAnswers = 1;
 
 $a1 = random(2,7,1);

--- a/courses.dist/modelCourse/templates/setDemo/sample_myown_ans.pg
+++ b/courses.dist/modelCourse/templates/setDemo/sample_myown_ans.pg
@@ -6,7 +6,6 @@ loadMacros(
 	"PGanswermacros.pl"
 );
 
-TEXT(&beginproblem);
 $showPartialCorrectAnswers = 1;
  
 BEGIN_TEXT

--- a/courses.dist/modelCourse/templates/setDemo/sample_units_ans.pg
+++ b/courses.dist/modelCourse/templates/setDemo/sample_units_ans.pg
@@ -5,8 +5,6 @@ loadMacros( "PGbasicmacros.pl",
 	        "PGanswermacros.pl",
 );
 
-TEXT(beginproblem());
-
 $showPartialCorrectAnswers = 1;
 $showHint =0;
 

--- a/courses.dist/modelCourse/templates/setDemo/srw1_9_4.pg
+++ b/courses.dist/modelCourse/templates/setDemo/srw1_9_4.pg
@@ -15,8 +15,6 @@ loadMacros(
 "PGauxiliaryFunctions.pl"
 );
 
-TEXT(&beginproblem);
-
 $showPartialCorrectAnswers = 1;
 
 #install_problem_grader(~~&std_problem_grader);    ##uncomment to use std grader

--- a/courses.dist/modelCourse/templates/setMAAtutorial/MAAtutorialSetHeader.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/MAAtutorialSetHeader.pg
@@ -6,8 +6,6 @@ loadMacros(
 	"PGanswermacros.pl"
 );
 
-TEXT($BEGIN_ONE_COLUMN);
-
 TEXT(MODES(TeX =>EV3(<<'EOT'), HTML=>"", Latex2HTML=>"" ));
 \noindent {\large \bf $studentName}
 \hfill
@@ -94,8 +92,6 @@ $PAR
 You can use the Feedback button on each problem
 page to send e-mail to the professors. 
 
-
-$END_ONE_COLUMN
 END_TEXT
 
 ENDDOCUMENT();        # This should be the last executable line in the problem.

--- a/courses.dist/modelCourse/templates/setMAAtutorial/conditionalquestionexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/conditionalquestionexample.pg
@@ -4,7 +4,7 @@ loadMacros(
         "PGchoicemacros.pl",
         "PGanswermacros.pl"
 );
-TEXT(beginproblem(), $BR,$BBOLD, "Conditional questions example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Conditional questions example", $EBOLD, $BR,$BR);
 $showPartialCorrectAnswers = 1;
 
 $a1 = random(3,25,1);

--- a/courses.dist/modelCourse/templates/setMAAtutorial/hermitegraphexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/hermitegraphexample.pg
@@ -5,7 +5,6 @@ loadMacros("PGbasicmacros.pl",
            "PGnumericalmacros.pl",
            "PGgraphmacros.pl"
 );
-TEXT($BEGIN_ONE_COLUMN);
 TEXT(beginproblem(), $BR,$BBOLD, "Hermite polynomial graph example", $EBOLD, $BR,$BR); 
 $showPartialAnswers = 1;
 
@@ -122,5 +121,4 @@ $PAR
 END_TEXT
 ANS(num_cmp([ @minimum_points ], tol => .3));
 
-TEXT($END_ONE_COLUMN);
 ENDDOCUMENT();

--- a/courses.dist/modelCourse/templates/setMAAtutorial/hermitegraphexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/hermitegraphexample.pg
@@ -5,7 +5,7 @@ loadMacros("PGbasicmacros.pl",
            "PGnumericalmacros.pl",
            "PGgraphmacros.pl"
 );
-TEXT(beginproblem(), $BR,$BBOLD, "Hermite polynomial graph example", $EBOLD, $BR,$BR); 
+TEXT($BBOLD, "Hermite polynomial graph example", $EBOLD, $BR,$BR);
 $showPartialAnswers = 1;
 
 $graph = init_graph(-5,-5,5,5,'axes'=>[0,0],'grid'=>[10,10]);

--- a/courses.dist/modelCourse/templates/setMAAtutorial/htmllinksexample/htmllinksexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/htmllinksexample/htmllinksexample.pg
@@ -5,7 +5,7 @@ loadMacros("PGbasicmacros.pl",
 );
 $showPartialCorrectAnswers = 0;
 
-TEXT(beginproblem(), $BR,$BBOLD, "HTML links example", $EBOLD, $BR,$BR); 
+TEXT($BBOLD, "HTML links example", $EBOLD, $BR,$BR)
 
 BEGIN_TEXT
 This example shows how to link to resources outside the problem itself.

--- a/courses.dist/modelCourse/templates/setMAAtutorial/javaappletexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/javaappletexample.pg
@@ -6,7 +6,7 @@ loadMacros("PG.pl",
            "PGanswermacros.pl",
            ); 
  
-TEXT(beginproblem(), $BR,$BBOLD, "Java applet example", $EBOLD, $BR,$BR); 
+TEXT($BBOLD, "Java applet example", $EBOLD, $BR,$BR);
 # define function to be evaluated
 $a= random(1,3,1);
 $b= random(-4,4,.1);

--- a/courses.dist/modelCourse/templates/setMAAtutorial/javascriptexample1.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/javascriptexample1.pg
@@ -5,7 +5,7 @@ loadMacros(
            "PGchoicemacros.pl",
            "PGanswermacros.pl",
 ); 
-TEXT(beginproblem(), $BR,$BBOLD, "JavaScript Example 1", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "JavaScript Example 1", $EBOLD, $BR,$BR);
 # define function to be evaluated
 $a= random(1,3,1);
 $b= random(-4,4,.1);
@@ -43,7 +43,6 @@ return( $a*Math.pow(x,2) + $b*x +$c );}
 
 EOF
 
-TEXT(beginproblem());
 TEXT(MODES( TeX => "",
 	        Latex2HTML => "\begin{rawhtml}
                          <NOSCRIPT> This problem requires that Java Script be 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/javascriptexample2.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/javascriptexample2.pg
@@ -5,7 +5,7 @@ loadMacros("PGbasicmacros.pl",
            "PGanswermacros.pl",
            "PGnumericalmacros.pl",  # needed for the javaScript spline code
            ); 
-TEXT(beginproblem(), $BR,$BBOLD, "JavaScript Example 2", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "JavaScript Example 2", $EBOLD, $BR,$BR);
 
 # define function to be evaluated
 $a= random(1,3,1);
@@ -49,7 +49,6 @@ $javascript= javaScript_cubic_spline(~~@x, ~~@y, name =>'func');
 HEADER_TEXT( javaScript_cubic_spline(~~@x, ~~@y, name =>'func')  );  
 
 
-TEXT(beginproblem());
 TEXT(MODES( TeX => "",
 	        Latex2HTML => "\begin{rawhtml}
                          <NOSCRIPT> This problem requires that Java Script be 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/liteApplet1.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/liteApplet1.pg
@@ -6,7 +6,6 @@ loadMacros("PGbasicmacros.pl",
 ); 
 
 $showPartialCorrectAnswers = 1;
-TEXT(beginproblem());
 
 # The link to the java applet is hard wired to use the java applet
 # served from the University of Rochester WeBWorK machine.

--- a/courses.dist/modelCourse/templates/setMAAtutorial/liteApplet2.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/liteApplet2.pg
@@ -6,8 +6,6 @@ loadMacros("PGbasicmacros.pl",
 ); 
 
 $showPartialCorrectAnswers = 1;
-TEXT(beginproblem());
-
 
 BEGIN_TEXT
 This is  a lite applet designed by Frank Wattenberg.

--- a/courses.dist/modelCourse/templates/setMAAtutorial/matchinglistexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/matchinglistexample.pg
@@ -7,7 +7,7 @@ loadMacros(
  );
 
 
-TEXT(beginproblem(), $BR,$BBOLD, "Matching list example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Matching list example", $EBOLD, $BR,$BR);
 
 
 # Since this is a matching question, we do not usually wish to tell students
@@ -126,4 +126,4 @@ END_TEXT
 # Enter the correct answers to be checked against the answers to the students.
 ANS( str_cmp( $ml->ra_correct_ans )   ) ;
 
-ENDDOCUMENT();      
+ENDDOCUMENT();

--- a/courses.dist/modelCourse/templates/setMAAtutorial/multiplechoiceexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/multiplechoiceexample.pg
@@ -4,7 +4,7 @@ loadMacros("PGbasicmacros.pl",
         "PGanswermacros.pl",
 
 );
-TEXT(beginproblem(), $BR,$BBOLD, "Multiple choice example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Multiple choice example", $EBOLD, $BR,$BR);
 
 $showPartialCorrectAnswers = 0;
 # Make a new multiple choice object.
@@ -42,4 +42,4 @@ END_TEXT
 # Enter the correct answers to be checked against the answers to the students.
 ANS( str_cmp( $mc->correct_ans )   ) ;
 
-ENDDOCUMENT();     
+ENDDOCUMENT();

--- a/courses.dist/modelCourse/templates/setMAAtutorial/ontheflygraphicsexample1.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/ontheflygraphicsexample1.pg
@@ -6,7 +6,7 @@ loadMacros(
            "PGgraphmacros.pl"
 );
           
-TEXT(beginproblem(), $BR,$BBOLD, "On-the-fly Graphics Example1", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "On-the-fly Graphics Example1", $EBOLD, $BR,$BR);
 $showPartialCorrectAnswers = 0;
 
 # First we define a graph with x and y in the range -4 to 4, axes (strong lines) 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/ontheflygraphicsexample2.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/ontheflygraphicsexample2.pg
@@ -6,7 +6,7 @@ loadMacros("PGbasicmacros.pl",
            "PGgraphmacros.pl"
 );
            
-TEXT(beginproblem(), $BR,$BBOLD, "On-the-fly Graphics Example2", $EBOLD, $BR,$BR); 
+TEXT($BBOLD, "On-the-fly Graphics Example2", $EBOLD, $BR,$BR);
 
 # First we define a graph with x and y in the range -4 to 4, axes (strong lines) 
 # defined at the point [0,0] and

--- a/courses.dist/modelCourse/templates/setMAAtutorial/paperHeader.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/paperHeader.pg
@@ -11,10 +11,8 @@ loadMacros(
 
 
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 This set shows how to write simple WeBWorK problems and introduces you to the most common
 constructions.
-$END_ONE_COLUMN
 
 END_TEXT
 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/popuplistexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/popuplistexample.pg
@@ -5,7 +5,7 @@ loadMacros("PGbasicmacros.pl",
            "PGanswermacros.pl",
 );
 
-TEXT(beginproblem(), $BR,$BBOLD, "True False Pop-up Example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "True False Pop-up Example", $EBOLD, $BR,$BR);
 $showPartialCorrectAnswers = 0;
 
 # Make a new select list

--- a/courses.dist/modelCourse/templates/setMAAtutorial/prob3.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/prob3.pg
@@ -19,14 +19,6 @@ loadMacros("PGbasicmacros.pl",
 # Is the simplest way of printing text, each string in the input is immediately printed.
 # It does not do any of the simplifying and evaluating tricks performed by the BEGIN_TEXT/END_TEXT construction.
 
-# beginproblem() is a macro which outputs the string 
-# which contains the number
-# of points the problem is worth.
-
-# Putting these two ideas together prints the standard opening line of a problem.
-# We will use this construction routinely at the beginning of all subsequent problems.
-TEXT(beginproblem());
-
 # Since this is a matching questions, we do not usually wish to tell students which
 # parts of the matching question have been answered correctly and which are
 # incorrect.  That is too easy.  To accomplish this we set the following flag to zero.

--- a/courses.dist/modelCourse/templates/setMAAtutorial/prob4.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/prob4.pg
@@ -12,7 +12,6 @@ loadMacros("PGbasicmacros.pl",
            "PGnumericalmacros.pl"
            );
  
-TEXT(&beginproblem);
 $showPartialCorrectAnswers = 0;
 
 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/simplemultiplechoiceexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/simplemultiplechoiceexample.pg
@@ -4,7 +4,7 @@ loadMacros(
                     "PGchoicemacros.pl", 
                     "PGanswermacros.pl",
 );
-TEXT(beginproblem(), $BR,$BBOLD, "Multiple choice example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Multiple choice example", $EBOLD, $BR,$BR);
 
    
 $showPartialCorrectAnswers = 0;
@@ -30,4 +30,4 @@ $PAR Enter the letter corresponding to the correct answer: \{ ans_rule(10) \}
 END_TEXT
 ANS( str_cmp( $inverted_alphabet[0] )   ) ;
 
-ENDDOCUMENT(); 
+ENDDOCUMENT();

--- a/courses.dist/modelCourse/templates/setMAAtutorial/standardexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/standardexample.pg
@@ -5,7 +5,7 @@ loadMacros("PGbasicmacros.pl",
            "PGauxiliaryFunctions.pl"    
 );     
 
-TEXT(beginproblem(), $BR,$BBOLD, "Standard Example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Standard Example", $EBOLD, $BR,$BR);
 
 # A question requiring a string answer.
 $str = 'world'; 
@@ -44,4 +44,3 @@ $new_exponent = $b-1;
 $ans2 = "$b*x^($new_exponent)";
 ANS( fun_cmp( $ans2 ) );
 ENDDOCUMENT();
- 

--- a/courses.dist/modelCourse/templates/setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
@@ -3,7 +3,7 @@ loadMacros("PGbasicmacros.pl",
            "PGchoicemacros.pl",
            "PGanswermacros.pl"
 );
-TEXT(beginproblem(), $BR,$BBOLD, "Static graphics Example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "Static graphics Example", $EBOLD, $BR,$BR);
 
 $showPartialCorrectAnswers = 0;
 # Define which of the three sets of pictures to use

--- a/courses.dist/modelCourse/templates/setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/staticgraphicsexample/staticgraphicsexample.pg
@@ -3,7 +3,6 @@ loadMacros("PGbasicmacros.pl",
            "PGchoicemacros.pl",
            "PGanswermacros.pl"
 );
-TEXT($BEGIN_ONE_COLUMN);
 TEXT(beginproblem(), $BR,$BBOLD, "Static graphics Example", $EBOLD, $BR,$BR);
 
 $showPartialCorrectAnswers = 0;
@@ -111,5 +110,4 @@ TEXT(
 
 ANS(  str_cmp( $ml ->ra_correct_ans()   ) ) ;
 
-TEXT($END_ONE_COLUMN);
 ENDDOCUMENT();

--- a/courses.dist/modelCourse/templates/setMAAtutorial/truefalseexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/truefalseexample.pg
@@ -4,7 +4,7 @@ loadMacros("PGbasicmacros.pl",
            "PGanswermacros.pl",
 
 );
-TEXT(beginproblem(), $BR,$BBOLD, "True False Example", $EBOLD, $BR,$BR);
+TEXT($BBOLD, "True False Example", $EBOLD, $BR,$BR);
 
 # Since this is a true questions, we do not usually wish to tell students which
 # parts of the matching question have been answered correctly and which are

--- a/courses.dist/modelCourse/templates/setMAAtutorial/vectorfieldexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/vectorfieldexample.pg
@@ -37,7 +37,6 @@ sub{my ($x,$y) = @_; $y + 2 ;},
 
 $tf ->choose($numberOfQuestions);
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 Match the following equations with their direction field. 
 Clicking on each picture will give you an
@@ -86,7 +85,6 @@ $PAR
                       [@ALPHABET[$numberOfQuestions/2..$numberOfQuestions-1]],
                              height => 200, width => 200,tex_size=>300 )  \}
        
-$END_ONE_COLUMN
 END_TEXT
 
 ANS( str_cmp( $tf->ra_correct_ans )   ) ;

--- a/courses.dist/modelCourse/templates/setMAAtutorial/vectorfieldexample.pg
+++ b/courses.dist/modelCourse/templates/setMAAtutorial/vectorfieldexample.pg
@@ -7,8 +7,6 @@ loadMacros("PG.pl",
            "PGgraphmacros.pl",        
 );
 
-TEXT(beginproblem()); # standard preamble to each problem.
-
 # Since this is a true questions, we do not usually wish to tell students which
 # parts of the matching question have been answered correctly and which are
 # incorrect.  That is too easy.  To accomplish this we set the following flag to zero.

--- a/courses.dist/modelCourse/templates/setOrientation/prob01.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob01.pg
@@ -8,8 +8,6 @@ loadMacros(
 );
 
 
-TEXT(beginproblem());
-
 Title("Understanding $WW Problem Pages");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob02.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob02.pg
@@ -8,8 +8,6 @@ loadMacros(
 );
 
 
-TEXT(beginproblem());
-
 Title("Controlling $WW");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob03.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob03.pg
@@ -12,7 +12,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Typing in Your Answers");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob04.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob04.pg
@@ -13,7 +13,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Rules of Precedence");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob05/prob05.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob05/prob05.pg
@@ -12,8 +12,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem);
-
 Title("Common Errors to Avoid");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob06.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob06.pg
@@ -15,7 +15,6 @@ Context("Numeric")->variables->are(y=>'Real'); $y = Formula('y');
 Context("Numeric")->variables->are(x=>'Real'); $x = Formula('x');
 Context()->flags->set(limits=>[0,2]);
 
-TEXT(beginproblem());
 Title("Using Parentheses Effectively");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob07.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob07.pg
@@ -13,7 +13,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Constants and Functions in $WW");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob08.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob08.pg
@@ -14,7 +14,6 @@ Context("Numeric")->variables->are(x=>'Real'); $x = Formula('x');
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Rules of Precedence (Again)");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob09.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob09.pg
@@ -10,7 +10,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Non-Numeric Answers");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob10.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob10.pg
@@ -11,7 +11,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Points and Vectors");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob11.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob11.pg
@@ -10,7 +10,6 @@ loadMacros(
 
 $showPartialCorrectAnswers = 1;
 
-TEXT(beginproblem());
 Title("Multiple Answers in One Blank");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob12.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob12.pg
@@ -9,7 +9,6 @@ loadMacros(
   "PGcourse.pl",
 );
 
-TEXT(beginproblem());
 Title("True/False Questions in $WW");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob13.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob13.pg
@@ -9,7 +9,6 @@ loadMacros(
   "PGcourse.pl",
 );
 
-TEXT(beginproblem());
 Title("Matching Lists in $WW");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob14/prob14.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob14/prob14.pg
@@ -17,8 +17,6 @@ loadMacros(
 $htmlWebworkURL = "http://omega.math.union.edu/webwork2_files/local";
 $hintURL = "${htmlWebworkURL}/parserOrientation/prob14-hint.html";
 
-TEXT(beginproblem);
-
 Title("Matching Graphs in $WW");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/prob15.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob15.pg
@@ -8,8 +8,6 @@ loadMacros(
 );
 
 
-TEXT(beginproblem());
-
 Title("When You're Stuck...");
 
 ##############################################

--- a/courses.dist/modelCourse/templates/setOrientation/setHeader.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/setHeader.pg
@@ -10,7 +10,7 @@ $WW = "WeBWorK";
 
 if ($displayMode eq 'TeX') {
 
-TEXT($BEGIN_ONE_COLUMN,
+TEXT(
     '\noindent{\large\bf '.$studentName.'}\hfill{\large\bf '.$course.'}',
     '\par\noindent',
 "
@@ -24,7 +24,6 @@ entries.
 
 ",
      "WeBWorK assignment $setNumber closes on $formattedDueDate.",
-     $END_ONE_COLUMN
 );
 
 } else {

--- a/doc/parser/extensions/1-function.pg
+++ b/doc/parser/extensions/1-function.pg
@@ -55,7 +55,6 @@ $x = Formula('x');
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we have added a new function to the Parser: ${BTT}log2(x)${ETT}.
 (Edit the code to see how this is done.)
@@ -75,7 +74,6 @@ $PAR
      'log2(1,3)',
   )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/1-function.pg
+++ b/doc/parser/extensions/1-function.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   Use  standard numeric mode

--- a/doc/parser/extensions/2-function.pg
+++ b/doc/parser/extensions/2-function.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   Use  standard numeric mode

--- a/doc/parser/extensions/2-function.pg
+++ b/doc/parser/extensions/2-function.pg
@@ -55,7 +55,6 @@ $x = Formula('x');
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we have added a new function to the Parser: ${BTT}C(n,r)${ETT}.
 (Edit the code to see how this is done).
@@ -75,7 +74,6 @@ $PAR
      'C(1,2,3)',
   )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/3-operator.pg
+++ b/doc/parser/extensions/3-operator.pg
@@ -86,7 +86,6 @@ $CHOOSE = MODES(TeX => '\#', HTML => '#');
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we have added a new operator to the Parser: ${BTT}n $CHOOSE r${ETT}, 
 which returns \(n\choose r\).
@@ -105,7 +104,6 @@ $PAR
     'Formula("1 # <x,3>")',
   )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/3-operator.pg
+++ b/doc/parser/extensions/3-operator.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  Define our own binary operator

--- a/doc/parser/extensions/4-list.pg
+++ b/doc/parser/extensions/4-list.pg
@@ -80,7 +80,6 @@ Context()->parens->replace('[' => {close => ']', type => 'Choose'});
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we have added a new list to the Parser: ${BTT}[n,r]${ETT}, 
 which returns \(n\choose r\).
@@ -98,7 +97,6 @@ $PAR
     'Formula("[x,<1,2>]")',
   )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/4-list.pg
+++ b/doc/parser/extensions/4-list.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  Define our own [n,r] notation for n choose r

--- a/doc/parser/extensions/5-operator.pg
+++ b/doc/parser/extensions/5-operator.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  Define our own operator for equality

--- a/doc/parser/extensions/5-operator.pg
+++ b/doc/parser/extensions/5-operator.pg
@@ -63,7 +63,6 @@ Context()->operators->add(
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we have added a new operator to the Parser: ${BTT} a
 = b${ETT}, for equality.
@@ -81,7 +80,6 @@ $PAR
     'Formula("x + y = 0, 3x-y = 4")', # you CAN get a list of equalities
   )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/6-precedence.pg
+++ b/doc/parser/extensions/6-precedence.pg
@@ -61,7 +61,6 @@ $nonstandard = ParserTable(
 #  The problem text
 #
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we compare the standard and non-standard precedences for
 multiplication.
@@ -76,7 +75,6 @@ $PAR$BR
 $PAR
 $standard
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/6-precedence.pg
+++ b/doc/parser/extensions/6-precedence.pg
@@ -13,8 +13,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  Use standard precedences for multiplication

--- a/doc/parser/extensions/7-context.pg
+++ b/doc/parser/extensions/7-context.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserTables.pl",
 );
 
-TEXT(beginproblem());
-
 BEGIN_TEXT
 
 In this problem, we compare formulas in complex and vector contexts.

--- a/doc/parser/extensions/7-context.pg
+++ b/doc/parser/extensions/7-context.pg
@@ -15,7 +15,6 @@ loadMacros(
 TEXT(beginproblem());
 
 BEGIN_TEXT
-$BEGIN_ONE_COLUMN
 
 In this problem, we compare formulas in complex and vector contexts.
 Note the difference between how ${BTT}i${ETT} is treated in the two
@@ -78,7 +77,6 @@ $PAR
    '3*i + 4*j - k',
 )\}
 
-$END_ONE_COLUMN
 END_TEXT
 
 ###########################################################

--- a/doc/parser/extensions/8-answer.pg
+++ b/doc/parser/extensions/8-answer.pg
@@ -17,8 +17,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  Use Vector context

--- a/doc/parser/problems/sample01.pg
+++ b/doc/parser/problems/sample01.pg
@@ -12,8 +12,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   Use  standard numeric mode

--- a/doc/parser/problems/sample02.pg
+++ b/doc/parser/problems/sample02.pg
@@ -12,8 +12,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   Use  standard numeric mode

--- a/doc/parser/problems/sample03.pg
+++ b/doc/parser/problems/sample03.pg
@@ -13,8 +13,6 @@ loadMacros(
   "Differentiation.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   Use standard numeric mode

--- a/doc/parser/problems/sample04.pg
+++ b/doc/parser/problems/sample04.pg
@@ -17,8 +17,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(&beginproblem);
-
 ##############################################
 #
 #  The setup

--- a/doc/parser/problems/sample05.pg
+++ b/doc/parser/problems/sample05.pg
@@ -17,8 +17,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(&beginproblem);
-
 ##############################################
 #
 #  The setup

--- a/doc/parser/problems/sample06.pg
+++ b/doc/parser/problems/sample06.pg
@@ -12,8 +12,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample07.pg
+++ b/doc/parser/problems/sample07.pg
@@ -11,8 +11,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample08.pg
+++ b/doc/parser/problems/sample08.pg
@@ -11,8 +11,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample09.pg
+++ b/doc/parser/problems/sample09.pg
@@ -11,8 +11,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample10.pg
+++ b/doc/parser/problems/sample10.pg
@@ -11,8 +11,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample11.pg
+++ b/doc/parser/problems/sample11.pg
@@ -11,8 +11,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample12.pg
+++ b/doc/parser/problems/sample12.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample13.pg
+++ b/doc/parser/problems/sample13.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample14.pg
+++ b/doc/parser/problems/sample14.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample15.pg
+++ b/doc/parser/problems/sample15.pg
@@ -12,8 +12,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ##########################################################
 #
 #  The setup

--- a/doc/parser/problems/sample16.pg
+++ b/doc/parser/problems/sample16.pg
@@ -13,8 +13,6 @@ loadMacros(
   "Differentiation.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample17.pg
+++ b/doc/parser/problems/sample17.pg
@@ -13,8 +13,6 @@ loadMacros(
   "Differentiation.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample18.pg
+++ b/doc/parser/problems/sample18.pg
@@ -13,8 +13,6 @@ loadMacros(
   "Differentiation.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample19.pg
+++ b/doc/parser/problems/sample19.pg
@@ -13,8 +13,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample20.pg
+++ b/doc/parser/problems/sample20.pg
@@ -12,8 +12,6 @@ loadMacros(
   "Parser.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample21.pg
+++ b/doc/parser/problems/sample21.pg
@@ -13,8 +13,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup

--- a/doc/parser/problems/sample22.pg
+++ b/doc/parser/problems/sample22.pg
@@ -13,8 +13,6 @@ loadMacros(
   "parserUtils.pl",
 );
 
-TEXT(beginproblem());
-
 ###########################################################
 #
 #   The setup


### PR DESCRIPTION
There are two commits here. One removes `BEGIN/END_ONE_COLUMN` from all pg files that come with the distribution. The other removes all `beginproblem()` from pg files that come with the distribution. These are all deprecated now and the distribution should not use them.

The four sets that come with model course should be redone (I think into just two sets: an orientation and a demo). But that is a later project.