### PR TITLE
give message if someone tries to visit an archived (and closed) course

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -201,7 +201,10 @@ async sub dispatch ($c) {
 	if ($routeCaptures{courseID}) {
 		debug("We got a courseID from the route, now we can do some stuff:\n");
 
-		return (0, 'This course does not exist.') unless -e $ce->{courseDirs}{root};
+		return (0, 'This course does not exist.')
+			unless (-e $ce->{courseDirs}{root}
+				|| -e "$ce->{webwork_courses_dir}/admin/archives/$routeCaptures{courseID}.tar.gz");
+		return (0, 'This course has been archived and closed.') unless -e $ce->{courseDirs}{root};
 
 		debug("...we can create a database object...\n");
 		my $db = WeBWorK::DB->new($ce->{dbLayout});


### PR DESCRIPTION
If a course `course_name` has been archived and deleted, so the archives folder has `course_name.tar.gz`, this makes it so that when a user visits `webwork.mysite.org/webwork2/course_name`, they get a message "This course has been archived and closed." instead of the message "This course does not exist.".