### PR TITLE
LTI 1.1 override protocol and domain only for OAuth

### DIFF
--- a/conf/authen_LTI_1_1.conf.dist
+++ b/conf/authen_LTI_1_1.conf.dist
@@ -134,6 +134,12 @@ $LTI{v1p1}{NonceLifeTime} = 60;    # in seconds
 # does not match the path that ends up in the webwork page.
 $LTI{v1p1}{OverrideSiteURL} = '';
 
+# This is like $LTI{v1p1}{OverrideSiteURL}, except that you only declare the protocol and domain
+# to replace and leave the rest of a URL alone. If somehow both are set in the config chain,
+# $LTI{v1p1}{OverrideSiteURL} is used, without being modified by the below.
+$LTI{v1p1}{OverrideSiteProtocolDomain} = '';
+#$LTI{v1p1}{OverrideSiteProtocolDomain} = 'https://vmwebwork42.myschool.edu';
+
 ################################################################################################
 # LTI 1.1 LMS Roles Mapped to WeBWorK Roles
 ################################################################################################

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -91,8 +91,8 @@ sub startup ($app) {
 
 	# Helpers
 
-	# This replaces the previous Apache2::RequestUtil method that was overriden in the WeBWorK::Request module to return
-	# the empty string for '/'.
+	# This replaces the previous Apache2::RequestUtil method that was overridden in
+	# the WeBWorK::Request module to return the empty string for '/'.
 	$app->helper(location => sub ($) { return $webwork_url eq '/' ? '' : $webwork_url });
 
 	$app->helper(server_root_url => sub ($) { return $server_root_url; });

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -28,7 +28,7 @@ use warnings;
 
 use Carp;
 use DBI;
-use URI;
+use Mojo::URL;
 use URI::Escape;
 use Net::OAuth;
 
@@ -455,12 +455,12 @@ sub authenticate {
 	my $requestHash = \%request_hash;
 
 	# We need to provide the request URL when verifying the OAuth request.
-	# We use the url request by default, but also allow it to be overriden
-	my $url = URI->new($c->url_for->to_abs);
+	# We use the url request by default, but also allow it to be overridden
+	my $url = $c->url_for->to_abs;
 	if ($ce->{LTI}{v1p1}{OverrideSiteProtocolDomain}) {
-		my $override = URI->new($ce->{LTI}{v1p1}{OverrideSiteProtocolDomain});
-		$url->scheme($override->scheme());
-		$url->host($override->host());
+		my $override = Mojo::URL->new($ce->{LTI}{v1p1}{OverrideSiteProtocolDomain});
+		$url->scheme($override->scheme);
+		$url->host($override->host);
 	}
 	my $path = $ce->{LTI}{v1p1}{OverrideSiteURL} || ($url =~ s|/?$|/|r);
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -28,6 +28,7 @@ use warnings;
 
 use Carp;
 use DBI;
+use URI;
 use URI::Escape;
 use Net::OAuth;
 
@@ -455,7 +456,13 @@ sub authenticate {
 
 	# We need to provide the request URL when verifying the OAuth request.
 	# We use the url request by default, but also allow it to be overriden
-	my $path = $ce->{LTI}{v1p1}{OverrideSiteURL} || ($c->url_for->to_abs =~ s|/?$|/|r);
+	my $url = URI->new($c->url_for->to_abs);
+	if ($ce->{LTI}{v1p1}{OverrideSiteProtocolDomain}) {
+		my $override = URI->new($ce->{LTI}{v1p1}{OverrideSiteProtocolDomain});
+		$url->scheme($override->scheme());
+		$url->host($override->host());
+	}
+	my $path = $ce->{LTI}{v1p1}{OverrideSiteURL} || ($url =~ s|/?$|/|r);
 
 	if ($ce->{debug_lti_parameters}) {
 		warn "The following path was reconstructed by WeBWorK.  It should match the path in the LMS:\n";

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -283,7 +283,7 @@ sub addbadmessage ($c, $message) {
 =item prepare_activity_entry()
 
 Prepare a string to be sent to the activity log, if it is turned on.
-This can be overriden by different modules.
+This can be overridden by different modules.
 
 =cut
 
@@ -787,7 +787,7 @@ sub url ($c, $args) {
 =head2 Template conditions
 
 Template condition methods are called in the template. If a method is defined
-here or overriden in the instantiated subclass, it is invoked.
+here or overridden in the instantiated subclass, it is invoked.
 
 The following conditions are currently defined:
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -619,7 +619,7 @@ sub parseDateTime($;$) {
 		} else {
 #warn "\t\$zone=$zone is invalid according to DateTime::TimeZone, so we will attempt to treat the date/time as UTC and then apply an offset for the zone $zone.\n";
 			$tz_to_use = "UTC";
-			# When the offset approach fails, we will overriden again and use $display_tz instead
+			# When the offset approach fails, we will override again and use $display_tz instead
 		}
 	} else {
 		#warn "\t\$zone not supplied, using \$display_tz\n";


### PR DESCRIPTION
This allows you to override the protocol/scheme (http vs https) and the domain for the URL that is used with LTI 1.1 for OAuth without changing the rest of the URL.

I have this working in production. I have
```
$LTI{v1p1}{OverrideSiteProtocolDomain} = 'https://webwork.pcc.edu';
```
and I can get into my WW course from the LMS, even after actively logging out from WW. But if I alter or comment out that config setting, I get "The course XXXXXXXXXXXXX uses an external authentication system ([Desire2Learn](https://online.pcc.edu/)). Please return to that system to access this course." The hack i previously had in place is removed.