### PR TITLE
add mhchem package to latex packages

### DIFF
--- a/conf/snippets/hardcopyThemes/common/packages.tex
+++ b/conf/snippets/hardcopyThemes/common/packages.tex
@@ -1,5 +1,6 @@
 \usepackage{amsmath,amsfonts,amssymb,multicol}
 \usepackage{booktabs,tabularx,colortbl,caption,xcolor}
+\usepackage[version=4]{mhchem}
 \usepackage{path}
 \discretionaries |~!@$%^&*()_+`-=#{"}[]:;'<>,.?\/abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789|
 


### PR DESCRIPTION
@limefrogyank has some WW chemistry macros that might be coming to `pg` or the OPL in the coming year. This tex package will support the hardcopy output for those.

Note that if you don't specify a version, this package issues a runtime warning. So we set it to the current version 4. Version 4.09 is the latest, from December 2021.