### PR TITLE
POD Viewer improvements

### DIFF
--- a/bin/dev_scripts/PODtoHTML.pm
+++ b/bin/dev_scripts/PODtoHTML.pm
@@ -17,20 +17,25 @@ package PODtoHTML;
 
 use strict;
 use warnings;
+use utf8;
 
 use Pod::Simple::Search;
+use Mojo::Template;
+use Mojo::DOM;
+use Mojo::Collection qw(c);
 use File::Path qw(make_path);
+use File::Basename qw(dirname);
 use IO::File;
 use POSIX qw(strftime);
 
 use WeBWorK::Utils::PODParser;
 
 our @sections = (
-	bin    => "Scripts",
-	conf   => "Config Files",
-	doc    => "Documentation",
-	lib    => "Libraries",
-	macros => "Macros"
+	bin    => 'Scripts',
+	conf   => 'Config Files',
+	doc    => 'Documentation',
+	lib    => 'Libraries',
+	macros => 'Macros'
 );
 
 sub new {
@@ -58,10 +63,10 @@ sub convert_pods {
 
 	my $regex = join('|', map {"^$_"} @{ $self->{section_order} });
 
-	(undef, my $podFiles) = Pod::Simple::Search->new->inc(0)->limit_re(qr!$regex!)->survey($self->{source_root});
-	for (keys %$podFiles) {
+	my ($name2path, $path2name) = Pod::Simple::Search->new->inc(0)->limit_re(qr!$regex!)->survey($self->{source_root});
+	for (keys %$path2name) {
 		print "Processing file: $_\n" if $self->{verbose} > 1;
-		$self->process_pod($_);
+		$self->process_pod($_, $name2path);
 	}
 
 	$self->write_index("$dest_root/index.html");
@@ -70,7 +75,7 @@ sub convert_pods {
 }
 
 sub process_pod {
-	my ($self, $pod_path) = @_;
+	my ($self, $pod_path, $pod_files) = @_;
 
 	my $pod_name;
 
@@ -86,7 +91,7 @@ sub process_pod {
 		}
 	}
 
-	$pod_name = (defined $subdir_rest ? "$subdir_rest/" : "") . $filename;
+	$pod_name = (defined $subdir_rest ? "$subdir_rest/" : '') . $filename;
 	if ($filename =~ /\.pl$/) {
 		$filename =~ s/\.pl$/.html/;
 	} elsif ($filename =~ /\.pod$/) {
@@ -97,22 +102,23 @@ sub process_pod {
 		$pod_name =~ s|/+|::|g;
 		$filename =~ s/\.pm$/.html/;
 	} elsif ($filename !~ /\.html$/) {
-		$filename .= ".html";
+		$filename .= '.html';
 	}
 
 	$pod_name =~ s/^(\/|::)//;
 
-	my $html_dir      = $self->{dest_root} . (defined $subdir ? "/$subdir" : "");
+	my $html_dir      = $self->{dest_root} . (defined $subdir ? "/$subdir" : '');
 	my $html_path     = "$html_dir/$filename";
 	my $html_rel_path = defined $subdir ? "$subdir/$filename" : $filename;
 
 	$self->update_index($subdir, $html_rel_path, $pod_name);
 	make_path($html_dir);
 	my $html = $self->do_pod2html(
-		pod_path => $pod_path,
-		pod_name => $pod_name
+		pod_path  => $pod_path,
+		pod_name  => $pod_name,
+		pod_files => $pod_files
 	);
-	my $fh = IO::File->new($html_path, '>')
+	my $fh = IO::File->new($html_path, '>:encoding(UTF-8)')
 		or die "Failed to open file '$html_path' for writing: $!\n";
 	print $fh $html;
 
@@ -137,84 +143,53 @@ sub update_index {
 sub write_index {
 	my ($self, $out_path) = @_;
 
-	my $source_root = $self->{source_root} =~ s|^.*/||r;
-	my $title       = "Index for $source_root";
-
-	my $content_start = '<ul>';
-	my $content       = '';
-
-	for my $section (@{ $self->{section_order} }) {
-		next unless defined $self->{idx}{$section};
-		$content_start .= qq{<li><a href="#$section">$self->{section_hash}{$section}</a></li>};
-		$content       .= qq{<h2><a href="#_podtop_" id="$section">$self->{section_hash}{$section}</a></h2><ul>};
-		for my $file (sort { $a->[1] cmp $b->[1] } @{ $self->{idx}{$section} }) {
-			$content .= qq{<li><a href="$file->[0]">$file->[1]</a></li>};
+	my $fh = IO::File->new($out_path, '>:encoding(UTF-8)') or die "Failed to open index '$out_path' for writing: $!\n";
+	print $fh Mojo::Template->new(vars => 1)->render_file(
+		"$self->{template_dir}/category-index.mt",
+		{
+			title         => 'POD for ' . ($self->{source_root} =~ s|^.*/||r),
+			base_url      => $self->{dest_url},
+			pod_index     => $self->{idx},
+			sections      => $self->{section_hash},
+			section_order => $self->{section_order},
+			date          => strftime('%a %b %e %H:%M:%S %Z %Y', localtime)
 		}
-		$content .= '</ul>';
-	}
-
-	$content_start .= '</ul>';
-	my $date = strftime '%a %b %e %H:%M:%S %Z %Y', localtime;
-
-	my $fh = IO::File->new($out_path, '>') or die "Failed to open index '$out_path' for writing: $!\n";
-	print $fh (get_header($title, $self->{dest_url}), $content_start, $content, "<p>Generated $date</p>", get_footer());
+	);
 
 	return;
 }
 
 sub do_pod2html {
 	my ($self, %o) = @_;
-	my $psx = WeBWorK::Utils::PODParser->new;
+
+	my $psx = WeBWorK::Utils::PODParser->new($o{pod_files});
 	$psx->{source_root}     = $self->{source_root};
 	$psx->{verbose}         = $self->{verbose};
 	$psx->{assert_html_ext} = 1;
-	$psx->{base_url}        = ($self->{dest_url} // "") . "/" . (($self->{source_root} // "") =~ s|^.*/||r);
+	$psx->{base_url}        = ($self->{dest_url} // '') . '/' . (($self->{source_root} // '') =~ s|^.*/||r);
 	$psx->output_string(\my $html);
-	$psx->html_header(get_header($o{pod_name}, "$psx->{base_url}/.."));
-	$psx->html_footer(get_footer());
+	$psx->html_header('');
+	$psx->html_footer('');
 	$psx->parse_file($o{pod_path});
-	return $html;
-}
 
-sub get_header {
-	my ($title, $base_url) = @_;
-	return << "EOF";
-<!DOCTYPE html>
-<html lang="en" dir="ltr">
-<head>
-<meta charset='UTF-8'>
-<link rel="icon" href="/favicon.ico">
-<title>$title</title>
-<link href="https://cdn.jsdelivr.net/npm/bootstrap\@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="$base_url/css/pod.css" rel="stylesheet">
-</head>
-<body>
-<div class="container mt-3">
-<h1>$title</h1>
-<hr>
-<div>Jump to: <a href="#column-one">Site Navigation</a></div>
-<hr>
-<div id="_podtop_">
-EOF
-}
+	my $dom        = Mojo::DOM->new($html);
+	my $podIndexUL = $dom->at('ul[id="index"]');
+	my $podIndex   = $podIndexUL ? $podIndexUL->find('ul[id="index"] > li') : c();
+	for (@$podIndex) {
+		$_->attr({ class => 'nav-item' });
+		$_->at('a')->attr({ class => 'nav-link p-0' });
+		for (@{ $_->find('ul') }) {
+			$_->attr({ class => 'nav flex-column w-100' });
+		}
+		for (@{ $_->find('li') }) {
+			$_->attr({ class => 'nav-item' });
+			$_->at('a')->attr({ class => 'nav-link p-0' });
+		}
+	}
+	my $podHTML = $podIndexUL ? $podIndexUL->remove : $html;
 
-sub get_footer {
-	return << 'EOF';
-</div>
-<hr>
-<div id="column-one">
-<h5>Site Navigation</h5>
-<div>
-<ul>
-<li><a href="/pod">WeBWorK POD Home</a></li>
-<li><a href="http://webwork.maa.org/wiki/WeBWorK_Main_Page">WeBWorK Wiki</a></li>
-</ul>
-</div>
-</div>
-</div>
-</body>
-</html>
-EOF
+	return Mojo::Template->new(vars => 1)->render_file("$self->{template_dir}/pod.mt",
+		{ title => $o{pod_name}, base_url => dirname($psx->{base_url}), index => $podIndex, content => $podHTML });
 }
 
 1;

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -62,6 +62,7 @@ pod2usage(2) unless $output_dir;
 
 $base_url = "/" if !$base_url;
 
+use Mojo::Template;
 use IO::File;
 use File::Copy;
 use File::Path qw(make_path remove_tree);
@@ -83,11 +84,13 @@ for my $dir ($webwork_root, $pg_root) {
 
 my $index_fh = IO::File->new("$output_dir/index.html", '>')
 	or die "failed to open '$output_dir/index.html' for writing: $!\n";
-write_index($index_fh, $base_url);
+write_index($index_fh);
 
-make_path("$output_dir/css");
-copy("$webwork_root/htdocs/js/PODViewer/podviewer.css", "$output_dir/css/pod.css");
-print "copying $webwork_root/htdocs/js/PODViewer/podviewer.css to $output_dir/css/pod.css\n" if $verbose;
+make_path("$output_dir/assets");
+copy("$webwork_root/htdocs/js/PODViewer/podviewer.css", "$output_dir/assets/podviewer.css");
+print "copying $webwork_root/htdocs/js/PODViewer/podviewer.css to $output_dir/assets/podviewer.css\n" if $verbose;
+copy("$webwork_root/htdocs/js/PODViewer/podviewer.js", "$output_dir/assets/podviewer.js");
+print "copying $webwork_root/htdocs/js/PODViewer/podviewer.css to $output_dir/assets/podviewer.js\n" if $verbose;
 
 sub process_dir {
 	my $source_dir = shift;
@@ -101,10 +104,11 @@ sub process_dir {
 	make_path($dest_dir);
 
 	my $htmldocs = PODtoHTML->new(
-		source_root => $source_dir,
-		dest_root   => $dest_dir,
-		dest_url    => $base_url,
-		verbose     => $verbose
+		source_root  => $source_dir,
+		dest_root    => $dest_dir,
+		template_dir => "$webwork_root/bin/dev_scripts/pod-templates",
+		dest_url     => $base_url,
+		verbose      => $verbose
 	);
 	$htmldocs->convert_pods;
 
@@ -112,29 +116,10 @@ sub process_dir {
 }
 
 sub write_index {
-	my ($fh, $base_url) = @_;
-	print $fh <<"EOF";
-<!DOCTYPE html>
-<html lang="en" dir="ltr">
-<head>
-<meta charset='UTF-8'>
-<link rel="shortcut icon" href="/favicon.ico">
-<link href="https://cdn.jsdelivr.net/npm/bootstrap\@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
-<link href="$base_url/css/pod.css" rel="stylesheet">
-<title>WeBWorK/PG POD</title>
-</head>
-<body>
-<div class="container mt-3">
-<h1>WeBWorK/PG POD</h1>
-<h2>(Plain Old Documentation)</h2>
-<div>
-<ul>
-EOF
+	my $fh = shift;
 
-	print $fh q{<li><a href="pg">PG</a></li>}            if $pg_root;
-	print $fh q{<li><a href="webwork2">WeBWorK</a></li>} if $webwork_root;
-
-	print $fh "</ul></div></div></body></html>";
+	print $fh Mojo::Template->new(vars => 1)->render_file("$webwork_root/bin/dev_scripts/pod-templates/main-index.mt",
+		{ base_url => $base_url, webwork_root => $webwork_root, pg_root => $pg_root });
 
 	return;
 }

--- a/bin/dev_scripts/pod-templates/category-index.mt
+++ b/bin/dev_scripts/pod-templates/category-index.mt
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= $title %></title>
+	<link rel="shortcut icon" href="/favicon.ico">
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+	<link href="<%= $base_url %>/assets/podviewer.css" rel="stylesheet">
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" defer></script>
+	<script src="<%= $base_url %>/assets/podviewer.js" defer></script>
+</head>
+%
+<body>
+	<div class="pod-header navbar navbar-dark bg-primary px-3 position-fixed border-bottom border-dark">
+		<div class="container-fluid d-flex flex-column d-md-block">
+			<h1 class="navbar-brand fw-bold fs-5 me-auto me-md-0 mb-2 mb-md-0"><%= $title %></h1>
+			<button class="navbar-toggler d-md-none me-auto" type="button" data-bs-toggle="offcanvas"
+				data-bs-target="#sidebar" aria-controls="sidebar" aria-label="Toggle Sidebar">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+		</div>
+	</div>
+	%
+	% my ($index, $content) = ('', '');
+	% for my $section (@$section_order) {
+		% next unless defined $pod_index->{$section};
+		% my $new_index = begin
+			<a href="#<%= $section %>" class="nav-link"><%= $sections->{$section} %></a>
+		% end
+		% $index .= $new_index->();
+		% my $new_content = begin
+			<h2><a href="#_podtop_" id="<%= $section %>"><%= $sections->{$section} %></a></h2>
+			<div class="list-group mb-2">
+				% for my $file (sort { $a->[1] cmp $b->[1] } @{ $pod_index->{$section} }) {
+					<a href="<%= $file->[0] %>" class="list-group-item list-group-item-action"><%= $file->[1] %></a>
+				% }
+			</div>
+		% end
+		% $content .= $new_content->();
+	% }
+	%
+	<aside class="offcanvas-md offcanvas-start border-end border-dark position-fixed" tabindex="-1"
+		id="sidebar" aria-labelledby="sidebar-label">
+		<div class="offcanvas-header">
+			<h2 class="offcanvas-title" id="sidebar-label">Index</h2>
+			<button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebar"
+			   	aria-label="Close">
+			</button>
+		</div>
+		<div class="offcanvas-body p-md-3 w-100">
+			<nav class="nav flex-column w-100">
+				<a href="<%= $base_url %>" class="nav-link">WeBWorK POD Home</a>
+				<a href="http://webwork.maa.org/wiki/WeBWorK_Main_Page" class="nav-link">WeBWorK Wiki</a>
+				<hr>
+				<%= $index =%>
+			</nav>
+		</div>
+	</aside>
+	<div class="pod-page-container d-flex">
+		<div class="container-fluid p-3 h-100" id="_podtop_">
+			<%= $content =%>
+			<p class="mt-3">Generated <%= $date %></p>
+		</div>
+	</div>
+</body>
+%
+</html>

--- a/bin/dev_scripts/pod-templates/main-index.mt
+++ b/bin/dev_scripts/pod-templates/main-index.mt
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<link rel="shortcut icon" href="/favicon.ico">
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+	<link href="<%= $base_url %>/assets/podviewer.css" rel="stylesheet">
+	<title>WeBWorK/PG POD</title>
+</head>
+%
+<body>
+	<div class="main-index-header navbar navbar-dark bg-primary px-3 position-fixed border-bottom border-dark">
+		<div class="container-fluid">
+			<h1 class="navbar-brand fw-bold fs-5 m-0">WeBWorK/PG POD</h1>
+		</div>
+	</div>
+	<div class="main-index-container mx-3">
+		<div class="pt-3">
+			<h2 class="fw-bold fs-6">(Plain Old Documentation)</h2>
+			<nav class="nav flex-column list-group">
+				% if ($pg_root) {
+					<a class="nav-link list-group-item list-group-item-action d-inline-block w-100" href="pg">
+						PG
+					</a>
+				% }
+				% if ($webwork_root) {
+					<a class="nav-link list-group-item list-group-item-action d-inline-block w-100" href="webwork2">
+						Webwork2
+					</a>
+				% }
+			</nav>
+		</div>
+	</div>
+</body>
+%
+</html>

--- a/bin/dev_scripts/pod-templates/pod.mt
+++ b/bin/dev_scripts/pod-templates/pod.mt
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= $title %></title>
+	<link rel="shortcut icon" href="/favicon.ico">
+	<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/css/bootstrap.min.css" rel="stylesheet">
+	<link href="<%= $base_url %>/assets/podviewer.css" rel="stylesheet">
+	<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.3/dist/js/bootstrap.bundle.min.js" defer></script>
+	<script src="<%= $base_url %>/assets/podviewer.js" defer></script>
+</head>
+%
+<body>
+	<div class="pod-header navbar navbar-dark bg-primary px-3 position-fixed border-bottom border-dark">
+		<div class="container-fluid d-flex flex-column d-md-block">
+			<h1 class="navbar-brand fw-bold fs-5 me-auto me-md-0 mb-2 mb-md-0"><%= $title %></h1>
+			<button class="navbar-toggler d-md-none me-auto" type="button" data-bs-toggle="offcanvas"
+				data-bs-target="#sidebar" aria-controls="sidebar" aria-label="Toggle Sidebar">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+		</div>
+	</div>
+	<aside class="offcanvas-md offcanvas-start border-end border-dark position-fixed" tabindex="-1"
+		id="sidebar" aria-labelledby="sidebar-label">
+		<div class="offcanvas-header">
+			<h2 class="offcanvas-title" id="sidebar-label">Index</h2>
+			<button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebar"
+			   	aria-label="Close">
+			</button>
+		</div>
+		<div class="offcanvas-body p-md-3 w-100">
+			<nav>
+				<ul class="nav flex-column w-100">
+					<li class="nav-item">
+						<a href="<%= $base_url %>" class="nav-link p-0">WeBWorK POD Home</a>
+					</li>
+					<li class="nav-item">
+						<a href="http://webwork.maa.org/wiki/WeBWorK_Main_Page" class="nav-link p-0">WeBWorK Wiki</a>
+					</li>
+					<li><hr></li>
+					<%= $index->join('') =%>
+				</ul>
+			</nav>
+		</div>
+	</aside>
+	<div class="pod-page-container d-flex">
+		<div class="container-fluid p-3 h-100" id="_podtop_">
+			<%= $content =%>
+		</div>
+	</div>
+</body>
+%
+</html>

--- a/htdocs/js/PODViewer/podviewer.css
+++ b/htdocs/js/PODViewer/podviewer.css
@@ -1,6 +1,66 @@
+.main-index-header,
+.pod-header {
+	height: 65px;
+	top: 0;
+	left: 0;
+	right: 0;
+	z-index: 2;
+}
+
+#sidebar {
+	--bs-offcanvas-width: 300px;
+	overflow-y: auto;
+}
+
+#sidebar ul.nav ul.nav li {
+	border-left: 1px solid #e1e4e8;
+	padding-left: 10px;
+}
+
+#sidebar ul.nav ul.nav li:hover {
+	border-left: 6px solid #e1e4e8;
+	padding-left: 5px;
+}
+
+.main-index-container,
+.pod-page-container {
+	margin-top: 65px;
+}
+
+@media only screen and (min-width: 768px) {
+	#sidebar {
+		height: calc(100vh - 65px);
+		width: 300px;
+	}
+
+	.pod-page-container {
+		margin-left: 300px;
+	}
+}
+
 #_podtop_ pre {
 	border: 1px solid #ccc;
 	border-radius: 5px;
 	background: #f6f6f6;
 	padding: 0.75rem;
+}
+
+#_podtop_,
+#_podtop_ *[id] {
+	scroll-margin-top: calc(65px + 1rem);
+}
+
+@media only screen and (max-width: 768px) {
+	.pod-header {
+		height: 100px;
+	}
+
+	.pod-page-container {
+		margin-top: 100px;
+	}
+
+	#_podtop_,
+	#_podtop_ *[id] {
+		scroll-margin-top: calc(100px + 1rem);
+	}
 }

--- a/htdocs/js/PODViewer/podviewer.js
+++ b/htdocs/js/PODViewer/podviewer.js
@@ -1,0 +1,8 @@
+(() => {
+	const offcanvas = bootstrap.Offcanvas.getOrCreateInstance(document.getElementById('sidebar'));
+	for (const link of document.querySelectorAll('#sidebar .nav-link')) {
+		// The timeout is to workaround an issue in Chrome. If the offcanvas hides before the window scrolls to the
+		// fragment in the page, scrolling stops before it gets there.
+		link.addEventListener('click', () => setTimeout(() => offcanvas.hide(), 500));
+	}
+})();

--- a/htdocs/themes/math4-yellow/_theme-colors.scss
+++ b/htdocs/themes/math4-yellow/_theme-colors.scss
@@ -35,3 +35,10 @@ $ww-achievement-level-color: darken($primary, 15%);
 
 // Make accordion buttons darker.
 $accordion-button-active-color: shade-color($primary, 50%);
+
+// Make the navbar colors dark.
+$navbar-dark-color:                 rgba(#000, .55);
+$navbar-dark-hover-color:           rgba(#000, .75);
+$navbar-dark-active-color:          #000;
+$navbar-dark-disabled-color:        rgba(#000, .25);
+$navbar-dark-toggler-border-color:  rgba(#000, .1);

--- a/templates/ContentGenerator/PODViewer.html.ep
+++ b/templates/ContentGenerator/PODViewer.html.ep
@@ -1,47 +1,31 @@
+% layout 'pod_viewer';
 % title maketext('PG POD');
 %
-<!DOCTYPE html>
-<html lang="en" dir="ltr">
-%
-<head>
-	<meta charset='UTF-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title><%= title %></title>
-	<%= stylesheet $c->url({ type => 'webwork', name => 'theme', file => 'bootstrap.css' }) =%>
-	<link rel="icon" type="x-image/icon"
-		href="<%= $c->url({ type => 'webwork', name => 'htdocs', file => 'images/favicon.ico' }) %>">
-</head>
-%
 % my %section_names = (
-	% doc    => 'Documentation',
-	% lib    => 'Libraries',
-	% macros => 'Macros'
+	% doc    => maketext('Documentation'),
+	% lib    => maketext('Libraries'),
+	% macros => maketext('Macros')
 % );
 %
-<body>
-	<div class="container" id="_podtop_">
-		<h1 class="mt-3"><%= title %></h1>
-		<hr>
-		% for my $section (sort keys %$sections) {
-			% content_for toc => begin
-				<li><a href="#<%= $section %>"><%= $section_names{$section} %></a></li>
-			% end
-			% content_for subjects => begin
-				<h2><a href="#_podtop_" id="<%= $section %>"><%= $section_names{$section} %></a></h2>
-				<ul>
-					% for (@{ $sections->{$section} }) {
-						<li>
-							% my $link_name = $_;
-							% $link_name = $1 =~ s!/!::!gr if $link_name =~ m/^(.*)\.pm$/;
-							<%= link_to $link_name => url_for('pod_viewer', filePath => "$section/$_") =%>
-						</li>
-					% }
-				</ul>
-			% end
-		% }
-		<ul><%= content 'toc' %></ul>
-		<%= content 'subjects' =%>
-	</div>
-</body>
-%
-</html>
+% for my $section (sort keys %$sections) {
+	% content_for toc => begin
+		<%= link_to $section_names{$section} => "#$section", class => 'nav-link' %>
+	% end
+	% content_for subjects => begin
+		<h2><a href="#_podtop_" id="<%= $section %>"><%= $section_names{$section} %></a></h2>
+		<div class="list-group mb-2">
+			% for (@{ $sections->{$section} }) {
+				% my $link_name = $_;
+				% $link_name = $1 =~ s!/!::!gr if $link_name =~ m/^(.*)\.pm$/;
+				<%= link_to $link_name, 'pod_viewer', { filePath => "$section/$_" },
+					class => 'list-group-item list-group-item-action' =%>
+			% }
+		</div>
+	% end
+% }
+% content_for sidebar => begin
+	<nav class="nav flex-column w-100">
+		<%= content 'toc' %>
+	</nav>
+% end
+<%= content 'subjects' %>

--- a/templates/ContentGenerator/PODViewer/POD.html.ep
+++ b/templates/ContentGenerator/PODViewer/POD.html.ep
@@ -1,35 +1,24 @@
+% layout 'pod_viewer';
 % my $title = $filePath =~ s!^[^/]*/!!r;
 % $title = $1 =~ s!/!::!gr if $title =~ m/^(.*)\.pm$/;
+% title $title;
 %
-<!DOCTYPE html>
-<html lang="en" dir="ltr">
-%
-<head>
-	<meta charset='UTF-8'>
-	<meta name="viewport" content="width=device-width, initial-scale=1.0">
-	<title><%= $title %></title>
-	<%= stylesheet $c->url({ type => 'webwork', name => 'theme',  file => 'bootstrap.css' }) =%>
-	<%= stylesheet $c->url({ type => 'webwork', name => 'htdocs', file => 'js/PODViewer/podviewer.css' }) =%>
-	<link rel="icon" type="x-image/icon"
-		href="<%= $c->url({ type => 'webwork', name => 'htdocs', file => 'images/favicon.ico' }) %>">
-</head>
-%
-<body>
-	<div class="container">
-		<h1 class="mt-3"><%= $title %></h1>
-		<hr>
-		<div><%= link_to "PG POD Home" => 'pod_index' %></div>
-		<hr>
-		<div id="_podtop_">
-			% if (stash('podHTML')) {
-				<%== stash('podHTML') =%>
-			% } elsif (stash('podError')) {
-				<%= maketext('Error generating POD for file [_1]: [_2]', $filePath, stash('podError')) =%>
-			% } else {
-				<%= maketext('Macro file [_1] not found.', $filePath) =%>
+% content_for sidebar => begin
+	<nav>
+		<ul class="nav flex-column w-100">
+			<li class="nav-item"><%= link_to "PG POD Home" => 'pod_index', class => 'nav-link p-0' %></li>
+			<li class="nav-item"><hr></li>
+			% for (@{ $c->stash->{podIndex} }) {
+				<%== $_ =%>
 			% }
-		</div>
-	</div>
-</body>
+		</ul>
+	</nav>
+% end
 %
-</html>
+% if (stash('podHTML')) {
+	<%== stash('podHTML') =%>
+% } elsif (stash('podError')) {
+	<%= maketext('Error generating POD for file [_1]: [_2]', $filePath, stash('podError')) =%>
+% } else {
+	<%= maketext('Macro file [_1] not found.', $filePath) =%>
+% }

--- a/templates/layouts/pod_viewer.html.ep
+++ b/templates/layouts/pod_viewer.html.ep
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+%
+<head>
+	<meta charset='UTF-8'>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= title %></title>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'theme',  file => 'bootstrap.css' }) =%>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'htdocs', file => 'js/PODViewer/podviewer.css' }) =%>
+	<%= javascript $c->url({
+		type => 'webwork', name => 'htdocs',
+		file => 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js'
+		}), defer => undef =%>
+	<%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'js/PODViewer/podviewer.js' }),
+		defer => undef =%>
+	<link rel="icon" type="x-image/icon"
+		href="<%= $c->url({ type => 'webwork', name => 'htdocs', file => 'images/favicon.ico' }) %>">
+</head>
+%
+<body>
+	<div class="pod-header navbar navbar-dark bg-primary px-3 position-fixed border-bottom border-dark">
+		<div class="container-fluid d-flex flex-column d-md-block">
+			<h1 class="navbar-brand fw-bold fs-5 me-auto me-md-0 mb-2 mb-md-0"><%= title %></h1>
+			<button class="navbar-toggler d-md-none me-auto" type="button" data-bs-toggle="offcanvas"
+				data-bs-target="#sidebar" aria-controls="sidebar" aria-label="<%= maketext('Toggle Sidebar') %>">
+				<span class="navbar-toggler-icon"></span>
+			</button>
+		</div>
+	</div>
+	<aside class="offcanvas-md offcanvas-start border-end border-dark position-fixed" tabindex="-1"
+		id="sidebar" aria-labelledby="sidebar-label">
+		<div class="offcanvas-header">
+			<h2 class="offcanvas-title" id="sidebar-label"><%= $sidebar_title %></h2>
+			<button type="button" class="btn-close" data-bs-dismiss="offcanvas" data-bs-target="#sidebar"
+			   	aria-label="Close">
+			</button>
+		</div>
+		<div class="offcanvas-body p-md-3 w-100">
+			<%= content 'sidebar' %>
+		</div>
+	</aside>
+	<div class="pod-page-container d-flex">
+		<div class="container-fluid p-3 h-100" id="_podtop_">
+			<%= content =%>
+		</div>
+	</div>
+</body>
+%
+</html>


### PR DESCRIPTION
First, improve the efficiency of the WeBWorK::Utils::PODPaser package.

The $podFiles argument must be provided to the new method in order for the module to resolve POD links to local files.  It should be the first return value of the POD::Simple::Search survey method if called in list context, or only return value if called in scalar context.

This is opposed to the previous method of search the root directory for each link that was encountered in the POD.  Now instead, the directory is searched for files containing POD only once, and the results are stored in a hash.  This is done by the caller and passed to the WeBWorK::Utils::PODPaser object on construction, instead of the WeBWorK::Utils::PODPaser object handling it.

The module now expects `L<...>` usage to be correct according to the documentation at https://perldoc.perl.org/perlpod#L-a-hyperlink.  Note that it also now honors links to POD head sections in other local files.

The module also honors the following special cases that fit into that scheme for local files:

* For a link to a local package, use the package name (exactly as the rules for `L<...>` dictate).
* For a link to a `.pod` file, just use the basename without the `.pod` extension.  So for example for a link to doc/MathObjects/UsingMathObjects.pod, use `L<UsingMathObjects>`.
* For a link to a macro file (or script), use the basename of the macro file with the `.pl` extension and no path.

The generate-ww-pg-pod.pl script now uses Mojo::Template to make it easier to make html.

The POD page layouts have been improved with a sidebar for indices. Mojo::DOM is used to parse the generate POD and pull the index out to place in the sidebar.

Also add a layout template for the POD rendered by webwork2.

This needs https://github.com/openwebwork/pg/pull/864 for some of the PG POD links to work right.