### PR TITLE
after upgrading courses, don't scan all courses again

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1587,7 +1587,6 @@ sub do_upgrade_course ($c) {
 			method => 'POST',
 			$c->c(
 				$c->hidden_authen_fields,
-				$c->hidden_fields('subDisplay'),
 				$c->tag(
 					'p',
 					class => 'text-center',


### PR DESCRIPTION
I think this is a good change, but not sure if all will agree.

When there are many courses, visiting the upgrade tool in the admin course takes a while for it to scan all courses looking for database tables to upgrade. Later when it's all done doing the upgrades, you click Done, and it reloads the same page, repeating that scan that takes so much time.

This changes it to go to the Course Listings page instead after clicking Done.