### PR TITLE
Student answers

### DIFF
--- a/templates/ContentGenerator/Hardcopy/form.html.ep
+++ b/templates/ContentGenerator/Hardcopy/form.html.ep
@@ -75,8 +75,7 @@
 					<span class="input-group-text"><b><%= maketext('Show:') %></b></span>
 					<div class="input-group-text">
 						<label class="form-check-label">
-							<%= check_box printStudentAnswers => 1, checked => undef,
-								class => 'form-check-input me-2' =%>
+							<%= check_box printStudentAnswers => 1, class => 'form-check-input me-2' =%>
 							<%= maketext('Student answers') =%>
 						</label>
 					</div>


### PR DESCRIPTION
This is another small change that I would like but I'm unsure if people like it the way it is now. This makes it so that when you go to print hardcopy, none of the optional components are checked. Presently, the student answers box is checked. This usually leads (for me) to a bunch of empty lists with spaces for answers that haven't been entered yet. If I am printing hardcopy, it is more often before students have had a chance to enter anything. Also this seems more clean in that none of the options are checked, instead of one standing out.