### PR TITLE
Fix scroll positioning issues.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -228,7 +228,8 @@
 
 		// Scroll to the top of the render window if the current scroll position is below that.
 		const renderAreaRect = renderArea.getBoundingClientRect();
-		if (renderAreaRect.top < 0) window.scrollBy(0, renderAreaRect.top);
+		const topBarHeight = document.querySelector('.webwork-logo')?.getBoundingClientRect().height ?? 0;
+		if (renderAreaRect.top < topBarHeight) window.scrollBy(0, renderAreaRect.top - topBarHeight);
 	});
 
 	const render = () => new Promise((resolve) => {

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -247,6 +247,10 @@ $site-nav-width: 250px !default;
 	margin-top: $masthead-height;
 	width: calc(100% - $site-nav-width);
 
+	*[id] {
+		scroll-margin-top: $masthead-height;
+	}
+
 	&.toggle-width {
 		width: 100%;
 		margin-left: 0;
@@ -256,6 +260,10 @@ $site-nav-width: 250px !default;
 		width: 100%;
 		margin-top: 0;
 		margin-left: auto;
+
+		*[id] {
+			scroll-margin-top: 0.75 * $masthead-height;
+		}
 	}
 }
 


### PR DESCRIPTION
Making the masthead fixed has caused some issues with scroll positioning.

First, if you click on a fragment link, the window scrolls the element that is referenced to the top of the page.  Unfortunately, that makes it under the masthead.  This adds a `scroll-margin-top` to all elements with ids in the main content of the page.  One example of this is the "Skip to main content" accessibility link.  If you load a page and hit the "tab" key immediately after the page loads this will appear.  If you then hit "enter", the "page-title" should be focused and scrolled to the top.  Without this pull request the page title will be under the masthead.  With this pull request it will be right under it.  This will also fix any other fragment links like this as well though.

Also on the PG problem editor page to fix scrolling to the top of the problem when the "View/Reload" button is clicked, the masthead height needs to be taken into account.  To test this open a problem in the editor, and scroll as far down as you can.  Make the window shorter if needed to make sure that the top of the problem is above the top of the window.  Then click "View/Reload".  With this pull request the window should scroll so that the top of the problem is visible below the masthead.  Withouth this pull request it will be obscured below the masthead.