### PR TITLE
change \ProvidesFile to \ProvidesPackage

### DIFF
--- a/conf/snippets/hardcopyThemes/common/webwork2.sty
+++ b/conf/snippets/hardcopyThemes/common/webwork2.sty
@@ -1,4 +1,5 @@
-\ProvidesFile{webwork2}
+\NeedsTeXFormat{LaTeX2e}
+\ProvidesPackage{webwork2}[2023/06/26 version 2.18]
 
 % These macros may be overridden with WeBWorK environment variables
 \def\webworkCourseName{}


### PR DESCRIPTION
As suggested by @drgrice1, this changes `\ProvidesFile` to `\ProvidesPackage`. Overleaf docs told me to also add the `\NeedsTeXFormat{LaTeX2e}` line.