### PR TITLE
fontspec in hardcopy preamble

### DIFF
--- a/conf/snippets/hardcopyThemes/oneColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/oneColumn/hardcopyPreamble.tex
@@ -4,6 +4,10 @@
 
 \usepackage[text={7.5in,9in},centering]{geometry}
 
+% If the "pdflatex" external program is set to xelatex in site.conf,
+% this is needed for bold, small caps, etc variants of Compute Modern
+\usepackage{fontspec}
+
 % This removes the margin for questions from the exam class.  At this point we only use questions and not parts or
 % subparts, but if those are used a similar thing will be needed for those as well.
 \renewcommand{\questionshook}{\leftmargin=0pt\labelwidth=-\labelsep}

--- a/conf/snippets/hardcopyThemes/twoColumn/hardcopyPreamble.tex
+++ b/conf/snippets/hardcopyThemes/twoColumn/hardcopyPreamble.tex
@@ -6,6 +6,10 @@
 \setlength{\columnsep}{.25in}
 \setlength{\columnseprule}{.4pt}
 
+% If the "pdflatex" external program is set to xelatex in site.conf,
+% this is needed for bold, small caps, etc variants of Compute Modern
+\usepackage{fontspec}
+
 % This removes the margin for questions from the exam class.  At this point we only use questions and not parts or
 % subparts, but if those are used a similar thing will be needed for those as well.
 \renewcommand{\questionshook}{\leftmargin=0pt\labelwidth=-\labelsep}


### PR DESCRIPTION
I use the `xelatex` for making hardcopy, initially just because some problems had things like π directly in their text.

I do not have a need for `xunicode` or `polyglossia`, so the distribution `XeLaTeX-***column` hardcopy themes seem like they are not what I should be using. But if using `xelatex`, then the `one-column` and `two-column` distribution themes fail to show font variants like bold, small caps, etc.

By adding the `fontspec` package, that is fixed. It's harmless for `pdflatex` sites, but lets these themes work when `$externalPrograms{pdflatex}` (a misnomer) is `xelatex --no-shell-escape`.

Try changing `$externalPrograms{pdflatex}` to `xelatex --no-shell-escape` and make a hardcopy before this PR and you should see the absence of bold. But with this commit, it comes back.