### PR TITLE
only show reduced credit date in set header when relevant

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -962,25 +962,25 @@ async sub write_set_tex ($c, $FH, $TargetUser, $setID) {
 
 	# write environment variables as LaTeX macros
 	for (qw(user_id student_id first_name last_name email_address section recitation)) {
-		print $FH '\\def\\webwork' . underscore_to_camel($_) . '{' . handle_underbar($TargetUser->{$_}) . "}\n";
+		print $FH '\\def\\webwork' . underscore_to_camel($_) . '{' . handle_underbar($TargetUser->{$_}) . "}\n"
+			if $TargetUser->{$_};
 	}
 	for (qw(set_id description)) {
-		print $FH '\\def\\webwork' . underscore_to_camel($_) . '{' . handle_underbar($MergedSet->{$_}) . "}\n";
+		print $FH '\\def\\webwork' . underscore_to_camel($_) . '{' . handle_underbar($MergedSet->{$_}) . "}\n"
+			if $MergedSet->{$_};
 	}
 	print $FH '\\def\\webworkPrettySetId{' . handle_underbar($MergedSet->{set_id}, 1) . "}\n";
 	for (qw(open_date due_date answer_date)) {
-		if (!ref($MergedSet->{$_}) && $MergedSet->{$_} =~ /^\d{10}$/) {
+		if ($MergedSet->{$_}) {
 			print $FH '\\def\\webwork'
 				. underscore_to_camel($_) . '{'
 				. WeBWorK::Utils::formatDateTime($MergedSet->{$_}, $ce->{siteDefaults}{timezone}) . "}\n";
-		} else {
-			print $FH '\\def\\webwork' . underscore_to_camel($_) . "{}\n";
 		}
 	}
 	# Leave reduced scoring date blank if it is disabled, or enabled but on (or somehow later) than the close date
-	if ($MergedSet->{enable_reduced_scoring}
-		&& !ref($MergedSet->{reduced_scoring_date})
-		&& $MergedSet->{reduced_scoring_date} =~ /^\d{10}$/
+	if ($MergedSet->{reduced_scoring_date}
+		&& $ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+		&& $MergedSet->{enable_reduced_scoring}
 		&& $MergedSet->{reduced_scoring_date} < $MergedSet->{due_date})
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -974,7 +974,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $setID) {
 		if ($MergedSet->{$_}) {
 			print $FH '\\def\\webwork'
 				. underscore_to_camel($_) . '{'
-				. WeBWorK::Utils::formatDateTime($MergedSet->{$_}, $ce->{siteDefaults}{timezone}) . "}\n";
+				. $c->formatDateTime($MergedSet->{$_}, $ce->{siteDefaults}{timezone}) . "}\n";
 		}
 	}
 	# Leave reduced scoring date blank if it is disabled, or enabled but on (or somehow later) than the close date
@@ -984,7 +984,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $setID) {
 		&& $MergedSet->{reduced_scoring_date} < $MergedSet->{due_date})
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
-			. WeBWorK::Utils::formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{siteDefaults}{timezone}) . "}\n";
+			. $c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{siteDefaults}{timezone}) . "}\n";
 	}
 
 	# write set header

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -968,7 +968,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $setID) {
 		print $FH '\\def\\webwork' . underscore_to_camel($_) . '{' . handle_underbar($MergedSet->{$_}) . "}\n";
 	}
 	print $FH '\\def\\webworkPrettySetId{' . handle_underbar($MergedSet->{set_id}, 1) . "}\n";
-	for (qw(open_date reduced_scoring_date due_date answer_date)) {
+	for (qw(open_date due_date answer_date)) {
 		if (!ref($MergedSet->{$_}) && $MergedSet->{$_} =~ /^\d{10}$/) {
 			print $FH '\\def\\webwork'
 				. underscore_to_camel($_) . '{'
@@ -976,6 +976,15 @@ async sub write_set_tex ($c, $FH, $TargetUser, $setID) {
 		} else {
 			print $FH '\\def\\webwork' . underscore_to_camel($_) . "{}\n";
 		}
+	}
+	# Leave reduced scoring date blank if it is disabled, or enabled but on (or somehow later) than the close date
+	if ($MergedSet->{enable_reduced_scoring}
+		&& !ref($MergedSet->{reduced_scoring_date})
+		&& $MergedSet->{reduced_scoring_date} =~ /^\d{10}$/
+		&& $MergedSet->{reduced_scoring_date} < $MergedSet->{due_date})
+	{
+		print $FH '\\def\\webworkReducedScoringDate{'
+			. WeBWorK::Utils::formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{siteDefaults}{timezone}) . "}\n";
 	}
 
 	# write set header


### PR DESCRIPTION
This fixes one essential thing: the new hardcopy header was showing a reduced credit date even when the set did not have reduced credit enabled.

And one other thing: the new hardcopy header was showing a reduced credit date even when it was equal to the close date.

This commit fixes both of these things.