### PR TITLE
Make messages dismissible and PG editor tmp edits more clear

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -54,7 +54,16 @@
 
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
-			.then((data) => showMessage(data.server_response, data.result_data))
+			.then((data) => {
+				showMessage(data.server_response, data.result_data);
+				if (data.result_data) {
+					// Add the temporary file coloring and change the current file to the saved file.
+					document.querySelectorAll('.set-file-info').forEach((nfo) => nfo.classList.add('temporaryFile'));
+					for (const currentFile of document.querySelectorAll('.current-file')) {
+						currentFile.textContent = currentFile.dataset.tmpFile;
+					}
+				}
+			})
 			.catch((err) => showMessage(`Error saving temporary file: ${err?.message ?? err}`));
 	};
 
@@ -104,6 +113,12 @@
 				if (revertRadio && revertRadio.disabled) {
 					revertRadio.disabled = false;
 					revertRadio.checked = true;
+				}
+
+				// Add the temporary file coloring and change the current file to the saved file.
+				document.querySelectorAll('.set-file-info').forEach((nfo) => nfo.classList.add('temporaryFile'));
+				for (const currentFile of document.querySelectorAll('.current-file')) {
+					currentFile.textContent = currentFile.dataset.tmpFile;
 				}
 
 				if (editorForm) editorForm.target = 'WW_View';

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -124,10 +124,18 @@
 	if (messages.length) {
 		const dismissBtn = document.getElementById('dismiss-messages-btn');
 		dismissBtn?.classList.remove('d-none');
-		dismissBtn?.addEventListener('click', () => {
-			messages.forEach((message) => message.remove());
-			dismissBtn.classList.add('d-none');
-		});
+
+		// Hide the dismiss button when the last alert is dismissed.
+		for (const message of messages) {
+			message.addEventListener('closed.bs.alert', () => {
+				if (!document.querySelector('#message .alert-dismissible, #message_bottom .alert-dismissible'))
+					dismissBtn.remove();
+			}, { once: true });
+		}
+
+		dismissBtn?.addEventListener('click', () =>
+			messages.forEach((message) => bootstrap.Alert.getOrCreateInstance(message)?.close())
+		);
 	}
 
 	// Accessibility

--- a/htdocs/themes/math4/math4.js
+++ b/htdocs/themes/math4/math4.js
@@ -120,6 +120,16 @@
 	const codeshards = document.querySelectorAll('.codeshard');
 	if (codeshards.length == 1) codeshards[0].setAttribute('aria-label', 'answer');
 
+	const messages = document.querySelectorAll('#message .alert-dismissible, #message_bottom .alert-dismissible');
+	if (messages.length) {
+		const dismissBtn = document.getElementById('dismiss-messages-btn');
+		dismissBtn?.classList.remove('d-none');
+		dismissBtn?.addEventListener('click', () => {
+			messages.forEach((message) => message.remove());
+			dismissBtn.classList.add('d-none');
+		});
+	}
+
 	// Accessibility
 	// Present the contents of the data-alt attribute as alternative content for screen reader users.
 	// The icon should be formatted as <i class="icon fas fa-close" data-alt="close"></i>

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -447,7 +447,14 @@ h2.page-title {
 
 /* Message section */
 .message:not(:empty) {
-	display: inline-block;
+	display: inline-flex;
+	flex-direction: column;
+	gap: 0.25rem;
+	margin: 0 0 0.5rem;
+
+	p {
+		margin: 0;
+	}
 }
 
 .font-visible { font-weight: bold; }

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -447,7 +447,6 @@ h2.page-title {
 
 /* Message section */
 .message:not(:empty) {
-	display: inline-block;
 	margin-bottom: 0.5rem;
 }
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -447,7 +447,7 @@ h2.page-title {
 
 /* Message section */
 .message:not(:empty) {
-	margin-bottom: 0.5rem;
+	display: inline-block;
 }
 
 .font-visible { font-weight: bold; }

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -164,7 +164,7 @@
 		% }
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>
-			<div class="mt-2">
+			<div>
 				<button type="button" id="dismiss-messages-btn" class="btn btn-primary d-none">
 					<%= maketext('Dismiss All Messages') %>
 				</button>

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -164,9 +164,11 @@
 		% }
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>
-			<button type="button" id="dismiss-messages-btn" class="btn btn-primary d-none">
-				<%= maketext('Dismiss All Messages') %>
-			</button>
+			<div class="mt-2">
+				<button type="button" id="dismiss-messages-btn" class="btn btn-primary d-none">
+					<%= maketext('Dismiss All Messages') %>
+				</button>
+			</div>
 		% }
 		%
 		% # Footer

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -164,6 +164,9 @@
 		% }
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>
+			<button type="button" id="dismiss-messages-btn" class="btn btn-primary d-none">
+				<%= maketext('Dismiss All Messages') %>
+			</button>
 		% }
 		%
 		% # Footer

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -266,7 +266,7 @@ message() template escape handler.
 sub addgoodmessage ($c, $message) {
 	$c->addmessage($c->tag(
 		'p',
-		class => 'alert alert-success alert-dismissible fade show ps-1 py-1 my-2',
+		class => 'alert alert-success alert-dismissible fade show ps-1 py-1',
 		$c->c(
 			$message,
 			$c->tag(
@@ -291,7 +291,7 @@ message() template escape handler.
 sub addbadmessage ($c, $message) {
 	$c->addmessage($c->tag(
 		'p',
-		class => 'alert alert-danger alert-dismissible fade show ps-1 py-1 my-2',
+		class => 'alert alert-danger alert-dismissible fade show ps-1 py-1',
 		$c->c(
 			$message,
 			$c->tag(

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -264,7 +264,20 @@ message() template escape handler.
 =cut
 
 sub addgoodmessage ($c, $message) {
-	$c->addmessage($c->tag('p', class => 'alert alert-success p-1 my-2', $c->b($message)));
+	$c->addmessage($c->tag(
+		'p',
+		class => 'alert alert-success alert-dismissible ps-1 py-1 my-2',
+		$c->c(
+			$message,
+			$c->tag(
+				'button',
+				type         => 'button',
+				class        => 'btn-close p-2',
+				data         => { bs_dismiss => 'alert' },
+				'aria-label' => $c->maketext('Dismiss')
+			)
+		)->join('')
+	));
 	return;
 }
 
@@ -276,7 +289,20 @@ message() template escape handler.
 =cut
 
 sub addbadmessage ($c, $message) {
-	$c->addmessage($c->tag('p', class => 'alert alert-danger p-1 my-2', $c->b($message)));
+	$c->addmessage($c->tag(
+		'p',
+		class => 'alert alert-danger alert-dismissible ps-1 py-1 my-2',
+		$c->c(
+			$message,
+			$c->tag(
+				'button',
+				type         => 'button',
+				class        => 'btn-close p-2',
+				data         => { bs_dismiss => 'alert' },
+				'aria-label' => $c->maketext('Dismiss')
+			)
+		)->join('')
+	));
 	return;
 }
 

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -266,7 +266,7 @@ message() template escape handler.
 sub addgoodmessage ($c, $message) {
 	$c->addmessage($c->tag(
 		'p',
-		class => 'alert alert-success alert-dismissible ps-1 py-1 my-2',
+		class => 'alert alert-success alert-dismissible fade show ps-1 py-1 my-2',
 		$c->c(
 			$message,
 			$c->tag(
@@ -291,7 +291,7 @@ message() template escape handler.
 sub addbadmessage ($c, $message) {
 	$c->addmessage($c->tag(
 		'p',
-		class => 'alert alert-danger alert-dismissible ps-1 py-1 my-2',
+		class => 'alert alert-danger alert-dismissible fade show ps-1 py-1 my-2',
 		$c->c(
 			$message,
 			$c->tag(

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -44,8 +44,10 @@ sub pre_header_initialize ($c) {
 	return unless $authz->hasPermissions($user, 'create_and_delete_courses');
 
 	# Get result and send to message
+	# FIXME: I am pretty sure this is not used anymore. All methods add their messages directly to the page except the
+	# table messages, and those are added below and not here.
 	my $status_message = $c->param('status_message');
-	$c->addmessage($c->tag('p', class => 'my-2', $c->b($status_message))) if $status_message;
+	$c->addmessage($c->tag('p', $c->b($status_message))) if $status_message;
 
 	# Check that the non-native tables are present in the database.
 	# These are the tables which are not course specific.

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementUserEditor.pm
@@ -42,11 +42,7 @@ sub initialize ($c) {
 
 	#Check and see if we need to assign or unassign things
 	if (defined $c->param('assignToAll')) {
-		$c->addmessage($c->tag(
-			'p',
-			class => 'alert alert-success p-1 mb-0',
-			$c->maketext('Achievement has been assigned to all users.')
-		));
+		$c->addgoodmessage($c->maketext('Achievement has been assigned to all users.'));
 		%selectedUsers      = map { $_ => 1 } @all_users;
 		$doAssignToSelected = 1;
 	} elsif (defined $c->param('unassignFromAll')
@@ -54,22 +50,14 @@ sub initialize ($c) {
 		&& $c->param('unassignFromAllSafety') == 1)
 	{
 		%selectedUsers = ();
-		$c->addmessage($c->tag(
-			'p',
-			class => 'alert alert-danger p-1 mb-0',
-			$c->maketext('Achievement has been unassigned to all students.')
-		));
+		$c->addbadmessage($c->maketext('Achievement has been unassigned to all students.'));
 		$doAssignToSelected = 1;
 	} elsif (defined $c->param('assignToSelected')) {
-		$c->addmessage($c->tag(
-			'p',
-			class => 'alert alert-success p-1 mb-0',
-			$c->maketext('Achievement has been assigned to selected users.')
-		));
+		$c->addgoodmessage($c->maketext('Achievement has been assigned to selected users.'));
 		$doAssignToSelected = 1;
 	} elsif (defined $c->param('unassignFromAll')) {
 		# no action taken
-		$c->addmessage($c->tag('p', class => 'alert alert-danger p-1 mb-0', $c->maketext('No action taken')));
+		$c->addbadmessage($c->maketext('No action taken'));
 	}
 
 	#do actual assignment and unassignment

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1211,7 +1211,7 @@ sub revert_handler ($c) {
 	}
 
 	# Determine revert action
-	my $revertType = $c->param('action.revert.type') || 'do_not_revert';
+	my $revertType = $c->param('action.revert.type') // '';
 
 	if ($revertType eq 'revert') {
 		$c->{inputFilePath} = $c->{editFilePath};

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -109,11 +109,7 @@ async sub initialize ($c) {
 
 	# Update grades if saving.
 	if ($c->param('assignGrades')) {
-		$c->addmessage($c->tag(
-			'p',
-			class => 'alert alert-success p-1 my-2',
-			$c->maketext('Grades have been saved for all current users.')
-		));
+		$c->addgoodmessage($c->maketext('Grades have been saved for all current users.'));
 
 		for my $user (@{ $c->stash->{users} }) {
 			my $userID = $user->user_id;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -407,8 +407,8 @@ async sub pre_header_initialize ($c) {
 		}
 
 		$c->addmessage($c->{set}->visible
-			? $c->tag('span', class => 'font-visible', $c->maketext('This set is visible to students.'))
-			: $c->tag('span', class => 'font-hidden',  $c->maketext('This set is hidden from students.')));
+			? $c->tag('p', class => 'font-visible', $c->maketext('This set is visible to students.'))
+			: $c->tag('p', class => 'font-hidden',  $c->maketext('This set is hidden from students.')));
 
 	} else {
 		# Test for additional problem validity if it's not already invalid.
@@ -460,7 +460,7 @@ async sub pre_header_initialize ($c) {
 	$c->{formFields}     = $formFields;
 
 	# Get the status message and add it to the messages.
-	$c->addmessage($c->tag('p', class => 'my-2', $c->b($c->param('status_message')))) if $c->param('status_message');
+	$c->addmessage($c->tag('p', $c->b($c->param('status_message')))) if $c->param('status_message');
 
 	# Now that the necessary variables are set, return if the set or problem is invalid.
 	return if $c->{invalidSet} || $c->{invalidProblem};

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -50,13 +50,13 @@ async sub initialize ($c) {
 	$c->{displayMode} = $user->displayMode || $ce->{pg}{options}{displayMode};
 
 	# Display status messages.
-	$c->addmessage($c->tag('p', class => 'my-2', $c->b($c->param('status_message')))) if $c->param('status_message');
+	$c->addmessage($c->tag('p', $c->b($c->param('status_message')))) if $c->param('status_message');
 
 	if ($authz->hasPermissions($userID, 'view_hidden_sets')) {
 		if ($c->{set}->visible) {
-			$c->addmessage($c->tag('span', class => 'font-visible', $c->maketext('This set is visible to students.')));
+			$c->addmessage($c->tag('p', class => 'font-visible', $c->maketext('This set is visible to students.')));
 		} else {
-			$c->addmessage($c->tag('span', class => 'font-hidden', $c->maketext('This set is hidden from students.')));
+			$c->addmessage($c->tag('p', class => 'font-hidden', $c->maketext('This set is hidden from students.')));
 		}
 	}
 
@@ -76,7 +76,7 @@ async sub initialize ($c) {
 			$screenSetHeader = "$ce->{courseDirs}{templates}/$screenSetHeader" unless $screenSetHeader =~ m!^/!;
 			die 'sourceFilePath is unsafe!' unless path_is_subdir($screenSetHeader, $ce->{courseDirs}{templates});
 			$c->addmessage($c->tag(
-				'div',
+				'p',
 				class => 'temporaryFile',
 				$c->maketext('Viewing temporary file: [_1]', $screenSetHeader)
 			));

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -60,7 +60,7 @@ sub initialize ($c) {
 
 	if ($authz->hasPermissions($user, 'access_instructor_tools')) {
 		my $status_message = $c->param('status_message');
-		$c->addmessage($c->tag('p', class => 'my-2', $c->b($status_message))) if $status_message;
+		$c->addmessage($c->tag('p', $c->b($status_message))) if $status_message;
 	}
 
 	if ($authz->hasPermissions($user, 'navigation_allowed')) {
@@ -105,7 +105,7 @@ sub initialize ($c) {
 
 			$c->addmessage($c->tag(
 				'p',
-				class => 'temporaryFile my-2',
+				class => 'temporaryFile',
 				$c->maketext('Viewing temporary file: [_1]', $course_info_path)
 			));
 		}

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -135,9 +135,11 @@
 					</ul>
 				</li>
 			% }
-
 			% # Problem Editor
-			<li class="list-group-item nav-item"><%= $makelink->('instructor_problem_editor') %></li>
+			<li class="list-group-item nav-item">
+				<%= $makelink->('instructor_problem_editor',
+					param('file_type') && param('file_type') eq 'course_info' ? (active => 0) : ()) %>
+			</li>
 			% if (defined $prettySetID && defined $problemID) {
 				<li class="nav-item">
 					<ul class="nav flex-column">
@@ -151,6 +153,36 @@
 								)),
 								captures => { setID => $setID, problemID => $problemID },
 								target   => 'WW_Editor'
+							) %>
+						</li>
+					</ul>
+				</li>
+			% } elsif (defined $prettySetID && param('file_type') && param('file_type') =~ /^(set|hardcopy)_header$/) {
+				<li class="nav-item">
+					<ul class="nav flex-column">
+						<li class="nav-item">
+							<%= $makelink->(
+								'instructor_problem_editor_withset_withproblem',
+								text => param('file_type') eq 'set_header'
+									? b(maketext('[_1]: Set Header',      $c->tag('span', dir => 'ltr', $prettySetID)))
+									: b(maketext('[_1]: Hardcopy Header', $c->tag('span', dir => 'ltr', $prettySetID))),
+								captures          => { setID => $setID, problemID => 0 },
+								systemlink_params => { file_type => param('file_type') },
+								target            => 'WW_Editor'
+							) %>
+						</li>
+					</ul>
+				</li>
+			% } elsif (param('file_type') && param('file_type') eq 'course_info') {
+				<li class="nav-item">
+					<ul class="nav flex-column">
+						<li class="nav-item">
+							<%= $makelink->(
+								'instructor_problem_editor',
+								text              => maketext('Course Information'),
+								systemlink_params => { file_type => 'course_info' },
+								active            => 1,
+								target            => 'WW_Editor'
 							) %>
 						</li>
 					</ul>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -25,7 +25,7 @@
 % }
 %
 % my %titles = (
-	% blank_problem                => x('Editing <strong>new problem</strong> template.'),
+	% blank_problem                => x('Editing <strong>new problem</strong> template "[_1]".'),
 	% set_header                   => x('Editing <strong>set header</strong> file "[_1]".'),
 	% hardcopy_header              => x('Editing <strong>hardcopy header</strong> file "[_1]".'),
 	% course_info                  => x('Editing <strong>course information</strong> file "[_1]".'),
@@ -36,23 +36,32 @@
 % my $setName     = stash('setID')  // '';
 % my $fullSetName = $c->{fullSetID} // $setName;
 %
-% my $header = begin
-	<i>
-		<%== $c->{file_type} eq 'problem'
-			? maketext(
-				'Editing <strong>problem [_1] of set [_2]</strong> in file "[_3]".',
-				$c->{prettyProblemNumber},
-				tag('span', dir => 'ltr', format_set_name_display($fullSetName)),
-				tag('span', dir => 'ltr', $c->shortPath($c->{inputFilePath}))
-				)
-			: maketext($titles{ $c->{file_type} }, $c->shortPath($c->{inputFilePath})) =%>
-	</i>
+% my $fileInfo = begin
+	<div class="mb-2">
+		<%= tag 'div', class => 'set-file-info' . ($c->isTempEditFilePath($c->{inputFilePath}) ? ' temporaryFile' : ''),
+			begin =%>
+			<i>
+				<%== $c->{file_type} eq 'problem'
+					? maketext(
+						'Editing <strong>problem [_1] of set [_2]</strong> in file "[_3]".',
+						$c->{prettyProblemNumber},
+						tag('span', dir => 'ltr', format_set_name_display($fullSetName)),
+						tag('span', dir => 'ltr', class => 'current-file',
+							data => { tmp_file => $c->shortPath($c->{tempFilePath}) },
+							$c->shortPath($c->{inputFilePath}))
+						)
+					: maketext(
+						$titles{ $c->{file_type} },
+						tag('span', dir => 'ltr', class => 'current-file',
+							data => { tmp_file => $c->shortPath($c->{tempFilePath}) },
+							$c->shortPath($c->{inputFilePath}))
+					) =%>
+			</i>
+		<% end =%>
+	</div>
 % end
-% $header = $c->isTempEditFilePath($c->{inputFilePath})
-	% ? tag('div', class => 'temporaryFile', $header)    # Use colors if this is a temporary file.
-	% : $header->();
+<%= $fileInfo->() %>
 %
-<div class="mb-2"><%= $header %></div>
 <%= form_for current_route, method => 'POST', id => 'editor', name => 'editor',
    	enctype => 'application/x-www-form-urlencoded', class => 'col-12', begin =%>
 	<%= $c->hidden_authen_fields =%>
@@ -148,6 +157,7 @@
 		</div>
 	</div>
 	<%= generate_codemirror_controls_html($c) =%>
+	<%= $fileInfo->() %>
 	%
 	% # Output action forms
 	% my $default_choice;

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -199,6 +199,6 @@
 	</div>
 	<div>
 		<%= submit_button maketext($actionFormTitles->{$default_choice}), name => 'submit', id => 'take_action',
-			class => 'btn btn-primary' =%>
+			class => 'btn btn-primary mb-2' =%>
 	</div>
 <% end =%>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -1,6 +1,3 @@
-% # Don't show the revert form when editing an existing course info file.
-% next if $c->{file_type} eq 'course_info';
-%
 % if (!-r $c->{editFilePath}) {
 	<%== maketext(
 		'Error: The original file [_1] cannot be read.',


### PR DESCRIPTION
Any message that is added by the ContentGenerator addgoodmessage or addbadmessage methods is now dismissible.  There is a close button to the right that can be clicked to remove the message from the page.  In additiona, a hidden button is also added to the end of the page.  If there are any dismissible messages, then the button is shown by javascript, and if clicked all of the dismissible messages are removed from the page (and the button hidden again).  This is a convenience for removing all of those messages at once if there are many of them.

In the PG editor, when a temporary file is created by javascript the file name is changed to the temporary file name in the "Editing ..." statement and the `temporaryFile` class is added which gives the text the orange temporary file color.  Furthermore, the "Editing ..." statement is now shown both above and below the codemirror editor in the page.  This makes it more clear that a temporary file is being edited.

Also fix a bug introduced by #1918.  The PG editor revert form needs to be shown for course information files as well.  Otherwise there is no way to revert to the original file once a temporary file is created other than saving the file.  @somiaj: What was your rationale for doing this?

Also add site nav sub links for set headers and the course information file.  Now that the problem editor is directly in the site nav that link is shown as active when editing one of these files.  That is confusing because if you click on that "active" link it does not open the page you are currently viewing that is editing one of these files.  Instead it opens the editor with a new problem.