### PR TITLE
remove unused latex packages

### DIFF
--- a/conf/snippets/hardcopyThemes/common/packages.tex
+++ b/conf/snippets/hardcopyThemes/common/packages.tex
@@ -15,9 +15,6 @@
   \DeclareUnicodeCharacter{20AC}{\euro} % make it possible to use the UTF-8 character for the euro symbol in problems
 \fi
 
-\usepackage{epsf}
-\usepackage{epsfig}
-\usepackage{pslatex}
 \usepackage{listings}
 \lstset{basicstyle=\ttfamily,breaklines=true,aboveskip=0pt,belowskip=0pt}
 \usepackage{hyperref}


### PR DESCRIPTION
These packages can go (and one of them is causing a problem). These packages were used back with LaTeX2.09

`epsf` only provides `\epsfbox` which I find nowhere in `webwork2`, `pg`, or `OpenProblemLibrary`.

`epsfig` only provides `\psfig` which I find nowhere in `webwork2`, `pg`, or `OpenProblemLibrary`.

`pslatex` is for using PostScript fonts. We are fine with default fonts, or if not, would use something newer.
