### PR TITLE
Add the capability in the pg problem editor to pg perltidy code.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -127,6 +127,7 @@ my @modulesList = qw(
 	Opcode
 	PadWalker
 	Path::Class
+	Perl::Tidy
 	PHP::Serialization
 	Pod::Simple::Search
 	Pod::Simple::XHTML
@@ -160,6 +161,7 @@ my %moduleVersion = (
 	'LWP::Protocol::https' => 6.06,
 	'Mojolicious'          => 9.22,
 	'Net::SSLeay'          => 1.46,
+	'Perl::Tidy'           => 20220613
 );
 
 my ($test_programs, $test_modules, $show_help);

--- a/conf/snippets/newProblem.pg
+++ b/conf/snippets/newProblem.pg
@@ -14,9 +14,9 @@
 DOCUMENT();
 
 loadMacros(
-   "PGstandard.pl",   # Standard macros for PG language
-   "PGML.pl",         # PGML markup and Math Objects
-   "PGcourse.pl",     # Customization file for the course
+    "PGstandard.pl",    # Standard macros for PG language
+    "PGML.pl",          # PGML markup and Math Objects
+    "PGcourse.pl",      # Customization file for the course
 );
 
 # Uncomment the following if you don't want to show which
@@ -34,6 +34,6 @@ END_PGML
 BEGIN_PGML_SOLUTION
 You could type [|pi|]* or [|3.14|]*, or [|22/7|]*,
 among other options.
-END_PGML_SOLUTION 
+END_PGML_SOLUTION
 
 ENDDOCUMENT();

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -98,7 +98,49 @@
 			?.addEventListener('change', () => deleteBackupCheck.checked = true);
 	}
 
+	// Send a request to the server to perltidy the current PG code in the CodeMirror editor.
+	const tidyPGCode = () => {
+		const request_object = {
+			user: document.getElementById('hidden_user')?.value,
+			courseID: document.getElementsByName('courseID')[0]?.value,
+			key: document.getElementById('hidden_key')?.value
+		};
+
+		request_object.rpc_command = 'tidyPGCode';
+		request_object.pgCode = webworkConfig?.pgCodeMirror?.getValue()
+			?? document.getElementById('problemContents')?.value ?? '';
+
+		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
+			.then((response) => response.json())
+			.then((data) => {
+				if (data.result_data.status) {
+					if (data.result_data.errors) {
+						renderArea.innerHTML = '<div class="alert alert-danger p-1 m-2">' +
+							'<p class="fw-bold">PG perltidy errors:</p>' +
+							'<pre><code>' +
+							data.result_data.errors
+							.replace(/^[\s\S]*Begin Error Output Stream\n\n/, '')
+							.replace(/\n\d*: To save a full \.LOG file rerun with -g/, '') +
+							'</code></pre>';
+					}
+					showMessage('Errors occurred perltidying code.', false);
+					return;
+				}
+				if (webworkConfig?.pgCodeMirror) webworkConfig.pgCodeMirror.setValue(data.result_data.tidiedPGCode);
+				else document.getElementById('problemContents').value = data.result_data.tidiedPGCode;
+				saveTempFile();
+				showMessage('Successfuly perltidied code.', true);
+			})
+			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));
+	};
+
 	document.getElementById('take_action')?.addEventListener('click', async (e) => {
+		if (document.getElementById('current_action')?.value === 'pgtidy') {
+			e.preventDefault();
+			tidyPGCode();
+			return;
+		}
+
 		const actionView = document.getElementById('view');
 		const editorForm = document.getElementById('editor');
 

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -126,10 +126,14 @@
 					showMessage('Errors occurred perltidying code.', false);
 					return;
 				}
-				if (webworkConfig?.pgCodeMirror) webworkConfig.pgCodeMirror.setValue(data.result_data.tidiedPGCode);
-				else document.getElementById('problemContents').value = data.result_data.tidiedPGCode;
-				saveTempFile();
-				showMessage('Successfuly perltidied code.', true);
+				if (request_object.pgCode === data.result_data.tidiedPGCode) {
+					showMessage('There were no changes to the code.', true);
+				} else {
+					if (webworkConfig?.pgCodeMirror) webworkConfig.pgCodeMirror.setValue(data.result_data.tidiedPGCode);
+					else document.getElementById('problemContents').value = data.result_data.tidiedPGCode;
+					saveTempFile();
+					showMessage('Successfuly perltidied code.', true);
+				}
 			})
 			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));
 	};

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -96,6 +96,7 @@ the submit button pressed (the action).
         Make this set header for:  action = add_problem
         Revert:                    action = revert
         Generate Hardcopy:         action = hardcopy
+        Tidy Code:                 action = pgtidy
 
 An undefined or invalid action is interpreted as an initial edit of the file.
 
@@ -115,13 +116,14 @@ use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
 use constant DEFAULT_SEED => 123456;
 
 # Editor tabs
-use constant ACTION_FORMS => [qw(view hardcopy save save_as add_problem revert)];
+use constant ACTION_FORMS => [qw(view hardcopy pgtidy save save_as add_problem revert)];
 use constant ACTION_FORM_TITLES => {
 	view        => x('View/Reload'),
 	hardcopy    => x('Generate Hardcopy'),
-	add_problem => x('Append'),
+	pgtidy      => x('Tidy Code'),
 	save        => x('Save'),
 	save_as     => x('Save As'),
+	add_problem => x('Append'),
 	revert      => x('Revert'),
 };
 
@@ -778,9 +780,10 @@ sub view_handler ($c) {
 	return;
 }
 
-# The hardcopy action is handled by javascript.  This is provided just in case
-# something goes wrong and the action gets called.
+# The hardcopy and pgtidy actions are handled by javascript.  These are provided just in case
+# something goes wrong and the actions are called.
 sub hardcopy_action { }
+sub pgtidy_action   { }
 
 sub add_problem_handler ($c) {
 	my $db = $c->db;

--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -101,6 +101,11 @@ sub new {
 	my %ORIG_SIG;
 	$ORIG_SIG{$_} = $SIG{$_} for keys %SIG;
 
+	# The following line is a work around for a bug that occurs on some systems.  See
+	# https://rt.cpan.org/Public/Bug/Display.html?id=77916 and
+	# https://github.com/openwebwork/webwork2/pull/2098#issuecomment-1619812699.
+	%+;
+
 	my $safe = Safe->new;
 	$safe->permit('rand');
 	# seed course environment with initial values

--- a/lib/WebworkWebservice.pm
+++ b/lib/WebworkWebservice.pm
@@ -268,6 +268,7 @@ sub command_permission {
 		putUserProblem    => 'modify_student_data',
 		putProblemVersion => 'modify_student_data',
 		putPastAnswer     => 'modify_student_data',
+		tidyPGCode        => 'access_instructor_tools',
 
 		# WebworkWebservice::RenderProblem
 		renderProblem => 'proctor_quiz_login',

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -22,6 +22,7 @@ use warnings;
 use Data::Structure::Util qw(unbless);
 
 use WeBWorK::Debug;
+use WeBWorK::PG::Tidy qw(pgtidy);
 
 sub getUserProblem {
 	my ($invocant, $self, $params) = @_;
@@ -130,6 +131,25 @@ sub putPastAnswer {
 			"Updated answer $params->{answer_id} for problem $pastAnswer->{problem_id} of $pastAnswer->{set_id} "
 			. "for user $pastAnswer->{user_id} in course "
 			. $self->ce->{courseName} . '.'
+	};
+}
+
+sub tidyPGCode {
+	my ($invocant, $self, $params) = @_;
+
+	debug('in tidyPGCode');
+
+	local @ARGV = ();
+
+	my $code = $params->{pgCode};
+	my $tidiedPGCode;
+	my $errors;
+
+	my $result = pgtidy(source => \$code, destination => \$tidiedPGCode, errorfile => \$errors);
+
+	return {
+		ra_out => { tidiedPGCode => $tidiedPGCode, status => $result, errors => $errors },
+		text   => 'Tidied code'
 	};
 }
 

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -21,13 +21,10 @@ use warnings;
 
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::Debug;
 use WeBWorK::PG::Tidy qw(pgtidy);
 
 sub getUserProblem {
 	my ($invocant, $self, $params) = @_;
-
-	debug('in getUserProblem');
 
 	my $db = $self->db;
 
@@ -43,8 +40,6 @@ sub getUserProblem {
 
 sub putUserProblem {
 	my ($invocant, $self, $params) = @_;
-
-	debug('in putUserProblem');
 
 	my $db = $self->db;
 
@@ -75,8 +70,6 @@ sub putUserProblem {
 
 sub putProblemVersion {
 	my ($invocant, $self, $params) = @_;
-
-	debug('in putProblemVersion');
 
 	my $db = $self->db;
 
@@ -109,8 +102,6 @@ sub putProblemVersion {
 sub putPastAnswer {
 	my ($invocant, $self, $params) = @_;
 
-	debug('in putPastAnswer');
-
 	my $db = $self->db;
 
 	my $pastAnswer = $db->getPastAnswer($params->{answer_id});
@@ -136,8 +127,6 @@ sub putPastAnswer {
 
 sub tidyPGCode {
 	my ($invocant, $self, $params) = @_;
-
-	debug('in tidyPGCode');
 
 	local @ARGV = ();
 

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pgtidy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pgtidy_form.html.ep
@@ -1,0 +1,6 @@
+% # Hardcopy headers are previewed from the hardcopy generation tab.
+% last if $c->{file_type} eq 'course_info';
+%
+<div class="row">
+	<p><%= maketext('Reformat the code using perltidy.') =%></p>
+</div>

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -120,6 +120,14 @@
 			. 'generating the PDF file using pdflatex.') =%>
 	</dd>
 
+	<dt><%= maketext('Tidy Code') %></dt>
+	<dd>
+		<%= maketext('Reformat the code using perltidy. This will change the code in the editor window, and save '
+			. 'changes to the temporary file. In some cases (if the code contains backslashes or double tildes) this '
+			. 'can result in odd spacing in the code. So make sure to inspect the formatted code, and edit further or '
+			. 'revert if needed.') =%>
+	</dd>
+
 	<dt><%= maketext('Save') %></dt>
 	<dd>
 		<%= maketext('Save the contents of the editor window to the file on disk and re-render the problem. If '


### PR DESCRIPTION
This adds a new tab to the PG problem editor (unless editing a course configuration file).  The tab contains basic information about what it does, but if the "Tidy Code" button is pressed it perltidies the code in the CodeMirror editor window.  The tidied code is also saved to the temprorary file.

The actual tidying is done by a new webwork webservice action (not a form submission).  If errors occur, they are shown in the renderer window.

The webwork webwservice depends on a new PG module defined in a corresponding PG pull request (see https://github.com/openwebwork/pg/pull/868).