### PR TITLE
use scalar return for grade_all_sets

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -126,7 +126,7 @@ async sub submit_course_grade ($self, $userID) {
 	$self->warning("lis_source_did is not available for user: $userID")
 		if !$user->lis_source_did && $ce->{debug_lti_grade_passback};
 
-	return await $self->submit_grade($user->lis_source_did, grade_all_sets($db, $userID));
+	return await $self->submit_grade($user->lis_source_did, scalar(grade_all_sets($db, $userID)));
 }
 
 # Computes and submits the set grade for $userID and $setID to the LMS.  For gateways the best score is used.


### PR DESCRIPTION
Grade passback with LTIAdvanced is broken, but this fixes it. `grade_all_sets` returns based on `wantarray` and with some changes to using named subroutine parameters, it was giving the array version when it needs the scalar. The result was either an error if `$LTIGradeOnSubmit` is true, or an error every time a mass update was triggered.

It looks like this was already recognized and applied to the corresponding place in LTIAdvantage.

If we are moving more to named parameters, we may need to be aware of this effect. There are 45 instances of `wantarray` in 13 modules across `webwork2` and `pg`. Plus 20 instances in 10 macro libraries.

