### PR TITLE
different help in LTIUpdate for course/homework

### DIFF
--- a/templates/HelpFiles/InstructorLTIUpdate.html.ep
+++ b/templates/HelpFiles/InstructorLTIUpdate.html.ep
@@ -17,8 +17,13 @@
 % title maketext('LTI Grade Update Help');
 %
 <p class="m-0">
-	<%= maketext('This page gives information about mass LTI grade updates, and allows you to trigger a grade update '
-		. 'for all users and all sets, all sets for one user, all users for one set, or one user for one set.  When '
-		. 'a user is selected, the sets drop down menu is updated to only allow selecting sets assigned the selected '
-		. 'user.  Similarly when a set is selected, the user menu is updated to only allow selecting valid users.') =%>
+	<%= maketext('This page gives information about mass LTI grade updates, and allows you to trigger a grade update. ') =%>
+	% if ($ce->{LTIGradeMode} eq 'course') {
+		<%= maketext('You may trigger a grade update for all users or just one user.') =%>
+	% } elsif ($ce->{LTIGradeMode} eq 'homework') {
+		<%= maketext('You may trigger a grade update for all users or just one user, for all sets or just one set. '
+			. 'When a user is selected, the menu for sets is updated to only allow selecting sets assigned to the '
+			. 'selected user. Similarly when a set is selected, the user menu is updated to only allow selecting '
+			. 'valid users.') =%>
+	% }
 </p>

--- a/templates/HelpFiles/InstructorLTIUpdate.html.ep
+++ b/templates/HelpFiles/InstructorLTIUpdate.html.ep
@@ -17,13 +17,15 @@
 % title maketext('LTI Grade Update Help');
 %
 <p class="m-0">
-	<%= maketext('This page gives information about mass LTI grade updates, and allows you to trigger a grade update. ') =%>
+	<%= maketext('This page gives information about mass LTI grade updates '
+		. 'and allows you to trigger a grade update. ') =%>
 	% if ($ce->{LTIGradeMode} eq 'course') {
 		<%= maketext('You may trigger a grade update for all users or just one user.') =%>
 	% } elsif ($ce->{LTIGradeMode} eq 'homework') {
-		<%= maketext('You may trigger a grade update for all users or just one user, for all sets or just one set. '
-			. 'When a user is selected, the menu for sets is updated to only allow selecting sets assigned to the '
-			. 'selected user. Similarly when a set is selected, the user menu is updated to only allow selecting '
-			. 'valid users.') =%>
+		<%= maketext('You may trigger a grade update for all users or just one user, '
+			. 'for all sets or just one set. When a user is selected, the menu '
+			. 'for sets is updated to only allow selecting sets assigned to the '
+			. 'selected user. Similarly when a set is selected, the user menu '
+			. 'is updated to only allow selecting valid users.') =%>
 	% }
 </p>


### PR DESCRIPTION
This tailors the help message in the LTI Update page for each grade passback mode. When using `course` mode, the current message is confusing.