### PR TITLE
Fix a warning that is being emitted due to the hack added in #2098

### DIFF
--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -104,7 +104,7 @@ sub new {
 	# The following line is a work around for a bug that occurs on some systems.  See
 	# https://rt.cpan.org/Public/Bug/Display.html?id=77916 and
 	# https://github.com/openwebwork/webwork2/pull/2098#issuecomment-1619812699.
-	%+;
+	my %dummy = %+;
 
 	my $safe = Safe->new;
 	$safe->permit('rand');


### PR DESCRIPTION
This just assigns the result of calling `%+` to a dummy variable to avoid the warning that perl gives stating that this is a useless use of a variable in void context.

If you are using morbo this warning is currently displayed in the terminal as soon as the app starts.

I  also think this hack needs further investigation.