### PR TITLE
fix error with blank problem in new window

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -736,6 +736,18 @@ sub view_handler ($c) {
 				status_message => $c->{status_message}->join('')
 			}
 		));
+	} elsif ($c->{file_type} eq 'blank_problem') {
+		# Redirect to Problem.pm.pm.
+		$c->reply_with_redirect($c->systemLink(
+			$c->url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
+			params => {
+				displayMode    => $displayMode,
+				problemSeed    => $problemSeed,
+				editMode       => 'temporaryFile',
+				sourceFilePath => $relativeTempFilePath,
+				status_message => $c->{status_message}->join('')
+			}
+		));
 	} elsif ($c->{file_type} eq 'set_header') {
 		# Redirect to ProblemSet
 		$c->reply_with_redirect($c->systemLink(


### PR DESCRIPTION
This fixes an error that happens when you go to Problem Editor, check the box to open in a new window, and then click to View.