### PR TITLE
don't show PG stuff while editing course_info

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -233,6 +233,9 @@ sub initialize ($c) {
 	$c->stash->{formsToShow}      = ACTION_FORMS();
 	$c->stash->{actionFormTitles} = ACTION_FORM_TITLES();
 
+	# Tell the templates if we are working on a PG file
+	$c->{is_pg} = ($c->{file_type} eq 'course_info') ? 0 : 1;
+
 	# Check permissions
 	return
 		unless $authz->hasPermissions($user, 'access_instructor_tools')

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -83,65 +83,67 @@
 	% }
 	%
 	% # PG problem authoring resource links
-	<div class="mb-2">
-		% # http://webwork.maa.org/wiki/Category:Problem_Techniques
-		<%= link_to maketext('Problem Techniques') => $ce->{webworkURLs}{problemTechniquesHelpURL},
-			target => 'techniques_window',
-			title  => maketext('Snippets of PG code illustrating specific techniques'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # http://webwork.maa.org/wiki/Category:MathObjects
-		<%= link_to maketext('Math Objects') => $ce->{webworkURLs}{MathObjectsHelpURL},
-			target => 'math_objects',
-			title  => maketext('Wiki summary page for MathObjects'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # PG POD served locally
-		<%= link_to maketext('POD') => url_for('pod_index'),
-			target => 'pod_docs',
-			title  => maketext('Documentation from source code for PG modules and macro files.'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # PGML lab problem rendered as an unattached problem in a new window.
-		% if (-e "$ce->{courseDirs}{templates}/PGMLLab/PGML-lab.pg") {
-			<%= link_to maketext('PGML') => $c->systemLink(
-					url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
-					params => {
-						displayMode    => $ce->{pg}{options}{displayMode},
-						problemSeed    => 1234,
-						editMode       => 'temporaryFile',
-						sourceFilePath => 'PGMLLab/PGML-lab.pg'
-					}
-				),
-				target => 'PGML',
-				title  => maketext(
-					'PG markdown syntax used to format WeBWorK questions. '
-					. 'This interactive lab can help you to learn the techniques.'
-				),
+	% if ($c->{is_pg}) {
+		<div class="mb-2">
+			% # http://webwork.maa.org/wiki/Category:Problem_Techniques
+			<%= link_to maketext('Problem Techniques') => $ce->{webworkURLs}{problemTechniquesHelpURL},
+				target => 'techniques_window',
+				title  => maketext('Snippets of PG code illustrating specific techniques'),
 				class  => 'reference-link btn btn-sm btn-info',
 				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% }
-		% # http://webwork.maa.org/wiki/Category:Authors
-		<%= link_to maketext('Author Info') => $ce->{webworkURLs}{AuthorHelpURL},
-			target => 'author_info',
-			title  => maketext('Top level of author information on the wiki.'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # Only show the report bugs in problem button if editing an OPL or Contrib problem.
-		% if ($c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/| && ($1 eq 'Library' || $1 eq 'Contrib')) {
-			<%= link_to maketext('Report Bugs in this Problem') =>
-					"$ce->{webworkURLs}{bugReporter}?product=Problem%20libraries"
-					. "&component=$1&bug_file_loc=$c->{editFilePath}_with_problemSeed=$c->{problemSeed}",
-				target => 'bug_report',
-				title  => maketext(
-					'Report bugs in a WeBWorK question/problem using this link. '
-					. 'The very first time you do this you will need to register with an email address so that '
-					. 'information on the bug fix can be reported back to you.'
-				),
+			% # http://webwork.maa.org/wiki/Category:MathObjects
+			<%= link_to maketext('Math Objects') => $ce->{webworkURLs}{MathObjectsHelpURL},
+				target => 'math_objects',
+				title  => maketext('Wiki summary page for MathObjects'),
 				class  => 'reference-link btn btn-sm btn-info',
 				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% }
-	</div>
+			% # PG POD served locally
+			<%= link_to maketext('POD') => url_for('pod_index'),
+				target => 'pod_docs',
+				title  => maketext('Documentation from source code for PG modules and macro files.'),
+				class  => 'reference-link btn btn-sm btn-info',
+				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% # PGML lab problem rendered as an unattached problem in a new window.
+			% if (-e "$ce->{courseDirs}{templates}/PGMLLab/PGML-lab.pg") {
+				<%= link_to maketext('PGML') => $c->systemLink(
+						url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
+						params => {
+							displayMode    => $ce->{pg}{options}{displayMode},
+							problemSeed    => 1234,
+							editMode       => 'temporaryFile',
+							sourceFilePath => 'PGMLLab/PGML-lab.pg'
+						}
+					),
+					target => 'PGML',
+					title  => maketext(
+						'PG markdown syntax used to format WeBWorK questions. '
+						. 'This interactive lab can help you to learn the techniques.'
+					),
+					class  => 'reference-link btn btn-sm btn-info',
+					data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% }
+			% # http://webwork.maa.org/wiki/Category:Authors
+			<%= link_to maketext('Author Info') => $ce->{webworkURLs}{AuthorHelpURL},
+				target => 'author_info',
+				title  => maketext('Top level of author information on the wiki.'),
+				class  => 'reference-link btn btn-sm btn-info',
+				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% # Only show the report bugs in problem button if editing an OPL or Contrib problem.
+			% if ($c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/| && ($1 eq 'Library' || $1 eq 'Contrib')) {
+				<%= link_to maketext('Report Bugs in this Problem') =>
+						"$ce->{webworkURLs}{bugReporter}?product=Problem%20libraries"
+						. "&component=$1&bug_file_loc=$c->{editFilePath}_with_problemSeed=$c->{problemSeed}",
+					target => 'bug_report',
+					title  => maketext(
+						'Report bugs in a WeBWorK question/problem using this link. '
+						. 'The very first time you do this you will need to register with an email address so that '
+						. 'information on the bug fix can be reported back to you.'
+					),
+					class  => 'reference-link btn btn-sm btn-info',
+					data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% }
+		</div>
+	% }
 	<div class="row mb-2">
 		<div class="col-lg-6 col-md-12 order-last order-lg-first">
 			<%= generate_codemirror_html($c, 'problemContents', $problemContents, $codemirrorMode) =%>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/add_problem_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/add_problem_form.html.ep
@@ -1,4 +1,4 @@
-% last if $c->{file_type} eq 'course_info';
+% last unless $c->{is_pg};
 %
 % my $allSetNames = [ map { $_->[0] =~ s/^set|\.def$//gr } $db->listGlobalSetsWhere({}, 'set_id') ];
 %

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
@@ -1,4 +1,4 @@
-% last if $c->{file_type} eq 'course_info';
+% last unless $c->{is_pg};
 %
 <div>
 	<div class="row align-items-center">

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pgtidy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pgtidy_form.html.ep
@@ -1,5 +1,4 @@
-% # Hardcopy headers are previewed from the hardcopy generation tab.
-% last if $c->{file_type} eq 'course_info';
+% last unless $c->{is_pg};
 %
 <div class="row">
 	<p><%= maketext('Reformat the code using perltidy.') =%></p>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/view_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/view_form.html.ep
@@ -2,28 +2,30 @@
 % last if $c->{file_type} eq 'hardcopy_header';
 %
 <div>
-	<div class="row align-items-center">
-		<%= label_for action_view_seed_id => maketext('Using what seed?'), class => 'col-form-label col-auto mb-2' =%>
-		<div class="col-auto mb-2">
-			<%= text_field 'action.view.seed' => $c->{problemSeed},
-				id => 'action_view_seed_id', class => 'form-control form-control-sm' =%>
+	% if ($c->{is_pg}) {
+		<div class="row align-items-center">
+			<%= label_for action_view_seed_id => maketext('Using what seed?'), class => 'col-form-label col-auto mb-2' =%>
+			<div class="col-auto mb-2">
+				<%= text_field 'action.view.seed' => $c->{problemSeed},
+					id => 'action_view_seed_id', class => 'form-control form-control-sm' =%>
+			</div>
+			<div class="col-auto mb-2">
+				<button id="randomize_view_seed_id" class="btn btn-info btn-sm" type="button">
+					<%= maketext('Randomize Seed') =%>
+				</button>
+			</div>
 		</div>
-		<div class="col-auto mb-2">
-			<button id="randomize_view_seed_id" class="btn btn-info btn-sm" type="button">
-				<%= maketext('Randomize Seed') =%>
-			</button>
+		<div class="row align-items-center mb-2">
+			<%= label_for action_view_displayMode_id => maketext('Using what display mode?'),
+				class => 'col-form-label col-auto' =%>
+			<div class="col-auto">
+				<%= select_field 'action.view.displayMode' => [
+					map { [ $_ => $_, $_ eq $c->{displayMode} ? (selected => undef) : () ] }
+						@{ $ce->{pg}{displayModes}}, @{ $ce->{pg}{additionalPGEditorDisplayModes}}
+				], id => 'action_view_displayMode_id', class => 'form-select form-select-sm d-inline w-auto' =%>
+			</div>
 		</div>
-	</div>
-	<div class="row align-items-center mb-2">
-		<%= label_for action_view_displayMode_id => maketext('Using what display mode?'),
-			class => 'col-form-label col-auto' =%>
-		<div class="col-auto">
-			<%= select_field 'action.view.displayMode' => [
-				map { [ $_ => $_, $_ eq $c->{displayMode} ? (selected => undef) : () ] }
-					@{ $ce->{pg}{displayModes}}, @{ $ce->{pg}{additionalPGEditorDisplayModes}}
-			], id => 'action_view_displayMode_id', class => 'form-select form-select-sm d-inline w-auto' =%>
-		</div>
-	</div>
+	% }
 	<div class="row g-0 mb-2">
 		<div class="form-check mb-2">
 			<%= check_box 'newWindowView' => 1, id => 'newWindowView', class => 'form-check-input' =%>


### PR DESCRIPTION
When editing `course_info`, this suppress the PG help stuff at the top, as well as the selects for problem seed and display mode.