### PR TITLE
Hardcopy themes editor

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -317,6 +317,18 @@
 			return;
 		}
 
+		if (fileType === 'hardcopy_theme') {
+			const contents = webworkConfig?.pgCodeMirror?.getValue();
+			if (contents) {
+				renderArea.innerHTML = '<pre>' + contents.replace(/&/g, "&amp;").replace(/</g, "&lt;") + '</pre>';
+			}
+			else
+				renderArea.innerHTML = '<div class="alert alert-danger p-1 m-2 fw-bold">The file has no content.</div>';
+
+			resolve();
+			return;
+		}
+
 		const isProblem = fileType && /problem/.test(fileType) ? 1 : 0;
 
 		renderProblem(new URLSearchParams({

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -241,7 +241,7 @@ sub initialize ($c) {
 	$c->stash->{hardcopyLabels}   = [];
 
 	# Tell the templates if we are working on a PG file
-	$c->{is_pg} = !$c->{file_type} || $c->{file_type} ne 'course_info' && $c->{file_type} ne 'hardcopy_theme';
+	$c->{is_pg} = !$c->{file_type} || ($c->{file_type} ne 'course_info' && $c->{file_type} ne 'hardcopy_theme');
 
 	# Check permissions
 	return

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -20,11 +20,14 @@ use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
 WeBWorK::ContentGenerator::Instructor::PGProblemEditor - Edit a pg file
 
-This editor will edit problem files, set header files, or files such as
-course_info whose name is defined in the defaults.config file.
+This editor will edit problem files, set header files, hardcopy theme files,
+or files such as course_info whose name is defined in the defaults.config file.
 
 Only files under the template directory (or linked to this location) can be
 edited.
+
+Editable hardcopy themes are in the directory defined by
+$ce->{courseDirs}{hardcopyThemes}
 
 The course information and problems are located in the course templates
 directory.  Course information has the name defined by
@@ -48,7 +51,7 @@ The suffix for a temporary file is "user_name.tmp" by default.
 =item problem
 
 This is the most common type. This editor can be called by an instructor when
-viewing any problem.  the information for retrieving the source file is found
+viewing any problem.  The information for retrieving the source file is found
 using the problemID in order to look look up the source file path.
 
 =item source_path_for_problem_file
@@ -69,6 +72,12 @@ listed as problem 0 in the set's list of problems.  But it is used instead of
 set_header when producing a hardcopy of the problem set in the TeX format,
 instead of producing HTML formatted version for use on the computer screen.
 
+=item hardcopy_theme
+
+This allows editing of a hardcopy theme file, which defines snippets of tex
+code to be inserted before and after problems in a hardcopy.  It can be called
+from this module when using the Hardcopy tab.
+
 =item course_info
 
 This allows editing of the course_info.txt file which gives general information
@@ -77,8 +86,8 @@ about the course.  It is called from the ProblemSets.pm module.
 =item blank_problem
 
 This is a special case which allows one to create and edit a new PG problem.
-The "stationary" source for this problem is stored in the conf/snippets
-directory and defined in defaults.config as
+The "stationary" source for this problem is stored in the assets/pg directory
+and defined in defaults.config as
 $webworkFiles{screenSnippets}{blankProblem}
 
 =back
@@ -232,7 +241,7 @@ sub initialize ($c) {
 	$c->stash->{hardcopyLabels}   = [];
 
 	# Tell the templates if we are working on a PG file
-	$c->{is_pg} = $c->{file_type} && $c->{file_type} eq 'course_info' ? 0 : 1;
+	$c->{is_pg} = !$c->{file_type} || $c->{file_type} ne 'course_info' && $c->{file_type} ne 'hardcopy_theme';
 
 	# Check permissions
 	return
@@ -281,7 +290,8 @@ sub initialize ($c) {
 			if (path_is_subdir($c->{editFilePath}, $ce->{courseDirs}{templates}, 1)
 				|| $c->{editFilePath} eq $ce->{webworkFiles}{screenSnippets}{setHeader}
 				|| $c->{editFilePath} eq $ce->{webworkFiles}{hardcopySnippets}{setHeader}
-				|| $c->{editFilePath} eq $ce->{webworkFiles}{screenSnippets}{blankProblem})
+				|| $c->{editFilePath} eq $ce->{webworkFiles}{screenSnippets}{blankProblem}
+				|| $c->{editFilePath} =~ m|^$ce->{webworkDirs}{hardcopyThemes}/[^/]*\.xml$|)
 			{
 				eval { $problemContents = readFile($c->{editFilePath}) };
 				$problemContents = $@ if $@;
@@ -351,8 +361,9 @@ sub page_title ($c) {
 
 	return $c->maketext('Editor') unless $c->{file_type};
 
-	return $c->maketext('Set Header for set [_1]',            $setID) if $c->{file_type} eq 'set_header';
-	return $c->maketext('Hardcopy Header for set [_1]',       $setID) if $c->{file_type} eq 'hardcopy_header';
+	return $c->maketext('Set Header for set [_1]',      $setID) if $c->{file_type} eq 'set_header';
+	return $c->maketext('Hardcopy Header for set [_1]', $setID) if $c->{file_type} eq 'hardcopy_header';
+	return $c->maketext('Hardcopy Theme') if $c->{file_type} eq 'hardcopy_theme';
 	return $c->maketext('Course Information for course [_1]', $c->stash('courseID'))
 		if $c->{file_type} eq 'course_info';
 
@@ -397,6 +408,7 @@ sub determineTempEditFilePath ($c, $path) {
 
 	my $templatesDirectory   = $c->ce->{courseDirs}{templates};
 	my $tmpEditFileDirectory = $c->getTempEditFileDirectory();
+	my $hardcopyThemesDir    = $c->ce->{webworkDirs}{hardcopyThemes};
 
 	$c->addbadmessage($c->maketext('The path to the original file should be absolute.'))
 		unless $path =~ m|^/|;
@@ -416,6 +428,9 @@ sub determineTempEditFilePath ($c, $path) {
 		} elsif ($path eq $c->ce->{webworkFiles}{screenSnippets}{setHeader}) {
 			# Handle the case of the hardcopy header in snippets.
 			$path = "$tmpEditFileDirectory/hardcopyHeader.$setID.$user.tmp";
+		} elsif ($path =~ m|$hardcopyThemesDir/([^/]*\.xml)$|) {
+			# Handle the case of the hardcopy themes in assets/hardcopyThemes.
+			$path = "$tmpEditFileDirectory/hardcopyTheme.$1.$user.tmp";
 		} else {
 			# If all else fails, just use a failsafe filename.  This is reused in all of these cases.
 			# This shouldn't be possible in any case.
@@ -445,6 +460,8 @@ sub determineOriginalEditFilePath ($c, $path) {
 			$newpath = $ce->{webworkFiles}{hardcopySnippets}{setHeader};
 		} elsif (($newpath =~ m|screenHeader\.[^/]*$|)) {
 			$newpath = $ce->{webworkFiles}{screenSnippets}{setHeader};
+		} elsif (($newpath =~ m|hardcopyTheme\.([^/]*\.xml)\.[^/]*$|)) {
+			$newpath = "$ce->{courseDirs}{hardcopyThemes}/$1";
 		} else {
 			my $user = $c->param('user');
 			$newpath =~ s|\.$user\.tmp$||;
@@ -487,6 +504,11 @@ sub getFilePaths ($c) {
 		$editFilePath = "$ce->{courseDirs}{templates}/$ce->{courseFiles}{course_info}";
 	} elsif ($c->{file_type} eq 'blank_problem') {
 		$editFilePath = $ce->{webworkFiles}{screenSnippets}{blankProblem};
+	} elsif ($c->{file_type} eq 'hardcopy_theme') {
+		$editFilePath = "$ce->{courseDirs}{hardcopyThemes}/" . $c->param('hardcopy_theme');
+		if (!-e $editFilePath) {
+			$editFilePath = "$ce->{webworkDirs}{hardcopyThemes}/" . $c->param('hardcopy_theme');
+		}
 	} elsif ($c->{file_type} eq 'set_header' || $c->{file_type} eq 'hardcopy_header') {
 		my $set_record = $db->getGlobalSet($c->{setID});
 
@@ -825,6 +847,17 @@ sub view_handler ($c) {
 sub hardcopy_action { }
 sub pgtidy_action   { }
 
+sub hardcopy_handler ($c) {
+	# Redirect to problem editor page.
+	$c->reply_with_redirect($c->systemLink(
+		$c->url_for('instructor_problem_editor',),
+		params => {
+			file_type      => 'hardcopy_theme',
+			hardcopy_theme => $c->param('action.hardcopy.theme')
+		}
+	));
+}
+
 sub add_problem_handler ($c) {
 	my $db = $c->db;
 
@@ -1010,6 +1043,18 @@ sub save_handler ($c) {
 				status_message => $c->{status_message}->join('')
 			}
 		));
+	} elsif ($c->{file_type} eq 'hardcopy_theme') {
+		# Redirect to PGProblemEditor.pm
+		$c->reply_with_redirect($c->systemLink(
+			$c->url_for('instructor_problem_editor'),
+			params => {
+				editMode       => 'savedFile',
+				hardcopy_theme => $c->{hardcopy_theme},
+				file_type      => 'hardcopy_theme',
+				status_message => $c->{status_message}->join(''),
+				sourceFilePath => $c->getRelativeSourceFilePath($c->{editFilePath}),
+			}
+		));
 	} elsif ($c->{file_type} eq 'course_info') {
 		# Redirect to ProblemSets.pm
 		$c->reply_with_redirect($c->systemLink(
@@ -1059,11 +1104,11 @@ sub save_as_handler ($c) {
 		$c->addbadmessage($c->maketext('Please specify a file to save to.'));
 	}
 
-	# Rescue the user in case they forgot to end the file name with the pg extension.
-	if (($file_type eq 'problem' || $file_type eq 'blank_problem' || $file_type eq 'set_header')
-		&& $new_file_name !~ /\.pg$/)
-	{
+	# Rescue the user in case they forgot to end the file name with the right extension.
+	if ($c->{is_pg} && $new_file_name !~ /\.pg$/) {
 		$new_file_name .= '.pg';
+	} elsif ($file_type eq 'hardcopy_theme' && $new_file_name !~ /\.xml$/) {
+		$new_file_name .= '.xml';
 	}
 
 	# Grab the problemContents from the form in order to save it to a new permanent file.
@@ -1094,10 +1139,10 @@ sub save_as_handler ($c) {
 		$c->saveFileChanges($outputFilePath);
 		my $targetProblemNumber;
 
-		if ($file_type eq 'course_info') {
-			# The saveMode is not set for course_info files as there are no such options presented in the form.
-			# So set that here so that the correct redirect is chosen below.
-			$saveMode = 'new_course_info';
+		if ($file_type eq 'course_info' || $file_type eq 'hardcopy_theme') {
+			# The saveMode is not set for course_info files or hardcopy_theme file as there are no such options
+			# presented in the form.  So set that here so that the correct redirect is chosen below.
+			$saveMode = "new_$file_type";
 		} elsif ($saveMode eq 'rename' && -r $outputFilePath) {
 			# Modify source file path in problem.
 			if ($file_type eq 'set_header') {
@@ -1199,6 +1244,7 @@ sub save_as_handler ($c) {
 	# Set up redirect.
 	my $problemPage;
 	my $new_file_type;
+	my %extra_params;
 
 	if ($saveMode eq 'new_course_info') {
 		$problemPage   = $c->url_for('instructor_problem_editor');
@@ -1207,6 +1253,10 @@ sub save_as_handler ($c) {
 		$problemPage =
 			$c->url_for('instructor_problem_editor_withset_withproblem', setID => 'Undefined_Set', problemID => 1);
 		$new_file_type = 'source_path_for_problem_file';
+	} elsif ($saveMode eq 'new_hardcopy_theme') {
+		$problemPage                  = $c->url_for('instructor_problem_editor');
+		$new_file_type                = 'hardcopy_theme';
+		$extra_params{hardcopy_theme} = $new_file_name =~ s|^.*\/([^/]*\.xml)|$1|r;
 	} elsif ($saveMode eq 'rename') {
 		$problemPage = $c->url_for(
 			'instructor_problem_editor_withset_withproblem',
@@ -1235,7 +1285,8 @@ sub save_as_handler ($c) {
 			sourceFilePath => $c->getRelativeSourceFilePath($outputFilePath),
 			problemSeed    => $c->{problemSeed},
 			file_type      => $new_file_type,
-			status_message => $c->{status_message}->join('')
+			status_message => $c->{status_message}->join(''),
+			%extra_params
 		}
 	));
 	return;

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -138,7 +138,7 @@
 			% # Problem Editor
 			<li class="list-group-item nav-item">
 				<%= $makelink->('instructor_problem_editor',
-					param('file_type') && param('file_type') eq 'course_info' ? (active => 0) : ()) %>
+					param('file_type') && (param('file_type') eq 'course_info' || param('file_type') eq 'hardcopy_theme') ? (active => 0) : ()) %>
 			</li>
 			% if (defined $prettySetID && defined $problemID) {
 				<li class="nav-item">
@@ -181,6 +181,23 @@
 								'instructor_problem_editor',
 								text              => maketext('Course Information'),
 								systemlink_params => { file_type => 'course_info' },
+								active            => 1,
+								target            => 'WW_Editor'
+							) %>
+						</li>
+					</ul>
+				</li>
+			% } elsif (param('file_type') && param('file_type') eq 'hardcopy_theme') {
+				<li class="nav-item">
+					<ul class="nav flex-column">
+						<li class="nav-item">
+							<%= $makelink->(
+								'instructor_problem_editor',
+								text              => maketext('Hardcopy Theme'),
+								systemlink_params => {
+									file_type      => 'hardcopy_theme',
+									hardcopy_theme => param('hardcopy_theme')
+								},
 								active            => 1,
 								target            => 'WW_Editor'
 							) %>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -2,7 +2,11 @@
 % use WeBWorK::HTML::CodeMirrorEditor
 	% qw(generate_codemirror_html generate_codemirror_controls_html output_codemirror_static_files);
 %
-% my $codemirrorMode = $c->{file_type} && $c->{file_type} eq 'course_info' ? 'htmlmixed' : 'PG';
+% my $codemirrorMode = 'PG';
+% if ($c->{file_type}) {
+%	$codemirrorMode = 'htmlmixed' if ($c->{file_type} eq 'course_info');
+%	$codemirrorMode = 'xml'       if ($c->{file_type} eq 'hardcopy_theme');
+% }
 % content_for js => begin
 	<%= output_codemirror_static_files($c, $codemirrorMode) =%>
 	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'),           defer => undef =%>
@@ -28,6 +32,7 @@
 	% blank_problem                => x('Editing <strong>new problem</strong> template "[_1]".'),
 	% set_header                   => x('Editing <strong>set header</strong> file "[_1]".'),
 	% hardcopy_header              => x('Editing <strong>hardcopy header</strong> file "[_1]".'),
+	% hardcopy_theme               => x('Editing <strong>hardcopy theme</strong> file "[_1]".'),
 	% course_info                  => x('Editing <strong>course information</strong> file "[_1]".'),
 	% ''                           => x('Editing <strong>unknown file type</strong> in file "[_1]".'),
 	% source_path_for_problem_file => x('Editing <strong>unassigned problem</strong> file "[_1]".')
@@ -80,6 +85,9 @@
 	% }
 	% if (not_blank($c->{tempFilePath})) {
 		<%= hidden_field temp_file_path => $c->{tempFilePath} =%>
+	% }
+	% if ($c->{file_type} eq 'hardcopy_theme') {
+		<%= hidden_field hardcopy_theme => param('hardcopy_theme') =%>
 	% }
 	%
 	% # PG problem authoring resource links

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
@@ -59,7 +59,9 @@
 				class => 'form-select form-select-sm d-inline w-auto' =%>
 		</div>
 		<div class="col-auto">
-			<button id="edit_hardcopy_theme" class="btn btn-secondary p-1" type="submit"><%= maketext('Edit Selected Theme') =%></button>
+			<button id="edit_hardcopy_theme" class="btn btn-secondary p-1" type="submit">
+				<%= maketext('Edit Selected Theme') =%>
+			</button>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
@@ -58,5 +58,8 @@
 				id    => 'action_hardcopy_theme_id',
 				class => 'form-select form-select-sm d-inline w-auto' =%>
 		</div>
+		<div class="col-auto">
+			<button id="edit_hardcopy_theme" class="btn btn-secondary p-1" type="submit"><%= maketext('Edit Selected Theme') =%></button>
+		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
@@ -5,12 +5,14 @@
 % # Don't show the save as form when editing an existing course info file.
 % last if $c->{file_type} eq 'course_info' && -e $c->{editFilePath};
 %
-% my $isBlank       = $c->{file_type} eq 'blank_problem';
-% my $templatesDir  = $ce->{courseDirs}{templates};
-% my $shortFilePath = $isBlank ? 'newProblem.pg' : $c->{editFilePath} =~ s|^$templatesDir/||r;
+% my $isBlank         = $c->{file_type} eq 'blank_problem';
+% my $isHardcopyTheme = $c->{file_type} eq 'hardcopy_theme';
+% my $templatesDir    = $ce->{courseDirs}{templates};
+% my $shortFilePath   = $isBlank         ? 'newProblem.pg' : $c->{editFilePath} =~ s|^$templatesDir/||r;
+% $shortFilePath      = $isHardcopyTheme ? 'hardcopyThemes/' . ($c->{editFilePath} =~ s|^.*\/||r) : $shortFilePath;
 %
 % # Suggest that modifications be saved to the "local" subdirectory if its not in a writeable directory
-% $shortFilePath = "local/$shortFilePath" unless $isBlank || -w dirname($c->{editFilePath});
+% $shortFilePath = "local/$shortFilePath" unless $isBlank || $isHardcopyTheme || -w dirname($c->{editFilePath});
 %
 % # If it is an absolute path make it relative.
 % $shortFilePath =~ s|^/*|| if $shortFilePath =~ m|^/|;
@@ -45,6 +47,9 @@
 		</div>
 		<%= hidden_field 'action.save_as.source_file' => $c->{editFilePath} =%>
 		<%= hidden_field 'action.save_as.file_type' => $c->{file_type} =%>
+		% if ($c->{file_type} eq 'hardcopy_theme') {
+			<%= hidden_field 'action.save_as.saveMode' => 'new_hardcopy_theme' =%>
+		% }
 	</div>
 	% if ($can_add_problem_to_set) {
 		<div class="form-check">
@@ -73,7 +78,7 @@
 			<% end =%>
 		</div>
 	% }
-	% if ($c->{file_type} ne 'course_info') {
+	% if ($c->{is_pg}) {
 		<div class="form-check">
 			<%= radio_button 'action.save_as.saveMode' => 'new_independent_problem',
 				id => 'action_save_as_saveMode_independent_problem_id', class => 'form-check-input',

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
@@ -47,9 +47,6 @@
 		</div>
 		<%= hidden_field 'action.save_as.source_file' => $c->{editFilePath} =%>
 		<%= hidden_field 'action.save_as.file_type' => $c->{file_type} =%>
-		% if ($c->{file_type} eq 'hardcopy_theme') {
-			<%= hidden_field 'action.save_as.saveMode' => 'new_hardcopy_theme' =%>
-		% }
 	</div>
 	% if ($can_add_problem_to_set) {
 		<div class="form-check">

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_form.html.ep
@@ -5,11 +5,13 @@
 	<div class="mb-2">
 		<%== maketext('Save to [_1] and View', tag('b', dir => 'ltr', $c->shortPath($c->{editFilePath}))) =%>
 	</div>
-	<div class="form-check mb-2">
-		<%= check_box newWindowSave => 1, id => 'newWindowSave', class => 'form-check-input',
-			$c->{file_type} eq 'hardcopy_header' ? (checked => undef) : () =%>
-		<%= label_for newWindowSave => maketext('Open in new window'), class => 'form-check-label' =%>
-	</div>
+	% unless ($c->{file_type} eq 'hardcopy_theme') {
+		<div class="form-check mb-2">
+			<%= check_box newWindowSave => 1, id => 'newWindowSave', class => 'form-check-input',
+				$c->{file_type} eq 'hardcopy_header' ? (checked => undef) : () =%>
+			<%= label_for newWindowSave => maketext('Open in new window'), class => 'form-check-label' =%>
+		</div>
+	% }
 	<%= hidden_field 'action.save.source_file' => $c->{editFilePath} =%>
 
 	% # Backup options

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/view_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/view_form.html.ep
@@ -26,10 +26,12 @@
 			</div>
 		</div>
 	% }
-	<div class="row g-0 mb-2">
-		<div class="form-check mb-2">
-			<%= check_box 'newWindowView' => 1, id => 'newWindowView', class => 'form-check-input' =%>
-			<%= label_for newWindowView => maketext('Open in new window'), class => 'form-check-label' =%>
+	% unless ($c->{file_type} eq 'hardcopy_theme') {
+		<div class="row g-0 mb-2">
+			<div class="form-check mb-2">
+				<%= check_box 'newWindowView' => 1, id => 'newWindowView', class => 'form-check-input' =%>
+				<%= label_for newWindowView => maketext('Open in new window'), class => 'form-check-label' =%>
+			</div>
 		</div>
-	</div>
+	% }
 </div>

--- a/templates/HelpFiles/Hardcopy.html.ep
+++ b/templates/HelpFiles/Hardcopy.html.ep
@@ -42,7 +42,10 @@
 	<dd><%= maketext('If selected, the file path of the problem source will be printed in the output.') %></dd>
 
 	<dt><%= maketext('Hardcopy Theme') %></dt>
-	<dd><%= maketext('Choose from the available hardcopy layout themes.') %> </dd>
+	<dd>
+		<%= maketext('Choose from the available hardcopy layout themes. '
+			. 'To create a new hardcopy theme, visit the Problem Editor, Generate Hardcopy tab. '
+			. 'New hardcopy themes will be stored in the templates/hardcopyThemes/ folder.') %> </dd>
 </dl>
 <p>
 	<%== maketext('Once "Generate Hardcopy for selected sets and selected users" is clicked a file in the selected '

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -115,12 +115,18 @@
 
 	<dt><%= maketext('Generate Hardcopy') %></dt>
 	<dd>
+		<p>
 		<%= maketext('Generate a hardcopy of the problem being edited. This does not change the permanent file on the '
 			. 'disk. You can generate a hardcopy for different versions of the same problem by changing the seed. You '
 			. 'can also change the format to "PDF" or "TeX Source". If "PDF" is selected, then a PDF file will be '
 			. 'generated for download, unless there are errors. If errors occur or "TeX Source" is selected, then a '
 			. 'zip file will be generated for download that contains the TeX source file and resources needed for '
 			. 'generating the PDF file using pdflatex.') =%>
+		</p>
+		<p>
+		<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be saved to '
+			. 'the templates/hardcopyThemes folder.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Tidy Code') %></dt>


### PR DESCRIPTION
This is on top of #2099. At present only one commit (85e2f37) is on top of #2099.

Of course, first of all there may be issues with the code that's already here that I need to fix. But beyond that, this is incomplete because the save handler is not working. I've tried various things, and here I tried to leave out all the small messes that I made while trying to figure it out. Towards the end I was making some hail marys that did not land... If you have time and interest to look into it, I appreciate it. I'm running out of time.

With what is here, you can go to the Editor, Hardcopy tab, and click to edit a Hardcopy theme. Either it's already a local theme, and you start editing it, or it is a site theme and you are set up to use "save as" to create a new local theme. But when using the save tab, somewhere along the way, `$c->{editFilePath}` stops being something like `/opt/webwork/courses/mycourse/templates/hardcopyThemes/myTheme.xml` and is reborn as just `/opt/webwork/courses/mycourse/templates/hardcopyThemes/`, leading to issues.

And once that is worked out, there are a few more things.

- I haven't reviewed documentation, but I'm sure there are places I need to add help about this. Waiting to get it actually working first.
- With view and save tabs, I am hiding the "open in a new window" checkbox. In theory it would be nice if those led to building a dummy set in a new tab, using the temporarily edited theme, but I don't know if I'll get to that.
- The codemirror display is just showing the same XML as from the editing side. It would be nice to copy the temporary file somewhere public in `htdocs/tmp`, and then have the display panel load it in an iframe and the browser would use it's XML tree display mode. This would at least let you know when you have invalid XML.
- It might be nice if there were a codemirror  mode for XML with LaTeX coloring within specified elements.  But maybe not, as here we could have unmatched braces, etc, that match up within other XML elements.