### PR TITLE
Don't strip the password from the input parameters for the rpc endpoints.

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -623,7 +623,7 @@ sub set_params {
 	# A2 - params are not non-modifiable, with no explanation or workaround given in docs. WTF!
 	$c->param("user",   $self->{user_id});
 	$c->param("key",    $self->{session_key});
-	$c->param("passwd", "");
+	$c->param("passwd", "") unless $c->{rpc};
 
 	debug("params user='", $c->param("user"), "' key='", $c->param("key"), "'");
 }


### PR DESCRIPTION
Password authentication for the rpc endpoints relies on this, and this is the cause of issue #2115.

There really is no reason that the password should ever be stripped from the parameters.  I suspect someone at some point thought leaving it in the parameters after authentication is complete was some sort of security vulnerability.  It really isn't.  The parameters are secure in the system.  Nothing outside of the application can see them.  In fact no real security is even gained by removing this parameter either.  So the line modified here could simply be safely deleted instead.  For now, I left and only leave the parameter for the rpc endpoints though.