### PR TITLE
pick and choose permission levels to receive feedback

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -738,9 +738,13 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 );
 
 # this hash maps operations to the roles that are allowed to perform those
-# operations. the role listed and any role with a higher permission level (in
-# the %userRoles hash) will be allowed to perform the operation. If the role
-# is undefined, no users will be allowed to perform the operation.
+# operations. If a single role is listed, the role listed and any role with
+# a higher permission level (in the %userRoles hash) will be allowed to perform
+# the operation. If the role is undefined, no users will be allowed to perform
+# the operation. Some permissionLevels can be an array reference containing a
+# list of roles. If that is the case, only those exact roles are allowed to
+# perform the operation. Only those roles below that use an array reference can
+# actually be set to an array reference.
 #
 %permissionLevels = (
 	login                          => "guest",
@@ -766,7 +770,7 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 	access_instructor_tools        => "ta",
 	score_sets                     => "professor",
 	send_mail                      => "professor",
-	receive_feedback               => "ta",
+	receive_feedback               => ['ta', 'professor', 'admin'],
 
 	create_and_delete_problem_sets => "professor",
 	assign_problem_sets            => "professor",
@@ -2056,12 +2060,10 @@ $ConfigValues = [
 			var  => 'permissionLevels{receive_feedback}',
 			doc  => x('E-mail feedback from students automatically sent to this permission level and higher'),
 			doc2 => x(
-				'Users with this permssion level or greater will automatically be sent feedback from students '
-					. '(generated when they use the "Contact instructor" button on any problem page).  In addition '
-					. 'the feedback message will be sent to addresses listed below.  To send ONLY to addresses listed '
-					. 'below set permission level to "nobody".'
+				'Users with these permission levels will automatically be sent feedback emails from students when they '
+					. 'use the "Contact instructor" button on any problem page.'
 			),
-			type => 'permission'
+			type => 'permission_checkboxlist',
 		},
 		{
 			var  => 'mail{feedbackRecipients}',

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -741,10 +741,9 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 # operations. If a single role is listed, the role listed and any role with
 # a higher permission level (in the %userRoles hash) will be allowed to perform
 # the operation. If the role is undefined, no users will be allowed to perform
-# the operation. Some permissionLevels can be an array reference containing a
-# list of roles. If that is the case, only those exact roles are allowed to
-# perform the operation. Only those roles below that use an array reference can
-# actually be set to an array reference.
+# the operation. The receive_feedback permission level can be also be an array
+# reference containing a list of roles. If that is the case, only those exact
+# roles are allowed to reeceive feedback emails.
 #
 %permissionLevels = (
 	login                          => "guest",

--- a/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
+++ b/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
@@ -15,29 +15,10 @@
 
 package WeBWorK::ConfigObject::permission_checkboxlist;
 use Mojo::Base 'WeBWorK::ConfigObject', -signatures;
-
-my %userRoles = (
-	guest         => -5,
-	student       => 0,
-	login_proctor => 2,
-	grade_proctor => 3,
-	ta            => 5,
-	professor     => 10,
-	admin         => 20,
-	nobody        => 99999999,    # insure that nobody comes at the end
-);
-
-sub role_and_above {
-	my $role       = shift;
-	my $role_array = [$role];
-	for my $userRole (keys %userRoles) {
-		push @$role_array, $userRole if ($userRoles{$userRole} > $userRoles{$role});
-	}
-	return $role_array;
-}
+use WeBWorK::Utils 'role_and_above';
 
 sub display_value ($self, $val) {
-	$val = role_and_above($val) unless ref($val) eq 'ARRAY';
+	$val = role_and_above($self->{c}->ce->{userRoles}, $val) unless ref($val) eq 'ARRAY';
 	return $self->{c}->c(@{ $val // [] })->join($self->{c}->tag('br'));
 }
 
@@ -62,13 +43,13 @@ sub save_string ($self, $oldval, $use_current = 0) {
 }
 
 sub comparison_value ($self, $val) {
-	$val = role_and_above($val) unless ref($val) eq 'ARRAY';
+	$val = role_and_above($self->{c}->ce->{userRoles}, $val) unless ref($val) eq 'ARRAY';
 	return join(',', @{ $val // [] });
 }
 
 sub entry_widget ($self, $default) {
 	my $c = $self->{c};
-	$default = role_and_above($default) unless ref($default) eq 'ARRAY';
+	$default = role_and_above($self->{c}->ce->{userRoles}, $default) unless ref($default) eq 'ARRAY';
 	return $c->c(
 		map {
 			$c->tag(

--- a/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
+++ b/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
@@ -1,0 +1,94 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2021 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.	 See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package WeBWorK::ConfigObject::permission_checkboxlist;
+use Mojo::Base 'WeBWorK::ConfigObject', -signatures;
+
+my %userRoles = (
+	guest         => -5,
+	student       => 0,
+	login_proctor => 2,
+	grade_proctor => 3,
+	ta            => 5,
+	professor     => 10,
+	admin         => 20,
+	nobody        => 99999999,    # insure that nobody comes at the end
+);
+
+sub role_and_above {
+	my $role       = shift;
+	my $role_array = [$role];
+	for my $userRole (keys %userRoles) {
+		push @$role_array, $userRole if ($userRoles{$userRole} > $userRoles{$role});
+	}
+	return $role_array;
+}
+
+sub display_value ($self, $val) {
+	$val = role_and_above($val) unless ref($val) eq 'ARRAY';
+	return $self->{c}->c(@{ $val // [] })->join($self->{c}->tag('br'));
+}
+
+# r->param() returns an array, so a custom version of convert_newval_source is needed.
+sub convert_newval_source ($self, $use_current) {
+	if ($use_current) {
+		return @{ $self->get_value($self->{c}->ce) };
+	} else {
+		return $self->{c}->param($self->{name});
+	}
+}
+
+sub save_string ($self, $oldval, $use_current = 0) {
+	my @newvals = $self->convert_newval_source($use_current);
+	if ($self->{min} && scalar(@newvals) < $self->{min}) {
+		$self->{c}->addbadmessage("You need to select at least $self->{min} display mode.");
+		return '' if $use_current;
+		return $self->save_string($oldval, 1);
+	}
+	return '' if $self->comparison_value($oldval) eq $self->comparison_value(\@newvals);
+	return "\$$self->{var} = [" . join(',', map {"'$_'"} @newvals) . "];\n";
+}
+
+sub comparison_value ($self, $val) {
+	$val = role_and_above($val) unless ref($val) eq 'ARRAY';
+	return join(',', @{ $val // [] });
+}
+
+sub entry_widget ($self, $default) {
+	my $c = $self->{c};
+	$default = role_and_above($default) unless ref($default) eq 'ARRAY';
+	return $c->c(
+		map {
+			$c->tag(
+				'div',
+				class => 'form-check',
+				$c->tag(
+					'label',
+					class => 'form-check-label',
+					$c->c(
+						$c->check_box(
+							$self->{name} => $_,
+							{ map { $_ => 1 } @$default }->{$_} ? (checked => undef) : (),
+							class => 'form-check-input',
+						),
+						$_
+					)->join('')
+				)
+			)
+		} ('guest', 'student', 'login_proctor', 'grade_proctor', 'ta', 'professor', 'admin')
+	)->join('');
+}
+
+1;

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -28,7 +28,7 @@ use Try::Tiny;
 use Text::Wrap qw(wrap);
 
 use WeBWorK::Upload;
-use WeBWorK::Utils qw(decodeAnswers createEmailSenderTransportSMTP fetchEmailRecipients);
+use WeBWorK::Utils qw(decodeAnswers createEmailSenderTransportSMTP role_and_above fetchEmailRecipients);
 
 # request paramaters used
 #

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -28,7 +28,7 @@ use Try::Tiny;
 use Text::Wrap qw(wrap);
 
 use WeBWorK::Upload;
-use WeBWorK::Utils qw(decodeAnswers createEmailSenderTransportSMTP role_and_above fetchEmailRecipients);
+use WeBWorK::Utils qw(decodeAnswers createEmailSenderTransportSMTP fetchEmailRecipients);
 
 # request paramaters used
 #

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -29,6 +29,7 @@ use WeBWorK::ConfigObject::time;
 use WeBWorK::ConfigObject::number;
 use WeBWorK::ConfigObject::boolean;
 use WeBWorK::ConfigObject::permission;
+use WeBWorK::ConfigObject::permission_checkboxlist;
 use WeBWorK::ConfigObject::list;
 use WeBWorK::ConfigObject::checkboxlist;
 use WeBWorK::ConfigObject::popuplist;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -119,6 +119,7 @@ our @EXPORT_OK = qw(
 	is_jitar_problem_closed
 	jitar_problem_adjusted_status
 	jitar_problem_finished
+	role_and_above
 	fetchEmailRecipients
 	processEmailMessage
 	createEmailSenderTransportSMTP
@@ -1840,6 +1841,16 @@ ID: foreach my $id (@problemIDs) {
 	return 1;
 }
 
+# Get the array of all permission levels at or above a given level
+sub role_and_above {
+	my ($c, $role) = @_;
+	my $role_array = [$role];
+	for my $userRole (keys %{ $c->ce->{userRoles} }) {
+		push @$role_array, $userRole if ($c->ce->{userRoles}{$userRole} > $c->ce->{userRoles}{$role});
+	}
+	return $role_array;
+}
+
 # Requires a ContentGenerator object, and a permission type.
 # If the optional sender argument is provided, then filter on the section of the given sender.
 sub fetchEmailRecipients {
@@ -1848,18 +1859,25 @@ sub fetchEmailRecipients {
 	my $ce    = $c->ce;
 	my $authz = $c->authz;
 
-	return
-		unless $permissionType
-		&& defined $ce->{permissionLevels}{$permissionType}
-		&& defined $ce->{userRoles}{ $ce->{permissionLevels}{$permissionType} };
+	return unless $permissionType && defined $ce->{permissionLevels}{$permissionType};
+
+	my $roles =
+		ref $ce->{permissionLevels}{$permissionType} eq 'ARRAY'
+		? $ce->{permissionLevels}{$permissionType}
+		: $c->role_and_above($ce->{permissionLevels}{$permissionType});
+	@$roles = grep { defined $ce->{userRoles}{$_} } @$roles;
+	return unless $roles;
+
+	my $user_ids = [];
+	for my $role (@$roles) {
+		push(@$user_ids,
+			map { $_->user_id }
+				$db->getPermissionLevelsWhere({ permission => { '=' => $ce->{userRoles}{$role} } }));
+	}
 
 	my @recipients =
 		map { $_->rfc822_mailbox } $db->getUsersWhere({
-			user_id => [
-				map { $_->user_id } $db->getPermissionLevelsWhere(
-					{ permission => { '>=' => $ce->{userRoles}{ $ce->{permissionLevels}{$permissionType} } } }
-				)
-			],
+			user_id       => $user_ids,
 			email_address => { '!=', undef },
 			$ce->{feedback_by_section}
 			&& defined $sender


### PR DESCRIPTION
This is an alternative to #1598. It allows you to set `$permissionLevels{receive_feedback} = ['ta', 'professor']` so that only those specific roles can receive feedback. There is no change in behavior if you use a string: `$permissionLevels{receive_feedback} = 'ta'` still means "ta and above".

I copied `checkboxlist.pm` to `permission_checkboxlist.pm` and tweaked it to work specifically for the list of permissions. I am unsure if that left some things present that are not needed.

Perhaps this is a model for any other permissionLevels where it would be better to allow you to pick and choose the roles instead of going with one role and above. Off the top of my head I can't think of another permissionLevel where you'd want this though.