### PR TITLE
Fix codemirror folding for html and xml.

### DIFF
--- a/htdocs/js/PGCodeMirror/pgeditor.js
+++ b/htdocs/js/PGCodeMirror/pgeditor.js
@@ -69,16 +69,15 @@
 		return configName;
 	};
 
-	const cm = webworkConfig.pgCodeMirror = CodeMirror.fromTextArea(document.querySelector('.codeMirrorEditor'), {
-		mode: document.querySelector('.codeMirrorEditor')?.dataset.mode ?? 'PG',
+	const mode = document.querySelector('.codeMirrorEditor')?.dataset.mode ?? 'PG';
+	const options = {
+		mode,
 		indentUnit: 4,
 		tabMode: 'spaces',
 		lineNumbers: true,
 		lineWrapping: true,
 		extraKeys: {
 			Tab:            (cm) => cm.execCommand('insertSoftTab'),
-			'Ctrl-/':       (cm) => cm.execCommand('toggleComment'),
-			'Cmd-/':        (cm) => cm.execCommand('toggleComment'),
 			'Shift-Ctrl-F': (cm) => cm.foldCode(cm.getCursor(), { scanUp : true }),
 			'Shift-Cmd-F':  (cm) => cm.foldCode(cm.getCursor(), { scanUp : true }),
 			'Shift-Ctrl-A': (cm) => CodeMirror.commands.foldAll(cm),
@@ -90,10 +89,20 @@
 		matchBrackets: true,
 		inputStyle: 'contenteditable',
 		spellcheck: localStorage.getItem('WW_PGEditor_spellcheck') === 'true',
-		gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'],
-		foldGutter: { rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.PG) },
-		fold: 'PG'
-	});
+		gutters: ['CodeMirror-linenumbers', 'CodeMirror-foldgutter']
+	};
+
+	if (mode === 'PG') {
+		options.extraKeys['Ctrl-/'] = (cm) => cm.execCommand('toggleComment');
+		options.extraKeys['Cmd-/'] = (cm) => cm.execCommand('toggleComment');
+		options.foldGutter = { rangeFinder: new CodeMirror.fold.combine(CodeMirror.fold.PG) }
+		options.fold = 'PG'
+	} else {
+		options.foldGutter = true;
+	}
+
+	const cm = webworkConfig.pgCodeMirror
+		= CodeMirror.fromTextArea(document.querySelector('.codeMirrorEditor'), options);
 	cm.setSize('100%', '550px');
 
 	const currentThemeFile = localStorage.getItem('WW_PGEditor_selected_theme') ?? 'default';

--- a/lib/WeBWorK/HTML/CodeMirrorEditor.pm
+++ b/lib/WeBWorK/HTML/CodeMirrorEditor.pm
@@ -61,7 +61,8 @@ use constant CODEMIRROR_ADDONS_JS => [
 	'search/searchcursor.js',      'search/matchesonscrollbar.js',
 	'search/match-highlighter.js', 'search/match-highlighter.js',
 	'scroll/annotatescrollbar.js', 'edit/matchbrackets.js',
-	'fold/foldcode.js',            'fold/foldgutter.js'
+	'fold/foldcode.js',            'fold/foldgutter.js',
+	'fold/xml-fold.js'
 ];
 
 sub generate_codemirror_html ($c, $name, $contents = '', $mode = 'PG') {


### PR DESCRIPTION
Currently when you edit a course info file in the PG problem editor, there is a console log error.  This is because the PG code folding options do not work for htmlmixed mode.  This will also happen with the xml mode that will be added in pull request #2114.

This uses different options for htmlmixed or xml mode than for PG mode so that folding works for html and xml as well.

This also only enables comment toggling for PG mode.  That doesn't work for html and xml.