### PR TITLE
allow enter key to activate submit/check

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -188,6 +188,11 @@ $editor{textEdition} = '';
 $editor{textAuthor} = '';
 
 ################################################################################
+# Enter key behavior
+################################################################################
+$enterKey = 'preview';
+
+################################################################################
 # showMeAnother
 ################################################################################
 # switch to enable showMeAnother button
@@ -1591,6 +1596,21 @@ $ConfigValues = [
 			type    => 'number',
 			hashVar => '{pg}->{answersOpenAfterDueDate}'
 		},
+		{
+			var => 'enterKey',
+			doc => x('Enter Key Behavior'),
+			doc2 => x(
+				'If this is set to "preview", hitting the enter key on a problem page activates the "Preview My Answers" '
+					. 'button. If this is set to "submit", then the enter key activates the "Submit Answers" button '
+					. 'instead. Or if that button is not present, it will activate the "Check Answers" button. Or if '
+					. 'that button is also not present, it will just activate the "Preview My Answers" button. A '
+					. 'third option is "conservative". In this case, the enter key behaves like "preview" when the '
+					. '"Submit" button is available and there are only finitely many attempts allowed. Otherise the '
+					. 'enter key behaves like "submit".'
+			),
+			type => 'popuplist',
+			values => ['preview', 'submit', 'conservative']
+		}
 	],
 	[
 		x('Optional Modules'),

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -190,7 +190,7 @@ $editor{textAuthor} = '';
 ################################################################################
 # Enter key behavior
 ################################################################################
-$enterKey = 'preview';
+$pg{options}{enterKey} = 'preview';
 
 ################################################################################
 # showMeAnother
@@ -1596,21 +1596,6 @@ $ConfigValues = [
 			type    => 'number',
 			hashVar => '{pg}->{answersOpenAfterDueDate}'
 		},
-		{
-			var => 'enterKey',
-			doc => x('Enter Key Behavior'),
-			doc2 => x(
-				'If this is set to "preview", hitting the enter key on a problem page activates the "Preview My Answers" '
-					. 'button. If this is set to "submit", then the enter key activates the "Submit Answers" button '
-					. 'instead. Or if that button is not present, it will activate the "Check Answers" button. Or if '
-					. 'that button is also not present, it will just activate the "Preview My Answers" button. A '
-					. 'third option is "conservative". In this case, the enter key behaves like "preview" when the '
-					. '"Submit" button is available and there are only finitely many attempts allowed. Otherise the '
-					. 'enter key behaves like "submit".'
-			),
-			type => 'popuplist',
-			values => ['preview', 'submit', 'conservative']
-		}
 	],
 	[
 		x('Optional Modules'),
@@ -2037,6 +2022,23 @@ $ConfigValues = [
 			values => [qw(Percent Point Both)],
 			type   => 'popuplist'
 		},
+		{
+			var => 'pg{options}{enterKey}',
+			doc => x('Enter Key Behavior'),
+			doc2 => x(
+				'If this is set to "preview", hitting the enter key on a homework problem page activates the "Preview '
+					. 'My Answers" button.  If this is set to "submit", then the enter key activates the "Submit '
+					. 'Answers" button instead.  Or if that button is not present, it will activate the "Check '
+					. 'Answers" button.  Or if that button is also not present, it will activate the "Preview My '
+					. 'Answers" button.  A third option is "conservative". In this case, the enter key behaves like '
+					. '"preview" when the "Submit" button is available and there are only finitely many attempts '
+					. 'allowed.  Otherise the enter key behaves like "submit".  Note that this is only affects '
+					. 'homework problem pages, not test/quiz pages, and not instructor pages like the PG Editor '
+					. 'and the Library Browser.'
+			),
+			type => 'popuplist',
+			values => ['preview', 'submit', 'conservative']
+		}
 	],
 	[
 		x('E-Mail'),

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -312,7 +312,7 @@ $mail{feedbackRecipients}    = [
 # A third option is "conservative". In this case, the enter key behaves like "preview"
 # when the "Submit" button is available and there are only finitely many
 # attempts allowed. Otherise the enter key behaves like "submit".
-#$enterKey = 'conservative';
+#$pg{options}{enterKey} = 'conservative';
 
 ################################################################################
 # Periodic re-randomization

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -302,6 +302,19 @@ $mail{feedbackRecipients}    = [
 #$problemDefaults{showHintsAfter} = 2;
 
 ################################################################################
+# Enter key behavior
+################################################################################
+# If this is set to "preview", hitting the enter key on a problem page activates
+# the "Preview My Answers" button. If this is set to "submit", then the enter
+# key activates the "Submit Answers" button instead. Or if that button is not
+# present, it will activate the "Check Answers" button. Or if that button is
+# also not present, it will just activate the "Preview My Answers" button.
+# A third option is "conservative". In this case, the enter key behaves like "preview"
+# when the "Submit" button is available and there are only finitely many
+# attempts allowed. Otherise the enter key behaves like "submit".
+#$enterKey = 'conservative';
+
+################################################################################
 # Periodic re-randomization
 ################################################################################
 # switch to enable periodic re-randomization

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -743,6 +743,11 @@ input.changed[type=text] { /* orange */
 	row-gap: 0.25rem;
 }
 
+.visually-hidden-unfocusable {
+	position: absolute;
+	left: -9999px;
+}
+
 /* Styles used when editing a temporary file */
 .temporaryFile { font-style: italic; color: #ca5000; background-color: inherit; }
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -744,6 +744,7 @@ input.changed[type=text] { /* orange */
 }
 
 .visually-hidden-unfocusable {
+	visibility: hidden;
 	position: absolute;
 	left: -9999px;
 }

--- a/templates/ContentGenerator/Problem/submit_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/submit_buttons.html.ep
@@ -3,25 +3,27 @@
 % my %can            = %{ $c->{can} };
 % my %will           = %{ $c->{will} };
 % my $effectiveUser  = param('effectiveUser');
-% my $enter_key_name = 'previewAnswers';
-% my $enter_key_value = maketext('Preview My Answers');
-% if ($c->ce->{enterKey} eq 'submit' || ($c->ce->{enterKey} eq 'conservative' && $c->{problem}{max_attempts} < 0)) {
-% 	if ($can{getSubmitButton}) {
-%		$enter_key_name = 'submitAnswers';
-%		$enter_key_value = (param('user') ne $effectiveUser)
-%			? maketext('Submit Answers for [_1]', $effectiveUser)
-%			: maketext('Submit Answers');
-%	} elsif ($can{checkAnswers}) {
-%		$enter_key_name = 'checkAnswers';
-%		$enter_key_value = maketext('Check Answers');
-%	}
-% }
-%
 % if ($will{requestNewSeed}) {
 	<%= submit_button maketext('Request New Version'), id => 'submitAnswers_id', name => 'requestNewSeed',
 		formtarget => '_self', class => 'btn btn-primary mb-1' =%>
 % } else {
-	<%= submit_button $enter_key_value, id => 'enter_key_submit', formtarget => '_self', name => $enter_key_name, tabindex => -1,
+	% my $enter_key_name  = 'previewAnswers';
+	% my $enter_key_value = maketext('Preview My Answers');
+	% if (
+		% $c->ce->{pg}{options}{enterKey} eq 'submit'
+		% || ($c->ce->{pg}{options}{enterKey} eq 'conservative' && $c->{problem}{max_attempts} < 0)
+	% ) {
+		% if ($can{getSubmitButton}) {
+			% $enter_key_name  = 'submitAnswers';
+			% $enter_key_value = (param('user') ne $effectiveUser)
+				% ? maketext('Submit Answers for [_1]', $effectiveUser)
+				% : maketext('Submit Answers');
+		% } elsif ($can{checkAnswers}) {
+			% $enter_key_name  = 'checkAnswers';
+			% $enter_key_value = maketext('Check Answers');
+		% }
+	% }
+	<%= submit_button $enter_key_value, id => 'enter_key_submit', formtarget => '_self', name => $enter_key_name,
 		class => 'visually-hidden-unfocusable' =%>
 	<%= submit_button maketext('Preview My Answers'), id => 'previewAnswers_id', formtarget => '_self',
 		name => 'previewAnswers', class => 'btn btn-primary mb-1' =%>

--- a/templates/ContentGenerator/Problem/submit_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/submit_buttons.html.ep
@@ -1,13 +1,28 @@
 % use WeBWorK::Utils qw(before);
 %
-% my %can           = %{ $c->{can} };
-% my %will          = %{ $c->{will} };
-% my $effectiveUser = param('effectiveUser');
+% my %can            = %{ $c->{can} };
+% my %will           = %{ $c->{will} };
+% my $effectiveUser  = param('effectiveUser');
+% my $enter_key_name = 'previewAnswers';
+% my $enter_key_value = maketext('Preview My Answers');
+% if ($c->ce->{enterKey} eq 'submit' || ($c->ce->{enterKey} eq 'conservative' && $c->{problem}{max_attempts} < 0)) {
+% 	if ($can{getSubmitButton}) {
+%		$enter_key_name = 'submitAnswers';
+%		$enter_key_value = (param('user') ne $effectiveUser)
+%			? maketext('Submit Answers for [_1]', $effectiveUser)
+%			: maketext('Submit Answers');
+%	} elsif ($can{checkAnswers}) {
+%		$enter_key_name = 'checkAnswers';
+%		$enter_key_value = maketext('Check Answers');
+%	}
+% }
 %
 % if ($will{requestNewSeed}) {
 	<%= submit_button maketext('Request New Version'), id => 'submitAnswers_id', name => 'requestNewSeed',
 		formtarget => '_self', class => 'btn btn-primary mb-1' =%>
 % } else {
+	<%= submit_button $enter_key_value, id => 'enter_key_submit', formtarget => '_self', name => $enter_key_name, tabindex => -1,
+		class => 'visually-hidden-unfocusable' =%>
 	<%= submit_button maketext('Preview My Answers'), id => 'previewAnswers_id', formtarget => '_self',
 		name => 'previewAnswers', class => 'btn btn-primary mb-1' =%>
 	%

--- a/templates/ContentGenerator/Problem/submit_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/submit_buttons.html.ep
@@ -4,6 +4,8 @@
 % my %will           = %{ $c->{will} };
 % my $effectiveUser  = param('effectiveUser');
 % if ($will{requestNewSeed}) {
+	<%= submit_button maketext('Request New Version'), id => 'enter_key_submit', name => 'requestNewSeed',
+		formtarget => '_self', class => 'visually-hidden-unfocusable' =%>
 	<%= submit_button maketext('Request New Version'), id => 'submitAnswers_id', name => 'requestNewSeed',
 		formtarget => '_self', class => 'btn btn-primary mb-1' =%>
 % } else {


### PR DESCRIPTION
This adds a hidden, unfocusable button preceding the Preview button, so that this new button will be the one that is activated when you have focus in an answer text input and you hit Enter.

This button is a copy of one of the three main buttons: Preview, Check, or Submit. Which one depends on the new config value `$enterKey`.
* `'preview'`: always the preview button (status quo, and the value in defaults.config)
* `'submit'`: always the submit button;  unless if the submit button not present, then the check button;  unless that not present too, and fall back to the preview button.
* `'hybrid'`: like 'submit' except if the problem only has finitely many attempts, then it's the preview button.

This was an issue for me today with a student who did not understand why their answer was "being counted wrong". They were hitting enter, it turns out, and interpreting the pink warning that it was only a preview as indicating they were incorrect. I plan to use `'hybrid'` in production.

I did not apply this to where these buttons come up in RPCRenderFormats. It seems unnecessary, but I could add that.

I know the release is soon, and aside from if I manage to fix the few bugs we know about, I won't make any more new PRs. Or if I do, I will target develop.