### PR TITLE
stop supporting a typo

### DIFF
--- a/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
+++ b/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
@@ -9,8 +9,6 @@ loadMacros(
 "PGanswermacros.pl"
 );
 
-$dateTime = $formattedDueDate;
-
 TEXT(EV2(<<EOT));
 \noindent {\large \bf $studentName}
 \hfill

--- a/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
+++ b/courses.dist/modelCourse/templates/set0/paperHeaderFile0.pg
@@ -9,14 +9,14 @@ loadMacros(
 "PGanswermacros.pl"
 );
 
-$dateTime = $formatedDueDate;
+$dateTime = $formattedDueDate;
 
 TEXT(EV2(<<EOT));
 \noindent {\large \bf $studentName}
 \hfill
 {\large \bf {\{protect_underbar($courseName)\}}}
 \par
-\noindent{\large \bf {Assignment \{protect_underbar($setNumber)\}  closes $formatedDueDate}}
+\noindent{\large \bf {Assignment \{protect_underbar($setNumber)\}  closes $formattedDueDate}}
 \par\noindent
 This first set (set 0) is designed to acquaint you with using WeBWorK. 
 {\bf Your score on this set will not be counted toward your final grade.}

--- a/courses.dist/modelCourse/templates/set0/screenHeaderFile0.pg
+++ b/courses.dist/modelCourse/templates/set0/screenHeaderFile0.pg
@@ -12,7 +12,7 @@ loadMacros(
 
 
 BEGIN_TEXT;
-WeBWorK assignment number $setNumber is closes $formatedDueDate.
+WeBWorK assignment number $setNumber is closes $formattedDueDate.
  
 $PAR
 This first problem set (set 0) is designed to acquaint you with using WeBWorK.

--- a/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
@@ -9,7 +9,7 @@ loadMacros(
 "PGanswermacros.pl"
 );
 
-$dateTime = $formatedDueDate;
+$dateTime = $formattedDueDate;
 
 TEXT(EV2(<<EOT));
 \noindent {\large \bf $studentName}

--- a/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/paperHeaderFile1.pg
@@ -9,14 +9,12 @@ loadMacros(
 "PGanswermacros.pl"
 );
 
-$dateTime = $formattedDueDate;
-
 TEXT(EV2(<<EOT));
 \noindent {\large \bf $studentName}
 \hfill
 \noindent {\large \bf MAA Minicourse San Diego January 2002}
 \par
-\noindent{\large \bf Homework Set $setNumber  closes $dateTime}\par
+\noindent{\large \bf Homework Set $setNumber  closes $formattedDueDate}\par
 
 \noindent This is a demonstration set designed to show you some types of questions 
 that can be asked using WeBWorK. 

--- a/courses.dist/modelCourse/templates/setDemo/screenHeaderFile1.pg
+++ b/courses.dist/modelCourse/templates/setDemo/screenHeaderFile1.pg
@@ -46,7 +46,7 @@ $HR
 Use this box  to give information about this problem
 set.  Typical information might include some of these facts:
 $PAR
-WeBWorK assignment number $setNumber closes on : $formatedDueDate.
+WeBWorK assignment number $setNumber closes on : $formattedDueDate.
 
 
 $PAR

--- a/doc/devel/daemon-problem-environment
+++ b/doc/devel/daemon-problem-environment
@@ -19,7 +19,6 @@
 	externalPng2EpsPath
 	externalTTHPath
 	fileName
-	formatedDueDate
 	formattedAnswerDate
 	formattedDueDate
 	formattedOpenDate

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -74,8 +74,6 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 		my $db_date = $date =~ s/D/_d/r;
 		$options{$date} = $set->$db_date;
 		$options{ 'formatted' . ucfirst($date) } = formatDateTime($options{$date}, $ce->{siteDefaults}{timezone});
-		# This is provided due to a typo in many header files.
-		$options{ 'formated' . ucfirst($date) } = $options{ 'formatted' . ucfirst($date) };
 		my $uc_date = ucfirst($date);
 		for (
 			[ 'DayOfWeek',       '%A' ],


### PR DESCRIPTION
This may be controversial, and I'm fine if this is rejected.

My problem with supporting this typo in old set header files, is that while doing dev work, I saw "formated" appear in a list of hash keys and I thought surely that's a typo. So I wasted time looking into it only to find it is supposed to be there. But is it time to make people correct their typos?