### PR TITLE
Correct htmlPath and imagesPath settings in defaults.config

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1108,20 +1108,18 @@ $pg{directories}{macrosPath} = [
    "$pg{directories}{macros}/deprecated",
 ];
 
-$pg{directories}{htmlPath} = [    # paths to search for auxiliary html files (requires full url)
-    ".",
-	"$courseURLs{html}",
-	"$webworkURLs{htdocs}",
+# Directories to search for auxiliary html files.
+$pg{directories}{htmlPath} = [
+	".",
+	$courseDirs{html},
+	$webworkDirs{htdocs},
 ];
-$pg{directories}{imagesPath} = [    # paths to search for image files (requires full url)
-    ".",
-	"$courseURLs{html}/images",
-	"$webworkURLs{htdocs}/images",
-];
-$pg{directories}{pdfPath} = [    # paths to search for pdf files (requires full url)
-    ".",
-	"$courseURLs{html}/pdf",
-	"$webworkURLs{htdocs}/pdf",
+
+# Directories to search for image files.
+$pg{directories}{imagesPath} = [
+	".",
+	"$courseDirs{html}/images",
+	"$webworkDirs{htdocs}/images",
 ];
 
 # Contains context-sensitive pg help files.


### PR DESCRIPTION
These paths have been incorrect since 2015 when they were added.  The comments that was there about these are completely incorrect.  They state that these should be complete urls.  They should not be urls at all. Instead they should be directories.  The only place that these are used is in PGalias.pm to search for auxiliary html files or images, and there they are treated as directories.

Also remove the completely unused pdfPath setting.