### PR TITLE
move help link outside of h1

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -380,6 +380,11 @@ div.showMeAnotherBox {
 h1.page-title {
 	font-size: 31.5px;
 	line-height: 35px;
+	display: inline-block;
+}
+h1.page-title + a {
+	font-size: 31.5px;
+	margin-left: 0.5rem;
 }
 
 h2.page-title {

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -124,11 +124,11 @@
 				<div class="col-12">
 					<h1 id="page-title" class="page-title">
 						<%== $c->page_title %>
-						% if ($authen->{was_verified}
-							% && $authz->hasPermissions(param('user'), 'access_instructor_tools')) {
-							<%= $c->help({ label_size => 'fa-xs' }) %>
-						% }
 					</h1>
+					% if ($authen->{was_verified}
+						% && $authz->hasPermissions(param('user'), 'access_instructor_tools')) {
+						<%= $c->help({ label_size => 'fa-xs' }) %>
+					% }
 				</div>
 			</div>
 		% }


### PR DESCRIPTION
This moves the question mark help icons next to each h1 outside of the h1 (but still visually in basically the same place).

Without this, when you look at a heading tree for a page, you see a little question mark at the end of each h1, and that shouldn't be in the actual heading.