### PR TITLE
Add the installation of Perl::Tidy to the docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -182,7 +182,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 \
+RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -144,7 +144,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 \
+RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================


### PR DESCRIPTION
This was missed in #2098.