### PR TITLE
Fix the PG Problem Editor buttons above the editor window (for develop).

### DIFF
--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -90,43 +90,45 @@
 		<%= hidden_field hardcopy_theme => param('hardcopy_theme') =%>
 	% }
 	%
-	% # PG problem authoring resource links
-	<div class="mb-2">
-		<%= link_to maketext('Sample Problems') => url_for('sample_problem_index'),
-			target => 'techniques_window',
-			title  => maketext('POD for macros and sample problem code and snippets'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # http://webwork.maa.org/wiki/Category:MathObjects
-		<%= link_to maketext('Math Objects') => $ce->{webworkURLs}{MathObjectsHelpURL},
-			target => 'math_objects',
-			title  => maketext('Wiki summary page for MathObjects'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # PG POD served locally
-		<%= link_to maketext('POD') => url_for('pod_index'),
-			target => 'pod_docs',
-			title  => maketext('Documentation from source code for PG modules and macro files.'),
-			class  => 'reference-link btn btn-sm btn-info',
-			data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
-		% # PGML lab problem rendered as an unattached problem in a new window.
-		% if (-e "$ce->{courseDirs}{templates}/PGMLLab/PGML-lab.pg") {
-			<%= link_to maketext('PGML') => $c->systemLink(
-					url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
-					params => {
-						displayMode    => $ce->{pg}{options}{displayMode},
-						problemSeed    => 1234,
-						editMode       => 'temporaryFile',
-						sourceFilePath => 'PGMLLab/PGML-lab.pg'
-					}
-				),
-				target => 'PGML',
-				title  => maketext(
-					'PG markdown syntax used to format WeBWorK questions. '
-					. 'This interactive lab can help you to learn the techniques.'
-				),
+	% if ($c->{is_pg}) {
+		% # PG problem authoring resource links
+		<div class="mb-2">
+			<%= link_to maketext('Sample Problems') => url_for('sample_problem_index'),
+				target => 'techniques_window',
+				title  => maketext('POD for macros and sample problem code and snippets'),
 				class  => 'reference-link btn btn-sm btn-info',
 				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% # http://webwork.maa.org/wiki/Category:MathObjects
+			<%= link_to maketext('Math Objects') => $ce->{webworkURLs}{MathObjectsHelpURL},
+				target => 'math_objects',
+				title  => maketext('Wiki summary page for MathObjects'),
+				class  => 'reference-link btn btn-sm btn-info',
+				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% # PG POD served locally
+			<%= link_to maketext('POD') => url_for('pod_index'),
+				target => 'pod_docs',
+				title  => maketext('Documentation from source code for PG modules and macro files.'),
+				class  => 'reference-link btn btn-sm btn-info',
+				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% # PGML lab problem rendered as an unattached problem in a new window.
+			% if (-e "$ce->{courseDirs}{templates}/PGMLLab/PGML-lab.pg") {
+				<%= link_to maketext('PGML') => $c->systemLink(
+						url_for('problem_detail', setID => 'Undefined_Set', problemID => 1),
+						params => {
+							displayMode    => $ce->{pg}{options}{displayMode},
+							problemSeed    => 1234,
+							editMode       => 'temporaryFile',
+							sourceFilePath => 'PGMLLab/PGML-lab.pg'
+						}
+					),
+					target => 'PGML',
+					title  => maketext(
+						'PG markdown syntax used to format WeBWorK questions. '
+						. 'This interactive lab can help you to learn the techniques.'
+					),
+					class  => 'reference-link btn btn-sm btn-info',
+					data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
+			% }
 			% # http://webwork.maa.org/wiki/Category:Authors
 			<%= link_to maketext('Author Info') => $ce->{webworkURLs}{AuthorHelpURL},
 				target => 'author_info',
@@ -134,7 +136,8 @@
 				class  => 'reference-link btn btn-sm btn-info',
 				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
 			% # Only show the report bugs in problem button if editing an OPL or Contrib problem.
-			% if ($c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/| && ($1 eq 'Library' || $1 eq 'Contrib')) {
+			% if ($c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/|
+				% && ($1 eq 'Library' || $1 eq 'Contrib')) {
 				<%= link_to maketext('Report Bugs in this Problem') =>
 						"$ce->{webworkURLs}{bugReporter}?product=Problem%20libraries"
 						. "&component=$1&bug_file_loc=$c->{editFilePath}_with_problemSeed=$c->{problemSeed}",


### PR DESCRIPTION
The `if` statement checking for the PGML labs problem went to far, and included the "Author Info" and "Report Bugs in this Problem" buttons, and the ending tag for the div that contains all of the buttons.

Those buttons are not present when editing the course information file.

This may have been caused by a merge conflict resolution issue.