### PR TITLE
Possible fix for CAS.pm authentication issue (for develop).

### DIFF
--- a/lib/WeBWorK/Authen/CAS.pm
+++ b/lib/WeBWorK/Authen/CAS.pm
@@ -115,7 +115,7 @@ sub get_credentials {
 		#    CAFile => $cas_certs);
 		my $cas = new AuthCAS(%{ $ce->{authen}{cas_options}{AuthCAS_opts} });
 
-		my $service = $c->unparsed_uri();
+		my $service = $c->req->url->to_string;
 		# Remove the "ticket=..." parameter that the CAS server added
 		# (Not sure if the second test is really needed.)
 		$service =~ s/[?&]ticket=[^&]*$//


### PR DESCRIPTION
This replaces the mod_perl `$r->unparsed_uri` method with Mojo::Message::Request method `$c->req->url->to_string` which should return the same thing.  This may fix the `CAS.pm` module.  This is the only mod_perl call in that file, and was missed in the conversion to Mojolicious.

I have not way to test this, but clearly that method must be replaced.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8317.