### PR TITLE
Add zip to archives in File Manager

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,6 +71,7 @@ RUN apt-get update \
 	imagemagick \
 	iputils-ping \
 	jq \
+	libarchive-extract-perl \
 	libarchive-zip-perl \
 	libarray-utils-perl \
 	libc6-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -185,7 +185,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
+RUN cpanm install Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -33,6 +33,7 @@ RUN apt-get update \
 	imagemagick \
 	iputils-ping \
 	jq \
+	libarchive-extract-perl \
 	libarchive-zip-perl \
 	libarray-utils-perl \
 	libc6-dev \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -147,7 +147,7 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 \
+RUN cpanm install -n Statistics::R::IO DBD::MariaDB Mojo::SQLite@3.002 Perl::Tidy@20220613 Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
 
 # ==================================================================

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,6 +65,7 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
+	Archive::Extract
 	Archive::Zip
 	Array::Utils
 	Benchmark

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -67,6 +67,7 @@ my @applicationsList = qw(
 my @modulesList = qw(
 	Archive::Extract
 	Archive::Zip
+	Archive::Zip::SimpleZip
 	Array::Utils
 	Benchmark
 	Carp

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,7 +65,6 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
-	Archive::Extract
 	Archive::Zip
 	Archive::Zip::SimpleZip
 	Array::Utils

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -89,8 +89,6 @@ $externalPrograms{mkdir} = "/bin/mkdir";
 $externalPrograms{tar}   = "/bin/tar";
 $externalPrograms{gzip}  = "/bin/gzip";
 $externalPrograms{git}   = "/usr/bin/git";
-$externalPrograms{unzip} = '/usr/bin/zip';
-$externalPrograms{unzip} = '/usr/bin/unzip';
 
 ####################################################
 # equation rendering/hardcopy utiltiies

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -88,7 +88,9 @@ $externalPrograms{rm}    = "/bin/rm";
 $externalPrograms{mkdir} = "/bin/mkdir";
 $externalPrograms{tar}   = "/bin/tar";
 $externalPrograms{gzip}  = "/bin/gzip";
-$externalPrograms{git} = "/usr/bin/git";
+$externalPrograms{git}   = "/usr/bin/git";
+$externalPrograms{unzip} = '/usr/bin/zip';
+$externalPrograms{unzip} = '/usr/bin/unzip';
 
 ####################################################
 # equation rendering/hardcopy utiltiies

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -42,14 +42,6 @@
 		}
 	};
 
-	for (const archiveTypeInput of document.querySelectorAll('input[name="archive_type"]')) {
-		archiveTypeInput.addEventListener('click', () => {
-			document.getElementById('filename_suffix').innerText = `.${
-				document.querySelector('input[name="archive_type"]:checked').value
-			}`;
-		});
-	}
-
 	files?.addEventListener('change', checkFiles);
 	if (files) checkFiles();
 

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -45,6 +45,19 @@
 	files?.addEventListener('change', checkFiles);
 	if (files) checkFiles();
 
+	const archiveFilenameInput = document.getElementById('archive-filename');
+	const archiveTypeSelect = document.getElementById('archive-type');
+	if (archiveFilenameInput && archiveTypeSelect) {
+		archiveTypeSelect.addEventListener('change', () => {
+			if (archiveTypeSelect.value) {
+				archiveFilenameInput.value = archiveFilenameInput.value.replace(
+					/\.(zip|tgz|tar.gz)$/,
+					`.${archiveTypeSelect.value}`
+				);
+			}
+		});
+	}
+
 	const file = document.getElementById('file');
 	const uploadButton = document.getElementById('Upload');
 	const checkFile = () => (uploadButton.disabled = file.value === '');

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -35,7 +35,7 @@
 			if (
 				numSelected === 0 ||
 				numSelected > 1 ||
-				!/\.(tar|tar\.gz|tgz)$/.test(files.children[files.selectedIndex].value)
+				!/\.(tar|tar\.gz|tgz|zip)$/.test(files.children[files.selectedIndex].value)
 			)
 				archiveButton.value = archiveButton.dataset.archiveText;
 			else archiveButton.value = archiveButton.dataset.unarchiveText;

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -43,19 +43,17 @@
 	};
 
 	// Used for the archive subpage to highlight all in the Select
-	const selectAllButton = document.getElementById('select-all-files-button');
-	selectAllButton?.addEventListener('click', () => {
-		const n = document.getElementById('archive-files').options.length;
-		for (const opt of document.getElementById('archive-files').options) {
-			opt.selected = 'selected';
+	document.getElementById('select-all-files-button')?.addEventListener('click', () => {
+		for (const option of document.getElementById('archive-files').options) {
+			option.selected = 'selected';
 		}
 	});
 
-
-	for (const r of document.querySelectorAll('input[name="archive_type"]')) {
-		r.addEventListener('click', () => {
-			const suffix = document.querySelector('input[name="archive_type"]:checked').value;
-			document.getElementById('filename_suffix').innerText = '.' + suffix;
+	for (const archiveTypeInput of document.querySelectorAll('input[name="archive_type"]')) {
+		archiveTypeInput.addEventListener('click', () => {
+			document.getElementById('filename_suffix').innerText = `.${
+				document.querySelector('input[name="archive_type"]:checked').value
+			}`;
 		});
 	}
 

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -42,13 +42,6 @@
 		}
 	};
 
-	// Used for the archive subpage to highlight all in the Select
-	document.getElementById('select-all-files-button')?.addEventListener('click', () => {
-		for (const option of document.getElementById('archive-files').options) {
-			option.selected = 'selected';
-		}
-	});
-
 	for (const archiveTypeInput of document.querySelectorAll('input[name="archive_type"]')) {
 		archiveTypeInput.addEventListener('click', () => {
 			document.getElementById('filename_suffix').innerText = `.${

--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -42,6 +42,23 @@
 		}
 	};
 
+	// Used for the archive subpage to highlight all in the Select
+	const selectAllButton = document.getElementById('select-all-files-button');
+	selectAllButton?.addEventListener('click', () => {
+		const n = document.getElementById('archive-files').options.length;
+		for (const opt of document.getElementById('archive-files').options) {
+			opt.selected = 'selected';
+		}
+	});
+
+
+	for (const r of document.querySelectorAll('input[name="archive_type"]')) {
+		r.addEventListener('click', () => {
+			const suffix = document.querySelector('input[name="archive_type"]:checked').value;
+			document.getElementById('filename_suffix').innerText = '.' + suffix;
+		});
+	}
+
 	files?.addEventListener('change', checkFiles);
 	if (files) checkFiles();
 

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -456,7 +456,7 @@ h2.page-title {
 	gap: 0.25rem;
 	margin: 0 0 0.5rem;
 
-	p {
+	div {
 		margin: 0;
 	}
 }

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -265,8 +265,9 @@ message() template escape handler.
 
 sub addgoodmessage ($c, $message) {
 	$c->addmessage($c->tag(
-		'p',
+		'div',
 		class => 'alert alert-success alert-dismissible fade show ps-1 py-1',
+		role  => 'alert',
 		$c->c(
 			$message,
 			$c->tag(
@@ -290,8 +291,9 @@ message() template escape handler.
 
 sub addbadmessage ($c, $message) {
 	$c->addmessage($c->tag(
-		'p',
+		'div',
 		class => 'alert alert-danger alert-dismissible fade show ps-1 py-1',
+		role  => 'alert',
 		$c->c(
 			$message,
 			$c->tag(

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -362,12 +362,7 @@ sub MakeArchive ($c) {
 		return $c->Refresh if $action eq 'Cancel' || $action eq $c->maketext('Cancel');
 
 		unless ($c->param('archive_filename')) {
-			$c->addbadmessage($c->maketext('The filename cannot be empty.'));
-			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
-		}
-
-		unless (@files > 0) {
-			$c->addbadmessage($c->maketext('At least one file must be selected'));
+			$c->addbadmessage($c->maketext('The archive filename cannot be empty.'));
 			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
 		}
 
@@ -384,11 +379,26 @@ sub MakeArchive ($c) {
 			$archive =~ s/(\.zip)?$/.tgz/ unless $archive =~ /\.(tgz|tar.gz)$/;
 		}
 
+		# Check filename validity.
+		if ($archive =~ m!/!) {
+			$c->addbadmessage($c->maketext('The archive filename may not contain a path component'));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+		if ($archive =~ m!^\.! || $archive =~ m![^-_.a-zA-Z0-9 ]!) {
+			$c->addbadmessage($c->maketext('The archive filename contains illegal characters'));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+
 		if (-e "$dir/$archive" && !$c->param('overwrite')) {
 			$c->addbadmessage($c->maketext(
 				'The file [_1] exists. Check "Overwrite existing archive" to force this file to be replaced.',
 				$archive
 			));
+			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
+		}
+
+		unless (@files > 0) {
+			$c->addbadmessage($c->maketext('At least one file must be selected'));
 			return $c->include('ContentGenerator/Instructor/FileManager/archive', dir => $dir, files => \@files);
 		}
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -81,6 +81,7 @@ our @EXPORT_OK = qw(
 	list2hash
 	listFilesRecursive
 	makeTempDirectory
+	min
 	max
 	nfreeze_base64
 	not_blank
@@ -1049,15 +1050,22 @@ sub thaw_base64 {
 
 }
 
-sub max(@) {
-	my $soFar;
-	foreach my $item (@_) {
-		$soFar = $item unless defined $soFar;
-		if ($item > $soFar) {
-			$soFar = $item;
-		}
+sub min {
+	my @items = @_;
+	my $min   = (shift @items) // 0;
+	for my $item (@items) {
+		$min = $item if ($item < $min);
 	}
-	return defined $soFar ? $soFar : 0;
+	return $min;
+}
+
+sub max {
+	my @items = @_;
+	my $max   = (shift @items) // 0;
+	for my $item (@items) {
+		$max = $item if ($item > $max);
+	}
+	return $max;
 }
 
 sub wwRound(@) {

--- a/templates/ContentGenerator/Instructor/FileManager.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager.html.ep
@@ -44,7 +44,6 @@
 		% x('Make Archive')   => 'MakeArchive',
 		% x('Unpack Archive') => 'UnpackArchive',
 		% x('Archive Course') => 'Refresh',
-		% x('Create Archive') => 'CreateArchive'
 	% );
 	%
 	% # Add translated action names to the method map.

--- a/templates/ContentGenerator/Instructor/FileManager.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager.html.ep
@@ -44,6 +44,7 @@
 		% x('Make Archive')   => 'MakeArchive',
 		% x('Unpack Archive') => 'UnpackArchive',
 		% x('Archive Course') => 'Refresh',
+		% x('Create Archive') => 'CreateArchive'
 	% );
 	%
 	% # Add translated action names to the method map.

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -12,9 +12,9 @@
 					<label class="input-group-text" for="archive-filename"><%= maketext('Archive Filename') %>:</label>
 					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
 						id => 'archive-filename', placeholder => maketext('Archive Filename'),
-						class => 'form-control', size => 30 =%>
+						class => 'form-control text-end', size => 30 =%>
 					<%= select_field archive_type => [
-							[ 'File Type' => '', disabled => undef, id => 'archive-type-label' ],
+							[ maketext('Archive Type') => '', disabled => undef, id => 'archive-type-label' ],
 							[ '.zip' => 'zip', selected => undef ],
 							[ '.tgz' => 'tgz' ]
 						],

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -1,16 +1,16 @@
 % use Mojo::File qw(path);
 %
-<div class="card mx-auto mb-2" style="max-width:700px">
+<div class="card mb-2" style="max-width:700px">
 	<div class="card-body">
 		<div class="mb-3">
-			<b><%= maketext('The following files have been selected for archiving.  Select the type '
-				. 'of archive and any subset of the requested files.') =%></b>
+			<%= maketext('The following files have been selected for archiving.  Select the type '
+				. 'of archive and any subset of the requested files.') =%>
 		</div>
 		<div class="row">
 			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
-					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : '',
+					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
 						'aria-labelledby' => 'archive_filename', placeholder => maketext('Archive Filename'),
 						class => 'form-control', size => 30 =%>
 					<span class="input-group-text" id="filename_suffix">.zip</span>
@@ -42,13 +42,6 @@
 						</label>
 					</div>
 				</div>
-			</div>
-		</div>
-		<div class="row mb-2">
-			<div class="col-12">
-				<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
-					<%= maketext('Select All Files') =%>
-				</button>
 			</div>
 		</div>
 		%

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -11,7 +11,7 @@
 				<div class="input-group input-group-sm mb-2">
 					<label class="input-group-text" for="archive-filename"><%= maketext('Archive Filename') %>:</label>
 					<%= text_field archive_filename =>
-							@$files == 1 ? $files->[0] =~ s/\..*$/.zip/r : 'webwork_files.zip',
+							@$files == 1 ? $files->[0] =~ s/(\..*)?$/.zip/r : 'webwork_files.zip',
 						id => 'archive-filename', placeholder => maketext('Archive Filename'),
 						class => 'form-control', size => 30, dir => 'ltr' =%>
 				</div>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -52,7 +52,7 @@
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
 		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
-			'arialabelled-by' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
+			'aria-labelledby' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
 		%
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -1,6 +1,6 @@
 % use Mojo::File qw(path);
 %
-<div class="card mx-auto" style="max-width:700px">
+<div class="card mx-auto mb-2" style="max-width:700px">
 	<div class="card-body">
 		<div class="mb-3">
 			<b><%= maketext('The following files have been selected for archiving.  Select the type '
@@ -10,7 +10,7 @@
 			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
-					<%= text_field archive_filename => '',
+					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : '',
 						'aria-labelledby' => 'archive_filename', placeholder => maketext('Archive Filename'),
 						class => 'form-control', size => 30 =%>
 					<span class="input-group-text" id="filename_suffix">.zip</span>
@@ -32,6 +32,18 @@
 				</div>
 			</div>
 		</div>
+		<div class="row">
+			<div class="col-md-12">
+				<div class="input-group input-group-sm mb-2">
+					<div class="input-group-text flex-grow-1">
+						<label class="form-check-label">
+							<%= check_box overwrite => 1, class => 'form-check-input me-2' =%>
+							<%= maketext('Overwrite existing archive') =%>
+						</label>
+					</div>
+				</div>
+			</div>
+		</div>
 		<div class="row mb-2">
 			<div class="col-12">
 				<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
@@ -49,7 +61,7 @@
 		% }
 		%
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
-		% param('files', \@files_to_compress);
+		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
 			size => 20, multiple => undef =%>
 		%

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -44,7 +44,7 @@
 		% for my $file (@$files) {
 			% push(@files_to_compress, $file);
 			% my $path = path("$dir/$file");
-			% push(@files_to_compress, @{ $path->list_tree({ hidden => 1 })->map('to_rel', $dir) })
+			% push(@files_to_compress, @{ $path->list_tree({ dir => 1, hidden => 1 })->map('to_rel', $dir) })
 				% if (-d $path && !-l $path);
 		% }
 		%

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -56,7 +56,7 @@
 		<p><%= maketext('Create the archive of the select files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
-			<%= submit_button maketext('Create Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>
+			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -2,18 +2,23 @@
 %
 <div class="card mb-2" style="max-width:700px">
 	<div class="card-body">
-		<div class="mb-3">
+		<div class="mb-3" id="files-label">
 			<%= maketext('The following files have been selected for archiving.  Select the type '
 				. 'of archive and any subset of the requested files.') =%>
 		</div>
 		<div class="row">
 			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
-					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
+					<label class="input-group-text" for="archive-filename"><%= maketext('Archive Filename') %>:</label>
 					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
-						'aria-labelledby' => 'archive_filename', placeholder => maketext('Archive Filename'),
+						id => 'archive-filename', placeholder => maketext('Archive Filename'),
 						class => 'form-control', size => 30 =%>
-					<%= select_field archive_type => ['zip', 'tgz'], class => 'form-select' =%>
+					<%= select_field archive_type => [
+							[ 'File Type' => '', disabled => undef, id => 'archive-type-label' ],
+							[ '.zip' => 'zip', selected => undef ],
+							[ '.tgz' => 'tgz' ]
+						],
+						class => 'form-select', style => 'max-width: 7em', 'aria-labelledby' => 'archive-type-label' =%>
 				</div>
 			</div>
 		</div>
@@ -41,9 +46,9 @@
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
 		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
-			size => 20, multiple => undef =%>
+			'arialabelled-by' => 'files-label', size => 20, multiple => undef =%>
 		%
-		<p><%= maketext('Create the archive of the select files?') %></p>
+		<p><%= maketext('Create archive of the selected files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
 			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -10,20 +10,26 @@
 			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<label class="input-group-text" for="archive-filename"><%= maketext('Archive Filename') %>:</label>
-					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
+					<%= text_field archive_filename =>
+							@$files == 1 ? $files->[0] =~ s/\..*$/.zip/r : 'webwork_files.zip',
 						id => 'archive-filename', placeholder => maketext('Archive Filename'),
-						class => 'form-control text-end', size => 30 =%>
-					<%= select_field archive_type => [
-							[ maketext('Archive Type') => '', disabled => undef, id => 'archive-type-label' ],
-							[ '.zip' => 'zip', selected => undef ],
-							[ '.tgz' => 'tgz' ]
-						],
-						class => 'form-select', style => 'max-width: 7em', 'aria-labelledby' => 'archive-type-label' =%>
+						class => 'form-control', size => 30, dir => 'ltr' =%>
 				</div>
 			</div>
 		</div>
 		<div class="row">
-			<div class="col-md-12">
+			<div class="col-12 col-lg-6">
+				<div class="input-group input-group-sm mb-2">
+					<label class="input-group-text" for="archive-type"><%= maketext('Archive Type') %>:</label>
+					<%= select_field archive_type => [
+							[ maketext('By extension') => '', selected => undef ],
+							[ 'zip'                    => 'zip' ],
+							[ 'tar'                    => 'tgz' ]
+						],
+						class => 'form-select', id => 'archive-type' =%>
+				</div>
+			</div>
+			<div class="col-12 col-lg-6">
 				<div class="input-group input-group-sm mb-2">
 					<div class="input-group-text flex-grow-1">
 						<label class="form-check-label">
@@ -46,9 +52,8 @@
 		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
 		% param('files', \@files_to_compress) unless param('confirmed');
 		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
-			'arialabelled-by' => 'files-label', size => 20, multiple => undef =%>
+			'arialabelled-by' => 'files-label', size => 20, multiple => undef, dir => 'ltr' =%>
 		%
-		<p><%= maketext('Create archive of the selected files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
 			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -56,7 +56,7 @@
 		<p><%= maketext('Create the archive of the select files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
-			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>
+			<%= submit_button maketext('Create Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -13,22 +13,7 @@
 					<%= text_field archive_filename => @$files == 1 ? $files->[0] =~ s/\..*$//r : 'webwork_files',
 						'aria-labelledby' => 'archive_filename', placeholder => maketext('Archive Filename'),
 						class => 'form-control', size => 30 =%>
-					<span class="input-group-text" id="filename_suffix">.zip</span>
-				</div>
-			</div>
-		</div>
-		<div class="row">
-			<div class="input-group input-group-sm mb-2">
-				<span class="input-group-text"><%= maketext('Archive Type') %>:</span>
-				<div class="input-group-text flex-grow-1">
-					<label class="form-check-label me-2">
-						<%= radio_button archive_type => 'zip', checked => undef, class => 'form-check-input mx-1' =%>
-						<%= maketext('Zip File') =%>
-					</label>
-					<label class="form-check-label">
-						<%= radio_button archive_type => 'tgz', class => 'form-check-input mx-1' =%>
-						<%= maketext('Compressed Tar') =%>
-					</label>
+					<%= select_field archive_type => ['zip', 'tgz'], class => 'form-select' =%>
 				</div>
 			</div>
 		</div>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -1,0 +1,62 @@
+% # template for the archive subpage.
+<div class="card w-75 mx-auto">
+	<div class="card-body">
+		<div class="mb-3">
+			<b><%= maketext('The following files have been selected for archiving.  Select the type '
+				. 'of archive and any subset of the requested files.') =%> </b>
+		</div>
+		<div class="row">
+		  <div class="col-4">
+				<div class="input-group input-group-sm mb-2">
+					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
+					<%= text_field archive_filename => '',
+						'aria-labelledby' => 'archive_filename', placeholder => maketext('Archive Filename'),
+						class => 'form-control', size => 30 =%>
+					<span class="input-group-text" id="filename_suffix">.zip</span>
+				</div>
+			</div>
+		</div>
+		<div class="row">
+			<div class="input-group input-group-sm mb-2">
+				<span class="input-group-text"><%= maketext('Archive Type') %>:</span>
+				<div class="input-group-text flex-grow-1">
+					<label class="form-check-label me-4">
+						<%= radio_button archive_type => 'zip', checked => undef, class => 'form-check-input mx-1' =%>
+						<%= maketext('Zip File') =%>
+					</label>
+					<label class="form-check-label me-4">
+						<%= radio_button archive_type => 'tgz', class => 'form-check-input mx-1' =%>
+						<%= maketext('Compressed Tar') =%>
+					</label>
+					<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
+						<%= maketext('Select All Files') =%>
+					</button>
+				</div>
+			</div>
+		</div>
+
+
+		% my @files_to_compress;
+		% chdir($dir);
+		% for my $f (@$files) {
+		% 	push(@files_to_compress, glob("$f/**")) if -d $f;
+		% 	push(@files_to_compress, $f)            if -f $f;
+		% }
+		% # remove any directories
+		% @files_to_compress = grep { -f $_ } @files_to_compress;
+
+		<%= select_field files => \@files_to_compress,
+					id    => 'archive-files',
+					class => 'form-select',
+					size => 20,
+					multiple => undef
+				=%>
+
+		<p><%= maketext('Create the archive of the select files?') %></p>
+		<div class="d-flex justify-content-evenly">
+			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
+			<%= submit_button maketext('Make Archive'), name => 'action', class => 'btn btn-sm btn-primary' =%>
+		</div>
+	</div>
+</div>
+<%= $c->HiddenFlags =%>

--- a/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/archive.html.ep
@@ -1,12 +1,13 @@
-% # template for the archive subpage.
-<div class="card w-75 mx-auto">
+% use Mojo::File qw(path);
+%
+<div class="card mx-auto" style="max-width:700px">
 	<div class="card-body">
 		<div class="mb-3">
 			<b><%= maketext('The following files have been selected for archiving.  Select the type '
-				. 'of archive and any subset of the requested files.') =%> </b>
+				. 'of archive and any subset of the requested files.') =%></b>
 		</div>
 		<div class="row">
-		  <div class="col-4">
+			<div class="col-12">
 				<div class="input-group input-group-sm mb-2">
 					<span class="input-group-text"><%= maketext('Archive Filename') %>:</span>
 					<%= text_field archive_filename => '',
@@ -20,38 +21,38 @@
 			<div class="input-group input-group-sm mb-2">
 				<span class="input-group-text"><%= maketext('Archive Type') %>:</span>
 				<div class="input-group-text flex-grow-1">
-					<label class="form-check-label me-4">
+					<label class="form-check-label me-2">
 						<%= radio_button archive_type => 'zip', checked => undef, class => 'form-check-input mx-1' =%>
 						<%= maketext('Zip File') =%>
 					</label>
-					<label class="form-check-label me-4">
+					<label class="form-check-label">
 						<%= radio_button archive_type => 'tgz', class => 'form-check-input mx-1' =%>
 						<%= maketext('Compressed Tar') =%>
 					</label>
-					<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
-						<%= maketext('Select All Files') =%>
-					</button>
 				</div>
 			</div>
 		</div>
-
-
+		<div class="row mb-2">
+			<div class="col-12">
+				<button type="button" class="btn btn-sm btn-secondary" id="select-all-files-button">
+					<%= maketext('Select All Files') =%>
+				</button>
+			</div>
+		</div>
+		%
 		% my @files_to_compress;
-		% chdir($dir);
-		% for my $f (@$files) {
-		% 	push(@files_to_compress, glob("$f/**")) if -d $f;
-		% 	push(@files_to_compress, $f)            if -f $f;
+		% for my $file (@$files) {
+			% push(@files_to_compress, $file);
+			% my $path = path("$dir/$file");
+			% push(@files_to_compress, @{ $path->list_tree({ hidden => 1 })->map('to_rel', $dir) })
+				% if (-d $path && !-l $path);
 		% }
-		% # remove any directories
-		% @files_to_compress = grep { -f $_ } @files_to_compress;
-
-		<%= select_field files => \@files_to_compress,
-					id    => 'archive-files',
-					class => 'form-select',
-					size => 20,
-					multiple => undef
-				=%>
-
+		%
+		% # Select all files initially. Even those that are in previously selected directories or subdirectories.
+		% param('files', \@files_to_compress);
+		<%= select_field files => \@files_to_compress, id => 'archive-files', class => 'form-select mb-2',
+			size => 20, multiple => undef =%>
+		%
 		<p><%= maketext('Create the archive of the select files?') %></p>
 		<div class="d-flex justify-content-evenly">
 			<%= submit_button maketext('Cancel'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
@@ -59,4 +60,5 @@
 		</div>
 	</div>
 </div>
+<%= hidden_field confirmed => 'MakeArchive' =%>
 <%= $c->HiddenFlags =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -34,7 +34,7 @@
 			dir => 'ltr', size => 17, multiple => undef =%>
 	</div>
 	<div class="col-md-4 mb-2">
-		<div class="d-md-flex flex-column justify-content-evenly">
+		<div class="d-flex flex-md-column flex-wrap flex-md-nowrap justify-content-evenly gap-1 gap-md-0">
 			<%= submit_button maketext('View'), id => 'View', %button =%>
 			<%= submit_button maketext('Edit'), id => 'Edit', %button =%>
 			<%= submit_button maketext('Download'), id => 'Download', %button =%>
@@ -50,7 +50,7 @@
 			% unless ($c->{courseName} eq 'admin') {
 				<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
 			% }
-			<div style="height: 10px"></div>
+			<div class="d-none d-md-block" style="height: 10px"></div>
 			<%= submit_button maketext('New File'), id => 'NewFile', %button =%>
 			<%= submit_button maketext('New Folder'), id => 'NewFolder', %button =%>
 			<%= submit_button maketext('Refresh'), id => 'Refresh', %button =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -40,7 +40,15 @@
 			<%= submit_button maketext('Download'), id => 'Download', %button =%>
 			<%= submit_button maketext('Rename'), id => 'Rename', %button =%>
 			<%= submit_button maketext('Copy'), id => 'Copy', %button =%>
-			<%= submit_button maketext('Delete'), id => 'Delete', %button =%>\
+			<%= submit_button maketext('Delete'), id => 'Delete', %button =%>
+			<div style="padding-top: 10px"></div>
+			<%= label_for archive_type => maketext('Archive Type'), class => 'col-auto col-form-label fw-bold' =%>
+			<div class="col-auto">
+				<%= select_field archive_type => [ [ 'Zip File' => 'zip'], ['Compressed Tar' => 'tgz'] ],
+					id    => 'archive-type',
+					class => 'form-select',
+				=%>
+			</div>
 			<%= submit_button maketext('Make Archive'), id => 'MakeArchive',
 				data => {
 					archive_text   => maketext('Make Archive'),

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -41,14 +41,6 @@
 			<%= submit_button maketext('Rename'), id => 'Rename', %button =%>
 			<%= submit_button maketext('Copy'), id => 'Copy', %button =%>
 			<%= submit_button maketext('Delete'), id => 'Delete', %button =%>
-			<div style="padding-top: 10px"></div>
-			<%= label_for archive_type => maketext('Archive Type'), class => 'col-auto col-form-label fw-bold' =%>
-			<div class="col-auto">
-				<%= select_field archive_type => [ [ 'Zip File' => 'zip'], ['Compressed Tar' => 'tgz'] ],
-					id    => 'archive-type',
-					class => 'form-select',
-				=%>
-			</div>
 			<%= submit_button maketext('Make Archive'), id => 'MakeArchive',
 				data => {
 					archive_text   => maketext('Make Archive'),

--- a/templates/HelpFiles/InstructorFileManager.html.ep
+++ b/templates/HelpFiles/InstructorFileManager.html.ep
@@ -18,8 +18,8 @@
 %
 <p>
 	<%= maketext('This allows for the viewing, downloading, uploading and other management '
-		. 'of files in the course.  Select a file or set of files (using CTRL or SHIFT) and click '
-		. 'the desired button on the right.  Many actions can only be done with a single file (like '
+		. 'of files in the course. Select a file or set of files (using CTRL or SHIFT) and click '
+		. 'the desired button on the right. Many actions can only be done with a single file (like '
 		. 'view). Selecting a directory or set of files and clicking "Make Archive" allows the creation '
 		. 'of a compressed tar or zip file.') =%>
 </p>
@@ -29,14 +29,13 @@
 </p>
 <p>
 	<%= maketext('Below the file list is a button and options for uploading files. Click the "Choose File" '
-		. 'button, select the file, then click "Upload". '
-		. 'A single file or a compressed tar (.tgz) file can be uploaded and if the option is selected, '
-		. 'the archive is automatically unpacked and deleted.  Generally the "automatic" option on Format '
-		. 'will correctly pick the correct type of file.') =%>
+		. 'button, select the file, then click "Upload". Generally the "automatic" option on Format will '
+		. 'correctly pick the correct type of file. A single file or a compressed tar (.tgz) file can be '
+		. 'uploaded and if the options are selected, the archive is automatically unpacked and deleted.') =%>
 </p>
 <p>
-	<%= maketext('WeBWorK expects many files to be in certain locations.  The following describe this. '
-	. 'Note that by default the File Manager shows the "templates" directory.  Other directories mentioned '
+	<%= maketext('WeBWorK expects many files to be in certain locations. The following describe this. '
+	. 'Note that by default the File Manager shows the "templates" directory. Other directories mentioned '
 	. 'below are at the same level and need to be accessed by going up a directory by clicking the "^" button '
 	. 'above the file list.') =%>
 </p>
@@ -48,7 +47,7 @@
 			. '<strong>Set Definition files</strong> is described in the <a [_1]>Set Definition specification</a>. '
 			. 'Set definition files are mainly useful for '
 			. 'transferring set assignments from one course to another and are created when exporting a problem '
-			. 'set from the "Hmwk Sets Editor".  Each set defintion file contains a list of problems used and the '
+			. 'set from the "Hmwk Sets Editor". Each set defintion file contains a list of problems used and the '
 			. 'dates and times. These definitions can be imported into the current course.',
 			'href="https://webwork.maa.org/wiki/Set_Definition_Files" target="Webworkdocs"') =%>
 	</dd>
@@ -58,10 +57,10 @@
 			. 'a large number of students into your class. To view the format for <strong>ClassList files</strong> see '
 			. 'the <a [_1]>ClassList specification</a> or download the [_2] file and use it as a model. '
 			. 'ClassList files can be prepared using a spreadsheet and then saved as [_3] (comma separated values) '
-			. 'text files.  However, to access as a classlist file, the file suffix needs to be changed to [_4], '
+			. 'text files. However, to access as a classlist file, the file suffix needs to be changed to [_4], '
 			. 'which can be done with the "Rename" button.',
 			'href="http://webwork.maa.org/wiki/Classlist_Files#Format_of_classlist_files" target="Webworkdocs"',
-			'<code>demoCourse.lst</code>','<code>.csv</code>','<code>.lst</code>') =%>
+			'<code>demoCourse.lst</code>', '<code>.csv</code>', '<code>.lst</code>') =%>
 	</dd>
 	<dt><%= maketext('Scoring (".csv") files') %></dt>
 	<dd>

--- a/templates/HelpFiles/InstructorFileManager.html.ep
+++ b/templates/HelpFiles/InstructorFileManager.html.ep
@@ -20,8 +20,8 @@
 	<%= maketext('This allows for the viewing, downloading, uploading and other management '
 		. 'of files in the course.  Select a file or set of files (using CTRL or SHIFT) and click '
 		. 'the desired button on the right.  Many actions can only be done with a single file (like '
-		. 'view). Selecting a directory or set of files and clicking "Make Archive" creates a compressed '
-		. 'tar file with the name COURSE_NAME.tgz' ) =%>
+		. 'view). Selecting a directory or set of files and clicking "Make Archive" allows the creation '
+		. 'of a compressed tar or zip file.') =%>
 </p>
 <p>
 	<%= maketext('The list of files include regular files, directories (ending in a "/") '


### PR DESCRIPTION
This adds the ability to use zip/unzip for archiving/unarchiving in the File Manager.  

Those on both Mac and PCs have zip/unzip ability more than a tar.gz file, so will increase the access to do handle archives. 

This currently has the ability to unarchive zip files in the File Manager, but not yet archive them.  I've been wondering about the UI to do this.  Some of my thoughts are
1. a course configuration to toggle between zip and tar.gz files.  Then "Make Archive" will use the desired method. 
2. Have a bootstrap dropdown button https://getbootstrap.com/docs/5.2/components/dropdowns/ that toggles between the two methods.  
3. Replace "Make Archive" with two buttons, "Make ZIP archive" and "Make tar.gz archive.  (not a fan of this)



