### PR TITLE
Quick fix for the new hardcopyThemes dir (hotfix).

### DIFF
--- a/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
@@ -338,7 +338,7 @@ sub updateCourseDirectories {
 	my @courseDirectories = keys %{ $ce->{courseDirs} };
 
 	#FIXME this is hardwired for the time being.
-	my %updateable_directories = (html_temp => 1, mailmerge => 1, tmpEditFileDir => 1);
+	my %updateable_directories = (html_temp => 1, mailmerge => 1, tmpEditFileDir => 1, hardcopyThemes => 1);
 
 	my @messages;
 


### PR DESCRIPTION
This simply adds the hardcopyThemes dir to the list of "updateable" directories.  That means that the directory will be created if it does not exist when a course is upgraded.

This is a quick fix that should be sufficient for a hotfix to main to fix the issue of this directory that all courses from old releases won't have.

The plan is to do much better for the next release.  Any missing directory (other than root) should either be copied from the model course if that directory exists (as is currently done for the achievements directory) or the directory should simple be created.  Care needs to be taken on the order that this is done for the directories due to nesting.