### PR TITLE
Quick fix for the new hardcopyThemes dir.

### DIFF
--- a/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseIntegrityCheck.pm
@@ -338,7 +338,7 @@ sub updateCourseDirectories {
 	my @courseDirectories = keys %{ $ce->{courseDirs} };
 
 	#FIXME this is hardwired for the time being.
-	my %updateable_directories = (html_temp => 1, mailmerge => 1, tmpEditFileDir => 1);
+	my %updateable_directories = (html_temp => 1, mailmerge => 1, tmpEditFileDir => 1, hardcopyThemes => 1);
 
 	my @messages;
 


### PR DESCRIPTION
This simply adds the hardcopyThemes dir to the list of "updateable" directories.

This is just to ensure this gets into develop for now.  Not the planned proper update outlined in #2170.