### PR TITLE
remove references to external programs in favor of packages

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,6 +65,7 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
+	Archive::Tar
 	Archive::Zip
 	Archive::Zip::SimpleZip
 	Array::Utils

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,6 +65,7 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
+	Archive::Zip
 	Archive::Zip::SimpleZip
 	Array::Utils
 	Benchmark

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -65,7 +65,6 @@ my @applicationsList = qw(
 );
 
 my @modulesList = qw(
-	Archive::Zip
 	Archive::Zip::SimpleZip
 	Array::Utils
 	Benchmark

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -92,6 +92,7 @@ my @modulesList = qw(
 	Errno
 	Exception::Class
 	File::Copy
+	File::Copy::Recursive
 	File::Fetch
 	File::Find
 	File::Find::Rule

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -9,7 +9,7 @@ use warnings;
 use File::Fetch;
 use File::Copy;
 use File::Path;
-use Archive::Extract;
+use Archive::Tar;
 use Mojo::File;
 use JSON;
 
@@ -54,9 +54,11 @@ my $releaseDownloadFF = File::Fetch->new(uri => $downloadURL);
 my $releaseFile       = $releaseDownloadFF->fetch(to => $ce->{webworkDirs}{tmp}) or die $releaseDownloadFF->error;
 say 'Downloaded release archive, now extracting.';
 
-my $arch = Archive::Extract->new(archive => "$releaseFile");
-my $ok   = $arch->extract(to => $ce->{webworkDirs}{tmp});
-die "There was an error extracting the release: $arch->error" unless $ok;
+my $arch = Archive::Tar->new($releaseFile);
+die "An error occurred while creating the tar file: $releaseFile" unless $arch;
+$arch->setcwd($path);
+$arch->extract();
+die "There was an error extracting the metadata release: $arch->error" if $arch->error;
 
 # Copy the json files into htdocs.
 for (glob("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/JSON-SAVED/*.json")) {

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -9,6 +9,7 @@ use warnings;
 use File::Fetch;
 use File::Copy;
 use File::Path;
+use Archive::Extract;
 use Mojo::File;
 use JSON;
 
@@ -53,8 +54,9 @@ my $releaseDownloadFF = File::Fetch->new(uri => $downloadURL);
 my $releaseFile       = $releaseDownloadFF->fetch(to => $ce->{webworkDirs}{tmp}) or die $releaseDownloadFF->error;
 say 'Downloaded release archive, now extracting.';
 
-`$ce->{externalPrograms}{tar} xzf $releaseFile -C $ce->{webworkDirs}{tmp}`;
-die "There was an error extracting the release: $!" if $?;
+my $arch = Archive::Extract->new(archive => "$releaseFile");
+my $ok   = $arch->extract(to => $ce->{webworkDirs}{tmp});
+die "There was an error extracting the release: $arch->error" unless $ok;
 
 # Copy the json files into htdocs.
 for (glob("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/JSON-SAVED/*.json")) {

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -92,8 +92,9 @@ $admin_course_id = 'admin';
 ####################################################
 # system utilities
 ####################################################
+$externalPrograms{tar} = "/bin/tar";
 $externalPrograms{git} = "/usr/bin/git";
-$externalPrograms{tar}   = "/bin/tar";
+
 
 ####################################################
 # equation rendering/hardcopy utiltiies

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -92,7 +92,6 @@ $admin_course_id = 'admin';
 ####################################################
 # system utilities
 ####################################################
-$externalPrograms{tar}   = "/bin/tar";
 $externalPrograms{git} = "/usr/bin/git";
 
 ####################################################

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -93,6 +93,7 @@ $admin_course_id = 'admin';
 # system utilities
 ####################################################
 $externalPrograms{git} = "/usr/bin/git";
+$externalPrograms{tar}   = "/bin/tar";
 
 ####################################################
 # equation rendering/hardcopy utiltiies

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -92,13 +92,8 @@ $admin_course_id = 'admin';
 ####################################################
 # system utilities
 ####################################################
-$externalPrograms{mv}    = "/bin/mv";
-$externalPrograms{cp}    = "/bin/cp";
-$externalPrograms{rm}    = "/bin/rm";
-$externalPrograms{mkdir} = "/bin/mkdir";
 $externalPrograms{tar}   = "/bin/tar";
-$externalPrograms{gzip}  = "/bin/gzip";
-$externalPrograms{git}   = "/usr/bin/git";
+$externalPrograms{git} = "/usr/bin/git";
 
 ####################################################
 # equation rendering/hardcopy utiltiies

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -50,7 +50,7 @@ sub hardcopyRenderedProblem {
 	my $userID   = $ws->{inputs_ref}{user};
 
 	# Create the parent directory for the temporary working directory.
-	my $temp_dir_parent_path = Mojo::File->new("$ce->{webworkDirs}{tmp}/$courseID/hardcopy/$userID");
+	my $temp_dir_parent_path = path("$ce->{webworkDirs}{tmp}/$courseID/hardcopy/$userID");
 	eval { $temp_dir_parent_path->make_path };
 	if ($@) {
 		push(@errors, "Couldn't create hardcopy directory $temp_dir_parent_path: $@");
@@ -127,19 +127,19 @@ sub generate_hardcopy_tex {
 
 	# Copy the common tex files into the working directory
 	my $ce            = $ws->c->ce;
-	my $assetsTex_dir = Mojo::File->new($ce->{webworkDirs}{assetsTex});
+	my $assetsTex_dir = path($ce->{webworkDirs}{assetsTex});
 	for (qw{webwork2.sty webwork_logo.png}) {
 		eval { $assetsTex_dir->child($_)->copy_to($working_dir) };
 		push(@$errors, qq{Failed to copy "$ce->{webworkDirs}{assetsTex}/$_" into directory "$working_dir": $@})
 			if $@;
 	}
-	my $pgAssetsTex_dir = Mojo::File->new($ce->{pg}{directories}{assetsTex});
+	my $pgAssetsTex_dir = path($ce->{pg}{directories}{assetsTex});
 	for (qw{pg.sty PGML.tex CAPA.tex}) {
 		eval { $pgAssetsTex_dir->child($_)->copy_to($working_dir) };
 		push(@$errors, qq{Failed to copy "$ce->{pg}{directories}{assetsTex}/$_" into directory "$working_dir": $@})
 			if $@;
 	}
-	my $pgsty = Mojo::File->new("$ce->{pg}{directories}{assetsTex}/pg.sty");
+	my $pgsty = path("$ce->{pg}{directories}{assetsTex}/pg.sty");
 	eval { $pgsty->copy_to($working_dir) };
 	push(@$errors, qq{Failed to copy "$ce->{pg}{directories}{assetsTex}/pg.sty" into directory "$working_dir": $@})
 		if $@;
@@ -150,7 +150,7 @@ sub generate_hardcopy_tex {
 		my $data = eval { $src_file->slurp };
 		unless ($@) {
 			for my $resource (keys %$resource_list) {
-				my $file_path = Mojo::File->new($resource_list->{$resource});
+				my $file_path = path($resource_list->{$resource});
 				$data =~ s{$file_path}{$file_path->basename}ge;
 
 				eval { $file_path->copy_to($working_dir) };

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -172,9 +172,12 @@ sub generate_hardcopy_tex {
 	push(@$errors, "Failed to generate error log file: $@")                                     if $@;
 
 	# Create a zip archive of the bundle directory
-	my $zip = Archive::Zip::SimpleZip->new($working_dir->dirname->child('hardcopy.zip')->to_string);
-	$zip->add($working_dir->dirname->to_string, storelinks => 1);
-
+	my $zip;
+	eval {
+		$zip = Archive::Zip::SimpleZip->new($working_dir->dirname->child('hardcopy.zip')->to_string);
+		$zip->add($working_dir->dirname->to_string, storelinks => 1);
+	};
+	push(@$errors, $@) if $@;
 	push(@$errors, qq{Failed to create zip archive of directory "$working_dir": $SimpleZipError}) unless ($zip->close);
 
 	return;

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -175,6 +175,7 @@ sub generate_hardcopy_tex {
 
 	push(@$errors, qq{Failed to create zip archive of directory "$working_dir"})
 		unless ($zip->writeToFileNamed($working_dir->dirname->child('hardcopy.zip')->to_string) == AZ_OK);
+
 	return;
 }
 

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -28,7 +28,7 @@ use warnings;
 
 use File::Path;
 use String::ShellQuote;
-use Archive::Zip qw(:ERROR_CODES);
+use Archive::Zip::SimpleZip qw($SimpleZipError);
 use Mojo::File qw(path tempdir);
 use XML::LibXML;
 
@@ -172,11 +172,10 @@ sub generate_hardcopy_tex {
 	push(@$errors, "Failed to generate error log file: $@")                                     if $@;
 
 	# Create a zip archive of the bundle directory
-	my $zip = Archive::Zip->new;
-	$zip->addTree($working_dir->dirname->to_string);
+	my $zip = Archive::Zip::SimpleZip->new($working_dir->dirname->child('hardcopy.zip')->to_string);
+	$zip->add($working_dir->dirname->to_string, storelinks => 1);
 
-	push(@$errors, qq{Failed to create zip archive of directory "$working_dir"})
-		unless ($zip->writeToFileNamed($working_dir->dirname->child('hardcopy.zip')->to_string) == AZ_OK);
+	push(@$errors, qq{Failed to create zip archive of directory "$working_dir": $SimpleZipError}) unless ($zip->close);
 
 	return;
 }

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -886,7 +886,8 @@ sub do_delete_course ($c) {
 		# Find the contact person for the course by searching the admin classlist.
 		my @contacts = grep {/_$delete_courseID$/} $db->listUsers;
 		if (@contacts) {
-			die 'Incorrect number of contacts for the course $delete_courseID' . join(' ', @contacts) if @contacts != 1;
+			die "Incorrect number of contacts for the course $delete_courseID: " . join(' ', @contacts)
+				if @contacts != 1;
 
 			# Mark the contact person as dropped.
 			my $User = $db->getUser($contacts[0]);

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -739,6 +739,7 @@ sub generate_hardcopy_tex ($c, $temp_dir_path, $final_file_basename) {
 		$c->add_error('Failed to create zip archive of directory "', $c->tag('code', $bundle_path), '"');
 		return "$bundle_path/$src_name";
 	}
+
 	return $zip_file;
 }
 

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -737,16 +737,25 @@ sub generate_hardcopy_tex ($c, $temp_dir_path, $final_file_basename) {
 
 	# Create a zip archive of the bundle directory
 	my $zip_file = "$temp_dir_path/$final_file_basename.zip";
-	my $zip;
-	eval {
-		$zip = Archive::Zip::SimpleZip->new($zip_file);
-		$zip->add($temp_dir_path, Name => "hardcopy_files", StoreLink => 1);
-	};
+	$zip = Archive::Zip::SimpleZip->new($zip_file);
+	unless ($zip) {
+		$c->add_error(
+			'Failed to create zip archive of directory "',
+			$c->tag('code', $bundle_path),
+			'": $SimpleZipError"'
+		);
+		return;
+	}
 
-	$c->add_error('Failed to create zip archive of directory "', $c->tag('code', $bundle_path), '": $SimpleZipError"')
-		unless $zip->close;
-	$c->add_error('Failed to create zip archive of directory "', $c->tag('code', $bundle_path), '": $@') if $@;
-	return "$bundle_path/$src_name" if (!$zip->close || $@);
+	my $ok = $zip->add($temp_dir_path, Name => "hardcopy_files", StoreLink => 1);
+	unless ($ok) {
+		$c->add_error(
+			'Failed to create zip archive of directory "',
+			$c->tag('code', $bundle_path),
+			'": $SimpleZipError"'
+		);
+		return;
+	}
 
 	return $zip_file;
 }

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -737,7 +737,7 @@ sub generate_hardcopy_tex ($c, $temp_dir_path, $final_file_basename) {
 
 	# Create a zip archive of the bundle directory
 	my $zip_file = "$temp_dir_path/$final_file_basename.zip";
-	$zip = Archive::Zip::SimpleZip->new($zip_file);
+	my $zip      = Archive::Zip::SimpleZip->new($zip_file);
 	unless ($zip) {
 		$c->add_error(
 			'Failed to create zip archive of directory "',

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -26,6 +26,7 @@ problem sets.
 use File::Path;
 use File::Copy qw(move copy);
 use File::Temp qw/tempdir/;
+use Mojo::File;
 use String::ShellQuote;
 use Archive::Zip::SimpleZip qw($SimpleZipError);
 use XML::LibXML;
@@ -629,14 +630,11 @@ async sub generate_hardcopy ($c, $format, $userIDsRef, $setIDsRef) {
 
 # helper function to remove temp dirs
 sub delete_temp_dir ($c, $temp_dir_path) {
-	rmtree($temp_dir_path), { error => \my $err };
+	Mojo::File->new($temp_dir_path)->remove_tree;
 
-	if ($err && @$err) {
-		for my $diag (@$err) {
-			my ($file, $message) = %$diag;
-			$c->add_error('Failed to remove temporary directory "',
-				$c->tag('code', $file, '":', $c->tag('br'), $c->tag('pre', $message)));
-		}
+	if ($!) {
+		$c->add_error('Failed to remove temporary directory "',
+			$c->tag('code', $file, '":', $c->tag('br'), $c->tag('pre', $!)));
 	}
 	return;
 }

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -254,7 +254,7 @@ sub addCourse {
 			"Can't create the course '$courseID' because the courses directory '$rootParent' is not writeable.";
 		# try to create it
 		eval { Mojo::File->new($root)->make_path };
-		croak "Can't create the course '$courseID' becasue the root directory '$root' could not be created: $@." if $@;
+		croak "Can't create the course '$courseID' because the root directory '$root' could not be created: $@." if $@;
 	}
 
 	# deal with the rest of the directories

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -282,7 +282,7 @@ sub addCourse {
 
 		# try to create it
 		eval { Mojo::File($courseDir)->make_path };
-		warn "Failed to create $courseDirName directory '$courseDir': $!. "
+		warn "Failed to create $courseDirName directory '$courseDir': $@. "
 			. "You will have to create this directory manually."
 			if $@;
 	}
@@ -659,7 +659,7 @@ sub deleteCourse {
 			# try to delete the directory
 			debug("Going to delete $courseDir...\n");
 			eval { Mojo::File->new($courseDir)->remove_tree };
-			warn "A error occurred when deleting $courseDir" if $@;
+			warn "An error occurred when deleting $courseDir" if $@;
 		} else {
 			debug("courseDir $courseDir was already deleted.\n");
 		}


### PR DESCRIPTION
This removes the use of the programs mv, cp, rm, mkdir, tar, gzip (some were no longer used).  Instead, use functions in perl modules.  

This should be tested on a few different platforms.  Especially
1. Hardcopy generation
2. Course Archiving
3. Course Unarchiving
4. Add new course
