### PR TITLE
remove catcode change with underscore

### DIFF
--- a/assets/tex/webwork2.sty
+++ b/assets/tex/webwork2.sty
@@ -15,8 +15,6 @@
   \usepackage{xunicode}
   \usepackage{polyglossia}
   \setdefaultlanguage{english}
-  % WeBWorK used Control+_ = ^_ for verbatim... so we change its charcode
-  \catcode`\_=12
 \fi
 
 % used in convenience macros below


### PR DESCRIPTION
I do not understand what this was for, but it causes problems. With this, when using xelatex and there is something like `\(x_1\)` in hardcopy, it comes out in the PDF looking like `x_1` with underscore visible.

Maybe there was a reason for this having to do with verbatim that @taniwallach can speak to, but it is breaking basic math so it needs to go for now.

While this predates 2.18, I think it should be considered for a hotfix to 2.18. Or maybe it does not predate 2.18. Maybe the issue only happens now along with other hardcopy changes that are new.