### PR TITLE
Add the texlive-science package missing from the docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -171,8 +171,8 @@ RUN apt-get update \
 	texlive-lang-arabic \
 	texlive-lang-other \
 	texlive-latex-extra \
-	texlive-latex-recommended \
 	texlive-plain-generic \
+	texlive-science \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -133,8 +133,8 @@ RUN apt-get update \
 	texlive-lang-arabic \
 	texlive-lang-other \
 	texlive-latex-extra \
-	texlive-latex-recommended \
 	texlive-plain-generic \
+	texlive-science \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \


### PR DESCRIPTION
Also remove the texlive-latex-recommended package from the list.  That is a dependency of texlive, and so will still be installed anyway.