### PR TITLE
Fix invalid html from #2159.

### DIFF
--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -1,6 +1,6 @@
 <ul class="nav flex-column">
 	<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
-	<hr class="site-nav-separator"/>
+	<li><hr class="site-nav-separator"></li>
 	% if ($authz->hasPermissions($userID, 'create_and_delete_courses')) {
 		<li class="list-group-item nav-item">
 			<%= $makelink->(

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -86,7 +86,7 @@
 		% }
 		%
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
-			<hr class="site-nav-separator"/>
+			<li><hr class="site-nav-separator"></li>
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
 			% # Class list editor
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>


### PR DESCRIPTION
Sorry @Alex-Jordan.  I forgot that to make an `hr` tag valid here, it needs to be in an `li` tag.  This doesn't change the appearance any.

Also switch to the ending `/>` to just `>`.  The w3 validator always complains about those.

This has also been added to the hotfix in #2168.