### PR TITLE
Fix the archive_path option for creating a course archive.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -762,7 +762,7 @@ sub archiveCourse {
 	my $data_dir         = $ce->{courseDirs}{DATA};
 	my $dump_dir         = "$data_dir/mysqldump";
 	my $archive_path;
-	if (defined $options{archive_path} && $options{archive_path} =~ /S/) {
+	if (defined $options{archive_path} && $options{archive_path} =~ /\S/) {
 		$archive_path = $options{archive_path};
 	} else {
 		$archive_path = "$ce->{webworkDirs}{courses}/admin/archives/$courseID.tar.gz";


### PR DESCRIPTION
This is my mistake.  Without the backslash this fails entirely.  The result is that a course archive is always saved in the admin/archives location, and there is no override.