### PR TITLE
Correct the version number for the modify_user method called in LTIAdvantage.pm (hotfix).

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -701,7 +701,7 @@ sub maybe_update_user ($self) {
 		$tempUser->student_id($self->{student_id} // '');
 
 		# Allow sites to customize the temp user
-		$ce->{LTI}{v1p1}{modify_user}($self, $tempUser) if ref($ce->{LTI}{v1p1}{modify_user}) eq 'CODE';
+		$ce->{LTI}{v1p3}{modify_user}($self, $tempUser) if ref($ce->{LTI}{v1p3}{modify_user}) eq 'CODE';
 
 		my $change_made = 0;
 		for my $element (qw(last_name first_name email_address status section recitation student_id)) {


### PR DESCRIPTION
Clearly the LTI 1.3 code should be using the v1p3 method from authen_LIT_1_3.conf, and not the v1p1 method from authen_LTI_1_1.conf.