### PR TITLE
only offer valid XML files for hardcopy theme

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -445,19 +445,17 @@ sub display_form ($c) {
 		my $themeTree = XML::LibXML->load_xml(location => "$ce->{webworkDirs}{hardcopyThemes}/$hardcopyTheme");
 		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label');
 	}
-	my @hardcopyThemesCourseAll;
+	my @files;
 	if (opendir(my $dhC, $ce->{courseDirs}{hardcopyThemes})) {
-		@hardcopyThemesCourseAll = grep {/\.xml$/} sort readdir($dhC);
+		@files = grep { /\.xml$/ && !/^\./ } sort readdir($dhC);
 	}
-	my @hardcopyThemesCourse = @hardcopyThemesCourseAll;
-	for my $hardcopyTheme (@hardcopyThemesCourseAll) {
+	my @hardcopyThemesCourse;
+	for my $hardcopyTheme (@files) {
 		eval {
 			my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
 			$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+			push(@hardcopyThemesCourse, $hardcopyTheme);
 		};
-		if ($@) {
-			@hardcopyThemesCourse = grep { $_ ne $hardcopyTheme } @hardcopyThemesCourse;
-		}
 	}
 	my $hardcopyThemesAvailable = [
 		sort(do {

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -445,13 +445,19 @@ sub display_form ($c) {
 		my $themeTree = XML::LibXML->load_xml(location => "$ce->{webworkDirs}{hardcopyThemes}/$hardcopyTheme");
 		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label');
 	}
-	my @hardcopyThemesCourse;
+	my @hardcopyThemesCourseAll;
 	if (opendir(my $dhC, $ce->{courseDirs}{hardcopyThemes})) {
-		@hardcopyThemesCourse = grep {/\.xml$/} sort readdir($dhC);
+		@hardcopyThemesCourseAll = grep {/\.xml$/} sort readdir($dhC);
 	}
-	for my $hardcopyTheme (@hardcopyThemesCourse) {
-		my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
-		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+	my @hardcopyThemesCourse = @hardcopyThemesCourseAll;
+	for my $hardcopyTheme (@hardcopyThemesCourseAll) {
+		eval {
+			my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
+			$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+		};
+		if ($@) {
+			@hardcopyThemesCourse = grep { $_ ne $hardcopyTheme } @hardcopyThemesCourse;
+		}
 	}
 	my $hardcopyThemesAvailable = [
 		sort(do {

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -315,13 +315,19 @@ sub initialize ($c) {
 		my $themeTree = XML::LibXML->load_xml(location => "$ce->{webworkDirs}{hardcopyThemes}/$hardcopyTheme");
 		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
 	}
-	my @hardcopyThemesCourse;
+	my @hardcopyThemesCourseAll;
 	if (opendir(my $dhC, $ce->{courseDirs}{hardcopyThemes})) {
-		@hardcopyThemesCourse = grep {/\.xml$/} sort readdir($dhC);
+		@hardcopyThemesCourseAll = grep {/\.xml$/} sort readdir($dhC);
 	}
-	for my $hardcopyTheme (@hardcopyThemesCourse) {
-		my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
-		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+	my @hardcopyThemesCourse = @hardcopyThemesCourseAll;
+	for my $hardcopyTheme (@hardcopyThemesCourseAll) {
+		eval {
+			my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
+			$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+		};
+		if ($@) {
+			@hardcopyThemesCourse = grep { $_ ne $hardcopyTheme } @hardcopyThemesCourse;
+		}
 	}
 	my $hardcopyThemesAvailable = [
 		sort(do {

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -315,19 +315,17 @@ sub initialize ($c) {
 		my $themeTree = XML::LibXML->load_xml(location => "$ce->{webworkDirs}{hardcopyThemes}/$hardcopyTheme");
 		$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
 	}
-	my @hardcopyThemesCourseAll;
+	my @files;
 	if (opendir(my $dhC, $ce->{courseDirs}{hardcopyThemes})) {
-		@hardcopyThemesCourseAll = grep {/\.xml$/} sort readdir($dhC);
+		@files = grep { /\.xml$/ && !/^\./ } sort readdir($dhC);
 	}
-	my @hardcopyThemesCourse = @hardcopyThemesCourseAll;
-	for my $hardcopyTheme (@hardcopyThemesCourseAll) {
+	my @hardcopyThemesCourse;
+	for my $hardcopyTheme (@files) {
 		eval {
 			my $themeTree = XML::LibXML->load_xml(location => "$ce->{courseDirs}{hardcopyThemes}/$hardcopyTheme");
 			$hardcopyLabels{$hardcopyTheme} = $themeTree->findvalue('/theme/@label') || $hardcopyTheme;
+			push(@hardcopyThemesCourse, $hardcopyTheme);
 		};
-		if ($@) {
-			@hardcopyThemesCourse = grep { $_ ne $hardcopyTheme } @hardcopyThemesCourse;
-		}
 	}
 	my $hardcopyThemesAvailable = [
 		sort(do {


### PR DESCRIPTION
This is a hotfix to address #2185.

Before this PR, if there is some ".xml" file in the course's `hardcopyThemes` folder that can't be parsed into an XML tree, there is an error in the problem editor page as well as the hardcopy page.

This culls files in that folder from consideration if they do not parse successfully as XML.

It is still the case that you can go to Course Config and activate the dropdown to choose the default hardcopyTheme (either for general us or for  the editor) and you will see unwanted files from the `hardcopyThemes` folder in that list. It doesn't seem worth trying to cull this list here. And if someone chooses a file that won't actually work, thin in the problem editor page as well as the hardcopy page, no harm done I think. The dropdown list there will just default to the top option. It won't actually try to use the bad file.

There may be better ways to do this. Once this is reviewed I can make the parallel `develop` PR.

To test this, put some bad file in a course's `hardcopyThemes` folder. "Bad" just means not valid as XML, but with a `.xml` extension. Then visit the problem editor and hardcopy pages.