### PR TITLE
Fix some minor issues (hotfix).

### DIFF
--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -165,7 +165,7 @@
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>
 			<div>
-				<button type="button" id="dismiss-messages-btn" class="btn btn-primary d-none">
+				<button type="button" id="dismiss-messages-btn" class="btn btn-secondary d-none">
 					<%= maketext('Dismiss All Messages') %>
 				</button>
 			</div>

--- a/htdocs/themes/math4/system.html.ep
+++ b/htdocs/themes/math4/system.html.ep
@@ -146,7 +146,7 @@
 		% }
 		%
 		% # Display the page body.
-		<div class="row">
+		<div class="row mb-2">
 			<div class="body <%= $c->can('info') ? 'col-md-8' : 'col-12' %>">
 				<%= content =%>
 			</div>
@@ -160,7 +160,7 @@
 		</div>
 		%
 		% if ($c->have_warnings) {
-			<div id="warnings" class="Warnings alert alert-danger mt-2"><%= $c->warnings %></div>
+			<div id="warnings" class="Warnings alert alert-danger mb-2"><%= $c->warnings %></div>
 		% }
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -358,7 +358,7 @@ sub MakeArchive ($c) {
 	@files = readpipe $tar . ' 2>&1';
 	if ($? == 0) {
 		my $n = scalar(@files);
-		$c->addgoodmessage($c->maketext('Archive "[_1]" created successfully ([quant, _2, file])', $archive, $n));
+		$c->addgoodmessage($c->maketext('Archive "[_1]" created successfully ([quant,_2,file])', $archive, $n));
 	} else {
 		$c->addbadmessage(
 			$c->maketext(q{Can't create archive "[_1]": command returned [_2]}, $archive, systemError($?)));

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -365,8 +365,9 @@ sub page_title ($c) {
 
 	return $c->maketext('Editor') unless $c->{file_type};
 
-	return $c->maketext('Set Header for set [_1]',      $setID) if $c->{file_type} eq 'set_header';
-	return $c->maketext('Hardcopy Header for set [_1]', $setID) if $c->{file_type} eq 'hardcopy_header';
+	return $c->maketext('Set Header for set [_1]', format_set_name_display($setID)) if $c->{file_type} eq 'set_header';
+	return $c->maketext('Hardcopy Header for set [_1]', format_set_name_display($setID))
+		if $c->{file_type} eq 'hardcopy_header';
 	return $c->maketext('Hardcopy Theme') if $c->{file_type} eq 'hardcopy_theme';
 	return $c->maketext('Course Information for course [_1]', $c->stash('courseID'))
 		if $c->{file_type} eq 'course_info';

--- a/templates/ContentGenerator/Instructor/FileManager/view.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/view.html.ep
@@ -16,6 +16,6 @@
 	<%= image $fileManagerURL, style => 'border:0;', alt => $name =%>
 % } else {
 	<div class="alert alert-danger p-1 mb-0">
-		<%= maketext('The file $file does not appear to be a text or image file.') =%>
+		<%= maketext('The file "[_1]" does not appear to be a text or image file.', $file) =%>
 	</div>
 % }

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -209,6 +209,6 @@
 	</div>
 	<div>
 		<%= submit_button maketext($actionFormTitles->{$default_choice}), name => 'submit', id => 'take_action',
-			class => 'btn btn-primary mb-2' =%>
+			class => 'btn btn-primary' =%>
 	</div>
 <% end =%>


### PR DESCRIPTION
Use `format_set_name_display` for the set id in the title when editing set headers in the PGProblemEditor.

Add a margin (class `mb-2`) to the bottom of the row containing the body in the system.html.ep template.  If there are messages on these pages, the messages are currently flush up against the end content.  This fixes that in a consistent way.  The margins that were added on some pages to handle this issue have been removed.  The problem with adding a margin to some element in the body aside from the inconsistency of handling this issue is that there can be content between the body and the bottom messages.  Page warnings can appear there.  The warnings margin has been adjusted to fit into this scheme.  Ideally everything would add a margin to bottom, and only the to most element in the page (the page title) add a margin to the top.  (Sounds like a niceTables.pl concept.)  In a few cases this may add a bit too much space between the last body element and the messages (probably because there are missed instances where special handling for this was added before), but that is better than no margin.

Fix some strings that were incorrectly interpolated for maketext in the view.html.ep template for the FileManager and in FileManager.pm itself. The first can be seen by selection a file that is neither a text or image file (like a tgz file), and clicking "View".  This will show the message `The file $file does not appear to be a text or image file.` `$file` is literally what is shown in that message.  The second can be seen by selecting some files in the file manager, and clicking "Make Archive".  The message that comes back always tells you there were 0 files in the archive, even though the correct number of files were added to the archive.