### PR TITLE
Fix the fallback password in the addcourse script

### DIFF
--- a/bin/addcourse
+++ b/bin/addcourse
@@ -146,7 +146,7 @@ if ($users) {
 
 		# Set the password if the password field is empty.
 		if (!defined $record{password} || $record{password} !~ /\S/) {
-			if (defined $record{student_id} && $record{student_id} !~ /\S/) {
+			if (defined $record{student_id} && $record{student_id} =~ /\S/) {
 				# Use the student ID if it is non-empty.
 				$record{password} = cryptPassword($record{student_id});
 			} else {


### PR DESCRIPTION
The conditional should check that the student_id contains a non-whitespace character, not that it does not contain a non-whitespace character.