### PR TITLE
consistent order of hash keys

### DIFF
--- a/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
@@ -27,7 +27,7 @@
 				map { [
 					maketext($_) => $ce->{statuses}{$_}{abbrevs}[0],
 					$ce->{statuses}{$_}{abbrevs}[0] eq $value ? (selected => undef) : ()
-				] } keys %{ $ce->{statuses} }
+				] } sort(keys %{ $ce->{statuses} })
 			],
 			id => $fieldName . '_id', class => 'form-select form-select-sm w-auto flex-grow-0',
 			aria_labelledby => ($fieldName =~ s/^.*\.([^.]*)$/$1/r) . '_header' =%>


### PR DESCRIPTION
When you go to edit a user in Classlist Editor, I noticed that the dropdown list of statuses appeared in a different order each time, usually in a way that makes no logical sense. This enforces an alphabetical order.