### PR TITLE
Change 'File Manager' to 'Course Files' in Library Browser

### DIFF
--- a/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_local_panel.html.ep
@@ -6,7 +6,7 @@
 <div class="InfoPanel">
 	<div class="mb-2">
 		<%= label_for library_sets =>
-				maketext('[_1] Problems:', $lib eq '' ? maketext('File Manager') : $c->{problibs}{$lib}),
+				maketext('[_1] Problems:', $lib eq '' ? maketext('Course Files') : $c->{problibs}{$lib}),
 			class => 'col-form-label-sm' =%>
 		<%= select_field library_sets => [
 				@$prob_dirs == 0 ? [ maketext('Found no directories containing problems') => '' ]

--- a/templates/ContentGenerator/Instructor/SetMaker/top_row.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/top_row.html.ep
@@ -42,7 +42,7 @@
 		<%= submit_button maketext('Open Problem Library'), name => 'browse_npl_library',
 			class => 'browse-lib-btn btn btn-secondary btn-sm mb-2 mx-1',
 			$browse_which eq 'browse_npl_library' ? (disabled => undef) : () =%>
-		<%= submit_button maketext('File Manager'), name => 'browse_local',
+		<%= submit_button maketext('Course Files'), name => 'browse_local',
 			class => 'browse-lib-btn btn btn-secondary btn-sm mb-2 mx-1',
 			$browse_which eq 'browse_local' ? (disabled => undef) : () =%>
 		<%= submit_button maketext('Course Sets'), name => 'browse_course_sets',

--- a/templates/HelpFiles/InstructorSetMaker.html.ep
+++ b/templates/HelpFiles/InstructorSetMaker.html.ep
@@ -38,7 +38,7 @@
 			. q{haven't been vetted as thoroughly as OPL problems. If you want hints or solutions included while }
 			. 'browsing select the appropriate box.') =%>
 	</dd>
-	<dt><%= maketext('File Manager') %></dt>
+	<dt><%= maketext('Course Files') %></dt>
 	<dd><%= maketext('This option shows all pg problems in the course directory structure.')%></dd>
 	<dt><%= maketext('Course Sets') %></dt>
 	<dd><%= maketext('This option shows all problems in sets that have been created in the course.') %></dd>


### PR DESCRIPTION
In the Library Browser I think the name 'File Manager' for the button to access PG files in the course templates folder is misleading.  We already have another page called 'File Manager'.  The button doesn't take you there, nor to a page where you can actually manage files.

I'm suggesting 'Course Files' as an alternative, but I'm not married to that name.  Perhaps "Files in This Course", "Problems From This Course", or "Course Folders"?  I'd even be okay with going back to "Local Problems", which is a lot less confusing now that the next button has been renamed to "Course Sets".