### PR TITLE
Make the library browser database connections use a cached connection

### DIFF
--- a/lib/WeBWorK/Utils/LibraryStats.pm
+++ b/lib/WeBWorK/Utils/LibraryStats.pm
@@ -13,61 +13,43 @@
 # Artistic License for more details.
 ################################################################################
 
-###########################
-# Utils::LibraryLocalStats
-#
-# This is an interface for getting local statistics about library problems
-# for display
-###########################
-
+# This is an interface for getting global and local statistics about library problems for display.
 package WeBWorK::Utils::LibraryStats;
 
-use base qw(Exporter);
 use strict;
 use warnings;
+
 use DBI;
 
-our @EXPORT    = ();
-our @EXPORT_OK = qw();
-
 sub new {
-	my $class = shift;
-	my $ce    = shift;
+	my ($class, $ce) = @_;
 
-	my $dbh = DBI->connect(
-		$ce->{problemLibrary_db}->{dbsource},
-		$ce->{problemLibrary_db}->{user},
-		$ce->{problemLibrary_db}->{passwd},
+	my $dbh = DBI->connect_cached(
+		$ce->{problemLibrary_db}{dbsource},
+		$ce->{problemLibrary_db}{user},
+		$ce->{problemLibrary_db}{passwd},
 		{
 			PrintError => 0,
 			RaiseError => 0,
 		},
 	);
 
-	my $localselectstm = $dbh->prepare("SELECT * FROM OPL_local_statistics WHERE source_file = ?");
-
-	my $globalselectstm = $dbh->prepare("SELECT * FROM OPL_global_statistics WHERE source_file = ?");
-
-	my $self = {
+	return bless {
 		dbh             => $dbh,
-		localselectstm  => $localselectstm,
-		globalselectstm => $globalselectstm,
-	};
-
-	bless($self, $class);
-	return $self;
+		localselectstm  => $dbh->prepare("SELECT * FROM OPL_local_statistics WHERE source_file = ?"),
+		globalselectstm => $dbh->prepare("SELECT * FROM OPL_global_statistics WHERE source_file = ?"),
+	}, $class;
 }
 
 sub getLocalStats {
-	my $self        = shift;
-	my $source_file = shift;
+	my ($self, $source_file) = @_;
 
 	my $selectstm = $self->{localselectstm};
 
 	unless ($selectstm->execute($source_file)) {
 		if ($selectstm->errstr =~ /Table .* doesn't exist/) {
-			warn
-				"Couldn't find the OPL local statistics table.  Did you download the latest OPL and run update-OPL-statistics.pl?";
+			warn "Couldn't find the OPL local statistics table.  "
+				. "Did you download the latest OPL and run update-OPL-statistics.pl?";
 		}
 		die $selectstm->errstr;
 	}
@@ -87,15 +69,14 @@ sub getLocalStats {
 }
 
 sub getGlobalStats {
-	my $self        = shift;
-	my $source_file = shift;
+	my ($self, $source_file) = @_;
 
 	my $selectstm = $self->{globalselectstm};
 
 	unless ($selectstm->execute($source_file)) {
 		if ($selectstm->errstr =~ /Table .* doesn't exist/) {
-			warn
-				"Couldn't find the OPL global statistics table.  Did you download the latest OPL and run load-OPL-global-statistics.pl?";
+			warn "Couldn't find the OPL global statistics table.  "
+				. "Did you download the latest OPL and run load-OPL-global-statistics.pl?";
 		}
 		die $selectstm->errstr;
 	}

--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -105,10 +105,10 @@ sub getTables {
 
 sub getDB {
 	my $ce  = shift;
-	my $dbh = DBI->connect(
-		$ce->{problemLibrary_db}->{dbsource},
-		$ce->{problemLibrary_db}->{user},
-		$ce->{problemLibrary_db}->{passwd},
+	my $dbh = DBI->connect_cached(
+		$ce->{problemLibrary_db}{dbsource},
+		$ce->{problemLibrary_db}{user},
+		$ce->{problemLibrary_db}{passwd},
 		{
 			PrintError => 0,
 			RaiseError => 1,


### PR DESCRIPTION
Currently the database connections used by the library browser are obtained with a `DBI->connect` call, and those connections are never closed.  As a result each time the library browser is accessed, a new database connection is obtained, and the previous connections are left open until the server process that created the connection is recycled. This results in the database connection count being unnecessarily incremented.

This changes those calls to `DBI->connect_cached`.  This means that if the process already has a database connection, it will be reused instead of a new one being made.  Thus keeping the database connection count down.

See https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8355 for the discussion that led to this pull request.