### PR TITLE
Use the `followSymlinks` instead of the `usePolling` chokidar option in generate-assets.js.

### DIFF
--- a/htdocs/generate-assets.js
+++ b/htdocs/generate-assets.js
@@ -212,8 +212,6 @@ if (argv.watchFiles) console.log('\x1b[32mEstablishing watches and performing in
 chokidar.watch(['js', 'themes'], {
 	ignored: /layouts|\.min\.(js|css)$/,
 	cwd: __dirname, // Make sure all paths are given relative to the htdocs directory.
-	usePolling: true, // Needed to get changes to symlinks.
-	interval: 500,
 	awaitWriteFinish: { stabilityThreshold: 500 },
 	persistent: argv.watchFiles ? true : false
 })


### PR DESCRIPTION
With node version 20 the `usePolling` option is resulting in high cpu usage.  The `followSymlinks` serves the purpose more correctly.  The `usePolling` option was initially used because either the `followSymlinks` option did not exist or there was a bug in chokidar and that option wasn't working.  I can't remember the exact details.

The actual high cpu usage occurs with the PG generate-assets.js script, and not this one with the `usePolling` option.  I don't really know why though.  In any case the `followSymlinks` option is more correct for what we want here.

Note this only affects usage of the script with the `-w` flag.  So it only affects developers.