### PR TITLE
Fix incorrect row label in stats page.

### DIFF
--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -166,7 +166,7 @@
 			<% for (@$problems) { %><td class="text-center"><%= $_->value %></td><% } =%>
 		</tr>
 		<tr>
-			<th><%= maketext('Point Value') %></th>
+			<th><%= maketext('Average Percent') %></th>
 			<% for (@$avgScore) { %><td class="text-center"><%= $_ %></td><% } =%>
 		</tr>
 		% if ($isJitarSet) {


### PR DESCRIPTION
Accidentally used 'Point Value' twice, when one of the rows was meant to be 'Average Percent'.  This is a simple fix for that (probably not worth a hot fix, but simple enough I can make one if others think we should clean up this visual issue).