### PR TITLE
Fix incorrect row label in stats page (hotfix).

### DIFF
--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -166,7 +166,7 @@
 			<% for (@$problems) { %><td class="text-center"><%= $_->value %></td><% } =%>
 		</tr>
 		<tr>
-			<th><%= maketext('Point Value') %></th>
+			<th><%= maketext('Average Percent') %></th>
 			<% for (@$avgScore) { %><td class="text-center"><%= $_ %></td><% } =%>
 		</tr>
 		% if ($isJitarSet) {


### PR DESCRIPTION
This is the hotfix of #2208.