### PR TITLE
Watch the PG.pl macro file when running morbo.

### DIFF
--- a/bin/dev_scripts/webwork2-morbo
+++ b/bin/dev_scripts/webwork2-morbo
@@ -87,9 +87,10 @@ push(@watch,
 	"$webwork_root/lib",           "$webwork_root/templates", "$webwork_root/htdocs/js",
 	"$webwork_root/htdocs/themes", "$webwork_root/conf");
 
-# Add the pg lib and pg htdocs directory if they are readable.
-push(@watch, "$config->{pg_dir}/lib")    if -r "$config->{pg_dir}/lib";
-push(@watch, "$config->{pg_dir}/htdocs") if -r "$config->{pg_dir}/htdocs";
+# Add the pg lib and pg htdocs directory and the PG.pl macro if they are readable.
+push(@watch, "$config->{pg_dir}/lib")          if -r "$config->{pg_dir}/lib";
+push(@watch, "$config->{pg_dir}/htdocs")       if -r "$config->{pg_dir}/htdocs";
+push(@watch, "$config->{pg_dir}/macros/PG.pl") if -r "$config->{pg_dir}/macros/PG.pl";
 
 my $morbo = Mojo::Server::Morbo->new(silent => !$verbose);
 $morbo->daemon->listen(\@listen) if @listen;


### PR DESCRIPTION
Since this file is cached in the safe zone when the application starts, changes to this file require the webwork2 application to be restarted in order for them to take effect.  I have noticed this recently when making changes to that file.

This of course only affects running the webwork2 app in development with morbo.  With hypnotoad you would need to restart the app manually since hypnotoad doesn't hot reload.  Of course you normally don't edit PG.pl in production, so that is how it should be.