### PR TITLE
Fix issue with hidden input probstatusX in gateway quizzes.

### DIFF
--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -589,7 +589,8 @@
 					% }
 				</div>
 				% # Store the problem status for continued attempts recording.
-				<%= hidden_field 'probstatus' . ($probOrder->[$i] + 1) => $c->{probStatus}[ $probOrder->[$i] ] =%>
+				<%= hidden_field 'probstatus' . $problems->[ $probOrder->[$i] ]{problem_id}
+					=> $c->{probStatus}[ $probOrder->[$i] ] =%>
 				%
 				<div class="gwDivider"></div>
 			% } else {
@@ -605,7 +606,8 @@
 					% }
 				% }
 				% # Store the problem status for continued attempts recording.
-				<%= hidden_field 'probstatus' . ($probOrder->[$i] + 1) => $c->{probStatus}[ $probOrder->[$i] ] %>
+				<%= hidden_field 'probstatus' . $problems->[ $probOrder->[$i] ]{problem_id}
+					=> $c->{probStatus}[ $probOrder->[$i] ] %>
 			% }
 		% }
 		%


### PR DESCRIPTION
  The number `X` in the hidden input `probstatusX` needs to be the
  problem ID, but was being set to the index + 1 of the array used
  to randomized the problems.  This causes the single problem grader
  javascript to hit an error if a test's problems do not start at
  1 and are not in sequential order, as mentioned in #2215.

  Also, since GatewayQuiz.pm assumes the X is the problem ID, and uses
  this hidden input to get the status of its problems when moving though
  different pages, a quiz whose problems don't start with 1 or are not
  in sequential error could retrieve an incorrect status as a result.

  This update fixes the issue by setting X equal to the problemID.