### PR TITLE
allow set list to be sorted by reduced scoring date

### DIFF
--- a/templates/ContentGenerator/Instructor/ProblemSetList/sort_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/sort_form.html.ep
@@ -6,6 +6,10 @@
 			<%= select_field 'action.sort.primary' => [
 					[ maketext('Set Name')    => 'set_id' ],
 					[ maketext('Open Date')   => 'open_date' ],
+					($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+						? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
+						: ()
+					),
 					[ maketext('Close Date')  => 'due_date', selected => undef ],
 					[ maketext('Answer Date') => 'answer_date' ],
 					[ maketext('Visibility')  => 'visible' ]
@@ -20,6 +24,10 @@
 			<%= select_field 'action.sort.secondary' => [
 					[ maketext('Set Name')    => 'set_id' ],
 					[ maketext('Open Date')   => 'open_date', selected => undef],
+					($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+						? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
+						: ()
+					),
 					[ maketext('Close Date')  => 'due_date' ],
 					[ maketext('Answer Date') => 'answer_date' ],
 					[ maketext('Visibility')  => 'visible' ]


### PR DESCRIPTION
A local instructor requested this, and this way of doing it was quick. I'm not 100% sure on the code formatting since this is a template file.

Sorting sets requires going to the Sort tab in the Hmwk Sets Editor. Is there a reason we don't enable simply clicking on column headers if you want to sort the table of sets, like we do with the Classlist Editor to sort users?  Is it too hard to sort that way when the cells have dates?