### PR TITLE
Validate hidden input existence when saving value in problemgrader.js.

### DIFF
--- a/htdocs/js/ProblemGrader/problemgrader.js
+++ b/htdocs/js/ProblemGrader/problemgrader.js
@@ -120,15 +120,16 @@
 					} else {
 						// Update the hidden problem status fields and score table for gateway quizzes
 						if (saveData.versionId !== '0') {
-							document.gwquiz.elements['probstatus' + saveData.problemId].value =
-								parseInt(scoreInput.value) / 100;
+							const probStatus = document.gwquiz.elements[`probstatus${saveData.problemId}`];
+							if (probStatus) probStatus.value = parseInt(scoreInput.value) / 100;
 							let testValue = 0;
 							for (const scoreCell of document.querySelectorAll('table.gwNavigation td.score')) {
 								if (scoreCell.dataset.problemId == saveData.problemId) {
 									scoreCell.textContent = scoreInput.value == '100' ? '\u{1F4AF}' : scoreInput.value;
 								}
-								testValue += document.gwquiz.elements['probstatus'
-									+ scoreCell.dataset.problemId].value * scoreCell.dataset.problemValue;
+								testValue +=
+									(document.gwquiz.elements[`probstatus${scoreCell.dataset.problemId}`]?.value ?? 0) *
+									scoreCell.dataset.problemValue;
 							}
 							const recordedScore = document.getElementById('test-recorded-score');
 							if (recordedScore) {


### PR DESCRIPTION
This is the real problem that prevents the functionality of the problem grader and causes issue #2215.  These hidden inputs not existing for some problems in a test with non-consecutive problems causes a javascript error that prevents the comment from being saved.  If the javascript error does not occur then the comment will be saved correctly.

To test this create a test with problems 1, 2, 3, and 4, and delete problem 2 (for example).  Then submit a version of the test, and open the problem grader in that version.  Then go to problem 2 and set the score and add a comment for that problem.  With the develop branch you will get the message

    Error saving score.
    document.gwquiz.elements[("probstatus" + s.dataset.problemId)] is undefined

If you check the database, you will see that the score is saved, but the comment is not.  With this branch the score and comment will be successfully saved (and you can verify this in the database).

This should be added together with #2216.  Both are part of the problem.