### PR TITLE
Remove PG translations and don't add those to the po and pot files.

### DIFF
--- a/bin/dev_scripts/update-localization-files
+++ b/bin/dev_scripts/update-localization-files
@@ -39,8 +39,8 @@ do
 	esac
 done
 
-if [ -z "$WEBWORK_ROOT" ] || [ -z "$PG_ROOT" ]; then
-    echo >&2 "You need to set both the WEBWORK_ROOT and PG_ROOT environment variables.  Aborting."
+if [ -z "$WEBWORK_ROOT" ]; then
+    echo >&2 "You need to set the WEBWORK_ROOT environment variable.  Aborting."
     exit 1
 fi
 
@@ -53,9 +53,9 @@ LOCDIR=$WEBWORK_ROOT/lib/WeBWorK/Localize
 
 cd $LOCDIR
 
-echo "Updating $WEBWORK_ROOT/webwork2.pot"
+echo "Updating $LOCDIR/webwork2.pot"
 
-xgettext.pl -o webwork2.pot -D $WEBWORK_ROOT/lib -D $PG_ROOT/lib -D $PG_ROOT/macros -D $WEBWORK_ROOT/templates \
+xgettext.pl -o webwork2.pot -D $WEBWORK_ROOT/lib -D $WEBWORK_ROOT/templates \
 	$WEBWORK_ROOT/conf/defaults.config $WEBWORK_ROOT/conf/LTIConfigValues.config
 
 if $UPDATE_PO; then

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1258,7 +1258,7 @@ ${pg}{modules} = [
 	[qw(Applet MIME::Base64)],
 	[qw(PGcore PGalias PGresource PGloadfiles PGanswergroup PGresponsegroup Tie::IxHash)],
 	[qw(Locale::Maketext)],
-	[qw(WeBWorK::Localize)],
+	[qw(WeBWorK::PG::Localize)],
 	[qw(JSON)],
 	[qw(Rserve Class::Tiny IO::Handle)],
 	[qw(DragNDrop)],

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -1,70 +1,49 @@
 package WeBWorK::Localize;
+use parent 'Locale::Maketext';
+
+use strict;
+use warnings;
 
 use File::Spec;
-use Locale::Maketext;
 use Locale::Maketext::Lexicon;
 
 use WeBWorK::Utils qw(x);
 
-my $path     = "$ENV{WEBWORK_ROOT}/lib/WeBWorK/Localize";
-my $pattern  = File::Spec->catfile($path, '*.[pm]o');
-my $decode   = 1;
-my $encoding = undef;
+Locale::Maketext::Lexicon->import({
+	'i-default' => ['Auto'],
+	'*'         => [ Gettext => File::Spec->catfile("$ENV{WEBWORK_ROOT}/lib/WeBWorK/Localize", '*.[pm]o') ],
+	_decode     => 1,
+	_encoding   => undef,
+});
+*tense = sub { \$_[1] . ((\$_[2] eq 'present') ? 'ing' : 'ed') };
 
-# For some reason this next stanza needs to be evaluated
-# separately.  I'm not sure why it can't be
-# directly entered into the code.
-# This code was cribbed from Locale::Maketext::Simple if I remember correctly
-#
-
-eval "
-	package WeBWorK::Localize::I18N;
-	use base 'Locale::Maketext';
-    %WeBWorK::Localize::I18N::Lexicon = ( '_AUTO' => 1 );
-	Locale::Maketext::Lexicon->import({
-	    'i-default' => [ 'Auto' ],
-	    '*'	=> [ Gettext => \$pattern ],
-	    _decode => \$decode,
-	    _encoding => \$encoding,
-	});
-	*tense = sub { \$_[1] . ((\$_[2] eq 'present') ? 'ing' : 'ed') };
-
-" or die "Can't process eval in WeBWorK/Localize.pm: line 35:  " . $@;
-
-package WeBWorK::Localize;
-
-# This subroutine is shared with the safe compartment in PG to
-# allow maketext() to be constructed in PG problems and macros
-# It seems to be a little fragile -- possibly it breaks
-# on perl 5.8.8
+# This subroutine is used to pass a language handle to job queue tasks
+# so that tasks can use maketext.
 sub getLoc {
 	my $lang = shift;
-	my $lh   = WeBWorK::Localize::I18N->get_handle($lang);
+	my $lh   = WeBWorK::Localize->get_handle($lang);
 	return sub { $lh->maketext(@_) };
 }
 
 sub getLangHandle {
 	my $lang = shift;
-	my $lh   = WeBWorK::Localize::I18N->get_handle($lang);
-	return $lh;
+	return WeBWorK::Localize->get_handle($lang);
 }
 
-# this is like [quant] but it doesn't write the number
+# This is like [quant] but it doesn't write the number.
 #  usage: [quant,_1,<singular>,<plural>,<optional zero>]
-
 sub plural {
 	my ($handle, $num, @forms) = @_;
 
 	return ''        if @forms == 0;
-	return $forms[2] if @forms > 2 and $num == 0;
+	return $forms[2] if @forms > 2 && $num == 0;
 
 	# Normal case:
-	return ($handle->numerate($num, @forms));
+	return $handle->numerate($num, @forms);
 }
 
-# this is like [quant] but it also has -1 case
-#  usage: [negquant,_1,<neg case>,<singular>,<plural>,<optional zero>]
-
+# This is like [quant] but it also has a negative case. (The one usage in the code interprets this as unlimited.)
+#  usage: [negquant,_1,<negative case>,<singular>,<plural>,<optional zero>]
 sub negquant {
 	my ($handle, $num, @forms) = @_;
 
@@ -73,12 +52,11 @@ sub negquant {
 	my $negcase = shift @forms;
 	return $negcase if $num < 0;
 
-	return $forms[2] if @forms > 2 and $num == 0;
-	return ($handle->numf($num) . ' ' . $handle->numerate($num, @forms));
+	return $forms[2] if @forms > 2 && $num == 0;
+	return $handle->numf($num) . ' ' . $handle->numerate($num, @forms);
 }
 
-# we use x to mark the strings for translation
-%Lexicon = (
+our %Lexicon = (
 	'_AUTO' => 1,
 
 	'_ONE_COLUMN' => x('One Column'),
@@ -92,8 +70,5 @@ sub negquant {
 
 	'_STATUS' => [ x('Enrolled'), x('Audit'), x('Drop'), x('Proctor') ],
 );
-
-package WeBWorK::Localize::I18N;
-use base(WeBWorK::Localize);
 
 1;

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -122,8 +122,7 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 	$options{PERSISTENCE_HASH} = decode_json($problem->problem_data || '{}');
 
 	# Language
-	$options{language}            = $ce->{language};
-	$options{language_subroutine} = WeBWorK::Localize::getLoc($options{language});
+	$options{language} = $ce->{language};
 
 	# Student and course Information
 	$options{courseName}       = $ce->{courseName};


### PR DESCRIPTION
PG will no longer use the language handle from webwork2.  It will now provide its own language handle.  So the PG code is no longer scanned for translations.

Also, the new WeBWorK::PG::Localize module is shared to PG's safe compartment.  That is PG's language handle module.

This is the alternate to #2213 that we discussed.

This is paired with https://github.com/openwebwork/pg/pull/936.

Note that the po and pot files have not actually been updated.  So at this point all of PG's translations are still in those files.  Those are saved for now, but can be removed later.