### PR TITLE
SMA compare answers and problem text

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -137,7 +137,7 @@ async sub pre_header_initialize ($c) {
 			showHints                => 0,
 			showSolutions            => 0,
 			refreshMath2img          => 0,
-			processAnswers           => 0,
+			processAnswers           => 1,
 			permissionLevel          => $db->getPermissionLevel($userName)->permission,
 			effectivePermissionLevel => $db->getPermissionLevel($effectiveUserName)->permission,
 			useMathQuill             => $c->{will}{useMathQuill},
@@ -173,7 +173,7 @@ async sub pre_header_initialize ($c) {
 					showHints                => 0,
 					showSolutions            => 0,
 					refreshMath2img          => 0,
-					processAnswers           => 0,
+					processAnswers           => 1,
 					permissionLevel          => $db->getPermissionLevel($userName)->permission,
 					effectivePermissionLevel => $db->getPermissionLevel($effectiveUserName)->permission,
 					useMathQuill             => $c->{will}{useMathQuill},
@@ -188,7 +188,9 @@ async sub pre_header_initialize ($c) {
 			}
 
 			# check to see if we've found a new version
-			if ($new_body_text ne $orig_body_text) {
+			if ($new_body_text ne $orig_body_text
+				|| have_different_answers($showMeAnotherNewPG, $showMeAnotherOriginalPG))
+			{
 				# if we've found a new version, then
 				# increment the counter detailing the number of times showMeAnother has been used
 				# unless we're trying to check answers from the showMeAnother screen
@@ -232,7 +234,7 @@ async sub pre_header_initialize ($c) {
 				showHints                => 0,
 				showSolutions            => 0,
 				refreshMath2img          => 0,
-				processAnswers           => 0,
+				processAnswers           => 1,
 				permissionLevel          => $db->getPermissionLevel($userName)->permission,
 				effectivePermissionLevel => $db->getPermissionLevel($effectiveUserName)->permission,
 				useMathQuill             => $c->{will}{useMathQuill},
@@ -592,6 +594,14 @@ sub output_hidden_info ($c) {
 	}
 
 	return '';
+}
+
+# Checks the PG object for two different seeds of the same pg file
+sub have_different_answers ($pg1, $pg2) {
+	for (keys %{ $pg1->{answers} }) {
+		return 1 if ($pg1->{answers}{$_}{correct_ans} ne $pg2->{answers}{$_}{correct_ans});
+	}
+	return 0;
 }
 
 1;


### PR DESCRIPTION
## Background

Show me another allows users to re-randomize a problem they've been assigned. This process currently involves checking the text output across multiple new random seeds to see if the problem has changed.

### Problem

I encountered an issue with SMA for a graph interpretation problem. The problem text does not change based on the randomization, but the dynamically-created graph does. SMA currently identifies this problem as not having any "new versions" because it only compares problem text, and cannot compare the images.

### Fix

If a new seed changes the *correct answers* for a problem, it should be considered as evidence that the new seed has in fact resulted in a new version of the problem. This PR adds a check for changes in the correct answers to the logic that identifies new versions of a problem.

### MWA

Before this PR, the following problem will fail to generate new versions when SMA is enabled.

With this PR, SMA will recognize new versions of the problem.

```
DOCUMENT();

loadMacros("PGstandard.pl", "PGML.pl");

$x = Real(random(1,10));

# assume image generation for a line with $x as the x-intercept

BEGIN_PGML

[@ #image(...) @]*

What is the [`x`]-intercept? [__]{$x}{5}

END_PGML

ENDDOCUMENT();
```