### PR TITLE
Add a page to manage jobs in the job queue.

### DIFF
--- a/htdocs/js/JobManager/jobmanager.js
+++ b/htdocs/js/JobManager/jobmanager.js
@@ -1,0 +1,47 @@
+(() => {
+	// Show/hide the filter elements depending on if the field matching option is selected.
+	const filter_select = document.getElementById('filter_select');
+	const filter_elements = document.getElementById('filter_elements');
+	if (filter_select && filter_elements) {
+		const toggle_filter_elements = () => {
+			if (filter_select.value === 'match_regex') filter_elements.style.display = 'block';
+			else filter_elements.style.display = 'none';
+		};
+		filter_select.addEventListener('change', toggle_filter_elements);
+		toggle_filter_elements();
+	}
+
+	// Submit the job list form when a sort header is clicked or enter or space is pressed when it has focus.
+	const currentAction = document.getElementById('current_action');
+	if (currentAction) {
+		for (const header of document.querySelectorAll('.sort-header')) {
+			const submitSortMethod = (e) => {
+				e.preventDefault();
+
+				currentAction.value = 'sort';
+
+				const sortInput = document.createElement('input');
+				sortInput.name = 'labelSortMethod';
+				sortInput.value = header.dataset.sortField;
+				sortInput.type = 'hidden';
+				currentAction.form.append(sortInput);
+
+				currentAction.form.submit();
+			};
+
+			header.addEventListener('click', submitSortMethod);
+			header.addEventListener('keydown', (e) => {
+				if (e.key === ' ' || e.key === 'Enter') submitSortMethod(e);
+			});
+		}
+	}
+
+	// Activate the results popovers.
+	document.querySelectorAll('.result-popover-btn').forEach((popoverBtn) => {
+		new bootstrap.Popover(popoverBtn, {
+			trigger: 'hover focus',
+			customClass: 'job-queue-result-popover',
+			html: true
+		});
+	});
+})();

--- a/htdocs/js/JobManager/jobmanager.js
+++ b/htdocs/js/JobManager/jobmanager.js
@@ -11,31 +11,6 @@
 		toggle_filter_elements();
 	}
 
-	// Submit the job list form when a sort header is clicked or enter or space is pressed when it has focus.
-	const currentAction = document.getElementById('current_action');
-	if (currentAction) {
-		for (const header of document.querySelectorAll('.sort-header')) {
-			const submitSortMethod = (e) => {
-				e.preventDefault();
-
-				currentAction.value = 'sort';
-
-				const sortInput = document.createElement('input');
-				sortInput.name = 'labelSortMethod';
-				sortInput.value = header.dataset.sortField;
-				sortInput.type = 'hidden';
-				currentAction.form.append(sortInput);
-
-				currentAction.form.submit();
-			};
-
-			header.addEventListener('click', submitSortMethod);
-			header.addEventListener('keydown', (e) => {
-				if (e.key === ' ' || e.key === 'Enter') submitSortMethod(e);
-			});
-		}
-	}
-
 	// Activate the results popovers.
 	document.querySelectorAll('.result-popover-btn').forEach((popoverBtn) => {
 		new bootstrap.Popover(popoverBtn, {

--- a/htdocs/js/JobManager/jobmanager.js
+++ b/htdocs/js/JobManager/jobmanager.js
@@ -10,13 +10,4 @@
 		filter_select.addEventListener('change', toggle_filter_elements);
 		toggle_filter_elements();
 	}
-
-	// Activate the results popovers.
-	document.querySelectorAll('.result-popover-btn').forEach((popoverBtn) => {
-		new bootstrap.Popover(popoverBtn, {
-			trigger: 'hover focus',
-			customClass: 'job-queue-result-popover',
-			html: true
-		});
-	});
 })();

--- a/htdocs/js/JobManager/jobmanager.scss
+++ b/htdocs/js/JobManager/jobmanager.scss
@@ -1,8 +1,0 @@
-.job-queue-result-popover {
-	--bs-popover-max-width: 500px;
-
-	.popover-body {
-		overflow-y: auto;
-		max-height: 25vh;
-	}
-}

--- a/htdocs/js/JobManager/jobmanager.scss
+++ b/htdocs/js/JobManager/jobmanager.scss
@@ -1,0 +1,8 @@
+.job-queue-result-popover {
+	--bs-popover-max-width: 500px;
+
+	.popover-body {
+		overflow-y: auto;
+		max-height: 25vh;
+	}
+}

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -26,7 +26,7 @@ use Env qw(WEBWORK_SERVER_ADMIN);
 
 use WeBWorK;
 use WeBWorK::CourseEnvironment;
-use WeBWorK::Utils qw(x writeTimingLogEntry);
+use WeBWorK::Utils qw(writeTimingLogEntry);
 use WeBWorK::Utils::Routes qw(setup_content_generator_routes);
 
 sub startup ($app) {
@@ -84,7 +84,8 @@ sub startup ($app) {
 	# Add the themes directory to the template search paths.
 	push(@{ $app->renderer->paths }, $ce->{webworkDirs}{themes});
 
-	# Setup the Minion job queue.
+	# Setup the Minion job queue. Make sure that any task added here is represented in the TASK_NAMES hash in
+	# WeBWorK::ContentGenerator::Instructor::JobManager.
 	$app->plugin(Minion => { $ce->{job_queue}{backend} => $ce->{job_queue}{database_dsn} });
 	$app->minion->add_task(lti_mass_update        => 'Mojolicious::WeBWorK::Tasks::LTIMassUpdate');
 	$app->minion->add_task(send_instructor_email  => 'Mojolicious::WeBWorK::Tasks::SendInstructorEmail');

--- a/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/LTIMassUpdate.pm
@@ -22,27 +22,22 @@ use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 
 # Perform a mass update of grades via LTI.
-sub run ($job, $courseID, $userID = '', $setID = '') {
-	# Establish a lock guard that only allow 1 job at a time (technichally more than one could run at a time if a job
+sub run ($job, $userID = '', $setID = '') {
+	# Establish a lock guard that only allows 1 job at a time (technically more than one could run at a time if a job
 	# takes more than an hour to complete).  As soon as a job completes (or fails) the lock is released and a new job
-	# can start.  New jobs retry every minute until they can aquire their own lock.
+	# can start.  New jobs retry every minute until they can acquire their own lock.
 	return $job->retry({ delay => 60 }) unless my $guard = $job->minion->guard('lti_mass_update', 3600);
 
+	my $courseID = $job->info->{notes}{courseID};
+	return $job->fail('The course id was not passed when this job was enqueued.') unless $courseID;
+
 	my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $courseID }) };
-	return $job->fail("Could not construct course environment for $courseID.") unless $ce;
+	return $job->fail('Could not construct course environment.') unless $ce;
+
+	$job->{language_handle} = WeBWorK::Localize::getLoc($ce->{language} || 'en');
 
 	my $db = WeBWorK::DB->new($ce->{dbLayout});
-	return $job->fail("Could not obtain database connection for $courseID.") unless $db;
-
-	if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
-		$job->app->log->info("LTI Mass Update: Starting grade update for user $userID and set $setID.");
-	} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
-		$job->app->log->info("LTI Mass Update: Starting grade update for all users assigned to set $setID.");
-	} elsif ($userID) {
-		$job->app->log->info("LTI Mass Update: Starting grade update of all sets assigned to user $userID.");
-	} else {
-		$job->app->log->info('LTI Mass Update: Starting grade update for all sets and users.');
-	}
+	return $job->fail($job->maketext('Could not obtain database connection.')) unless $db;
 
 	# Pass a fake controller object that will work for the grader.
 	my $grader =
@@ -76,8 +71,19 @@ sub run ($job, $courseID, $userID = '', $setID = '') {
 		}
 	}
 
-	$job->app->log->info("Updated grades via LTI for course $courseID.");
-	return $job->finish("Updated grades via LTI for course $courseID.");
+	if ($setID && $userID && $ce->{LTIGradeMode} eq 'homework') {
+		return $job->finish($job->maketext('Updated grades via LTI for user [_1] and set [_2].', $userID, $setID));
+	} elsif ($setID && $ce->{LTIGradeMode} eq 'homework') {
+		return $job->finish($job->maketext('Updated grades via LTI all users assigned to set [_1].', $setID));
+	} elsif ($userID) {
+		return $job->finish($job->maketext('Updated grades via LTI of all sets assigned to user [_1].', $userID));
+	} else {
+		return $job->finish($job->maketext('Updated grades via LTI for all sets and users.'));
+	}
+}
+
+sub maketext ($job, @args) {
+	return &{ $job->{language_handle} }(@args);
 }
 
 1;

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -28,46 +28,46 @@ use WeBWorK::Utils qw/processEmailMessage createEmailSenderTransportSMTP/;
 # Send instructor email messages to students.
 # FIXME: This job currently allows multiple jobs to run at once.  Should it be limited?
 sub run ($job, $mail_data) {
-	my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $mail_data->{courseName} }) };
-	return $job->fail("Could not construct course environment for $mail_data->{courseName}.") unless $ce;
+	my $courseID = $job->info->{notes}{courseID};
+	return $job->fail('The course id was not passed when this job was enqueued.') unless $courseID;
 
-	my $db = WeBWorK::DB->new($ce->{dbLayout});
-	return $job->fail("Could not obtain database connection for $mail_data->{courseName}.") unless $db;
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $courseID }) };
+	return $job->fail('Could not construct course environment.') unless $ce;
 
 	$job->{language_handle} = WeBWorK::Localize::getLoc($ce->{language} || 'en');
 
-	my $result_message = eval { $job->mail_message_to_recipients($ce, $db, $mail_data) };
+	my $db = WeBWorK::DB->new($ce->{dbLayout});
+	return $job->fail($job->maketext('Could not obtain database connection.')) unless $db;
+
+	my @result_messages = eval { $job->mail_message_to_recipients($ce, $db, $mail_data) };
 	if ($@) {
-		$result_message .= "An error occurred while trying to send email.\n" . "The error message is:\n\n$@\n\n";
-		$job->app->log->error("An error occurred while trying to send email: $@\n");
+		push(@result_messages,
+			$job->maketext('An error occurred while trying to send email.'),
+			$job->maketext('The error message is:'),
+			ref($@) ? $@->message : $@);
+		return $job->fail(\@result_messages);
 	}
 
-	eval { $job->email_notification($ce, $mail_data, $result_message) };
-	if ($@) {
-		$job->app->log->error("An error occurred while trying to send the email notification: $@\n");
-		return $job->fail("FAILURE: Unable to send email notifation to instructor.");
-	}
-
-	return $job->finish("SUCCESS: Email messages sent.");
+	return $job->finish(\@result_messages);
 }
 
 sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
-	my $result_message  = '';
+	my @result_messages;
 	my $failed_messages = 0;
-	my $error_messages  = '';
+	my @error_messages;
 
 	my @recipients = @{ $mail_data->{recipients} };
 
 	for my $recipient (@recipients) {
-		$error_messages = '';
+		@error_messages = ();
 
 		my $user_record = $db->getUser($recipient);
 		unless ($user_record) {
-			$error_messages .= "Record for user $recipient not found\n";
+			push(@error_messages, $job->maketext('Record for user [_1] not found.', $recipient));
 			next;
 		}
 		unless ($user_record->email_address =~ /\S/) {
-			$error_messages .= "User $recipient does not have an email address -- skipping\n";
+			push(@error_messages, $job->maketext('User [_1] does not have an email address.', $recipient));
 			next;
 		}
 
@@ -86,52 +86,44 @@ sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
 				transport => createEmailSenderTransportSMTP($ce),
 				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 			});
-			debug 'email sent successfully to ' . $user_record->email_address;
+			debug 'Email successfully sent to ' . $user_record->email_address;
 		};
 		if ($@) {
-			debug "Error sending email: $@";
-			$error_messages .= "Error sending email: $@";
+			my $exception_message = ref($@) ? $@->message : $@;
+			debug 'Error sending email to ' . $user_record->email_address . ": $exception_message";
+			push(
+				@error_messages,
+				$job->maketext(
+					'Error sending email to [_1]: [_2]', $user_record->email_address, $exception_message
+				)
+			);
 			next;
 		}
 
-		$result_message .=
-			$job->maketext('Message sent to [_1] at [_2].', $recipient, $user_record->email_address) . "\n"
-			unless $error_messages;
+		push(@result_messages, $job->maketext('Message sent to [_1] at [_2].', $recipient, $user_record->email_address))
+			unless @error_messages;
 	} continue {
 		# Update failed messages before continuing loop.
-		if ($error_messages) {
+		if (@error_messages) {
 			$failed_messages++;
-			$result_message .= $error_messages;
+			push(@result_messages, @error_messages);
 		}
 	}
 
 	my $number_of_recipients = @recipients - $failed_messages;
-	return $job->maketext(
-		'A message with the subject line "[_1]" has been sent to [quant,_2,recipient] in the class [_3].  '
-			. 'There were [_4] message(s) that could not be sent.',
-		$mail_data->{subject}, $number_of_recipients, $mail_data->{courseName},
+	return (
+		$job->maketext(
+			'A message with the subject line "[_1]" has been sent to [quant,_2,recipient].',
+			$mail_data->{subject}, $number_of_recipients
+		),
 		$failed_messages
-		)
-		. "\n\n"
-		. $result_message;
-}
-
-sub email_notification ($job, $ce, $mail_data, $result_message) {
-	my $email =
-		Email::Stuffer->to($mail_data->{defaultFrom})->from($mail_data->{defaultFrom})->subject('WeBWorK email sent')
-		->text_body($result_message)->header('X-Remote-Host' => $mail_data->{remote_host});
-
-	eval {
-		$email->send_or_die({
-			transport => createEmailSenderTransportSMTP($ce),
-			$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
-		});
-	};
-	$job->app->log->error("Error sending email: $@") if $@;
-
-	$job->app->log->info("WeBWorK::Tasks::SendInstructorEmail: Instructor message sent from $mail_data->{defaultFrom}");
-
-	return;
+		? ($job->maketext(
+			'There [plural,_1,was,were] [quant,_1,message] that could not be sent.',
+			$failed_messages
+		))
+		: (),
+		@result_messages
+	);
 }
 
 sub maketext ($job, @args) {

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -43,11 +43,13 @@ sub run ($job, $mail_data) {
 	if ($@) {
 		push(@result_messages,
 			$job->maketext('An error occurred while trying to send email.'),
-			$job->maketext('The error message is:'),
-			ref($@) ? $@->message : $@);
+			$job->maketext('The error message is: [_1]', ref($@) ? $@->message : $@),
+		);
+		$job->app->log->error($_) for @result_messages;
 		return $job->fail(\@result_messages);
 	}
 
+	$job->app->log->error($_) for @result_messages;
 	return $job->finish(\@result_messages);
 }
 

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -257,13 +257,13 @@ sub checkForAchievements ($problem_in, $pg, $c, %options) {
 				send_achievement_email => [ {
 					recipient       => $user_id,
 					subject         => 'Congratulations on earning a new achievement!',
-					courseName      => $ce->{courseName},
 					achievementID   => $achievement_id,
 					setID           => $set_id,
 					nextLevelPoints => $nextLevelPoints || 0,
 					pointsEarned    => $achievementPoints,
 					remote_host     => $c->tx->remote_address || "UNKNOWN",
-				} ]
+				} ],
+				{ notes => { courseID => $ce->{courseName} } }
 			) if ($ce->{mail}{achievementEmailFrom} && $achievement->email_template);
 		}
 

--- a/lib/WeBWorK/Authen/LTI/MassUpdate.pm
+++ b/lib/WeBWorK/Authen/LTI/MassUpdate.pm
@@ -63,7 +63,7 @@ sub mass_update ($c, $manual_update = 0, $userID = undef, $setID = undef) {
 		}
 	}
 
-	$c->minion->enqueue(lti_mass_update => [ $ce->{courseName}, $userID, $setID ]);
+	$c->minion->enqueue(lti_mass_update => [ $userID, $setID ], { notes => { courseID => $ce->{courseName} } });
 
 	return;
 }

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -50,7 +50,7 @@ sub new ($invocant, $c, $post_processing_mode = 0) {
 # is set, but these warnings are always sent to the debug log if debugging is enabled.
 sub warning ($self, $warning) {
 	debug($warning);
-	return unless $self->{c}{ce}{debug_lti_grade_passback};
+	return unless $self->{c}{ce}{debug_lti_grade_passback} || $self->{post_processing_mode};
 
 	if ($self->{post_processing_mode}) {
 		$self->{c}{app}->log->info($warning);

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -250,7 +250,7 @@ $emailableURL
 				$ce->{mail}{set_return_path} ? (from => $ce->{mail}{set_return_path}) : ()
 			});
 		} catch {
-			$c->stash->{send_error} = $c->maketext('Failed to send message: [_1]', $_);
+			$c->stash->{send_error} = $c->maketext('Failed to send message: [_1]', ref($_) ? $_->message : $_);
 		};
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
@@ -131,7 +131,7 @@ sub saveFileChanges ($c, $outputFilePath) {
 		print $OUTPUTFILE $c->stash('achievementNotification');
 		close $OUTPUTFILE;
 	};
-	my $writeFileErrors = $@ if $@;
+	my $writeFileErrors = $@;
 
 	# Catch errors in saving files,
 	if ($writeFileErrors) {
@@ -290,6 +290,8 @@ sub disable_handler ($c) {
 			$c->stash('achievementID')
 		));
 	}
+
+	return;
 }
 
 1;

--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -1,0 +1,205 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2021 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.	 See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package WeBWorK::ContentGenerator::Instructor::JobManager;
+use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
+
+=head1 NAME
+
+WeBWorK::ContentGenerator::Instructor::JobManager - Minion job queue job management
+
+=cut
+
+use WeBWorK::Utils qw(x);
+
+use constant ACTION_FORMS => [ [ filter => x('Filter') ], [ sort => x('Sort') ], [ delete => x('Delete') ] ];
+
+# All tasks added in the Mojolicious::WeBWorK module need to be listed here.
+use constant TASK_NAMES => {
+	lti_mass_update       => x('LTI Mass Update'),
+	send_instructor_email => x('Send Instructor Email')
+};
+
+# This constant is not used.  It is here so that gettext adds these strings to the translation files.
+use constant JOB_STATES => [ x('inactive'), x('active'), x('finished'), x('failed') ];
+
+use constant FIELDS => [
+	[ id       => x('Id') ],
+	[ courseID => x('Course Id') ],
+	[ task     => x('Task') ],
+	[ created  => x('Created') ],
+	[ started  => x('Started') ],
+	[ finished => x('Finished') ],
+	[ state    => x('State') ],
+];
+
+use constant SORT_SUBS => {
+	id       => \&byJobID,
+	courseID => \&byCourseID,
+	task     => \&byTask,
+	created  => \&byCreatedTime,
+	started  => \&byStartedTime,
+	finished => \&byFinishedTime,
+	state    => \&byState
+};
+
+sub initialize ($c) {
+	$c->stash->{taskNames}   = TASK_NAMES();
+	$c->stash->{actionForms} = ACTION_FORMS();
+	$c->stash->{fields} = $c->stash->{courseID} eq 'admin' ? FIELDS() : [ grep { $_ ne 'courseID' } @{ FIELDS() } ];
+	$c->stash->{jobs}   = {};
+	$c->stash->{visibleJobs}        = {};
+	$c->stash->{selectedJobs}       = {};
+	$c->stash->{sortedJobs}         = [];
+	$c->stash->{primarySortField}   = $c->param('primarySortField')   || 'created';
+	$c->stash->{secondarySortField} = $c->param('secondarySortField') || 'task';
+	$c->stash->{ternarySortField}   = $c->param('ternarySortField')   || 'state';
+
+	return unless $c->authz->hasPermissions($c->param('user'), 'access_instructor_tools');
+
+	# Get a list of all jobs.  If this is not the admin course, then restrict to the jobs for this course.
+	my $jobs = $c->minion->jobs;
+	while (my $job = $jobs->next) {
+		# Get the course id from the job arguments for backwards compatibility with jobs before the job manager was
+		# added and the course id was moved to the notes.
+		unless (defined $job->{notes}{courseID}) {
+			if (ref($job->{args}[0]) eq 'HASH' && defined $job->{args}[0]{courseName}) {
+				$job->{notes}{courseID} = $job->{args}[0]{courseName};
+			} else {
+				$job->{notes}{courseID} = $job->{args}[0];
+			}
+		}
+
+		# Copy the courseID from the notes hash directly to the job for convenience of access.  Particularly, so that
+		# that the filter_handler method can access it the same as for other fields.
+		$job->{courseID} = $job->{notes}{courseID};
+
+		$c->stash->{jobs}{ $job->{id} } = $job
+			if $c->stash->{courseID} eq 'admin' || $job->{courseID} eq $c->stash->{courseID};
+	}
+
+	if (defined $c->param('visible_jobs')) {
+		$c->stash->{visibleJobs} = { map { $_ => 1 } @{ $c->every_param('visible_jobs') } };
+	} elsif (defined $c->param('no_visible_jobs')) {
+		$c->stash->{visibleJobs} = {};
+	} else {
+		$c->stash->{visibleJobs} = { map { $_ => 1 } keys %{ $c->stash->{jobs} } };
+	}
+
+	$c->stash->{selectedJobs} = { map { $_ => 1 } @{ $c->every_param('selected_jobs') // [] } };
+
+	my $actionID = $c->param('action');
+	if ($actionID) {
+		my $actionHandler = "${actionID}_handler";
+		die $c->maketext('Action [_1] not found', $actionID) unless $c->can($actionHandler);
+		$c->addgoodmessage($c->$actionHandler);
+	}
+
+	# Sort jobs
+	my $primarySortSub   = SORT_SUBS()->{ $c->stash->{primarySortField} };
+	my $secondarySortSub = SORT_SUBS()->{ $c->stash->{secondarySortField} };
+	my $ternarySortSub   = SORT_SUBS()->{ $c->stash->{ternarySortField} };
+
+	# byJobID is included to ensure a definite sort order in case the
+	# first three sorts do not determine a proper order.
+	$c->stash->{sortedJobs} = [
+		map  { $_->{id} }
+		sort { &$primarySortSub || &$secondarySortSub || &$ternarySortSub || byJobID }
+		grep { $c->stash->{visibleJobs}{ $_->{id} } } (values %{ $c->stash->{jobs} })
+	];
+
+	return;
+}
+
+sub filter_handler ($c) {
+	my $ce = $c->ce;
+
+	my $scope = $c->param('action.filter.scope');
+	if ($scope eq 'all') {
+		$c->stash->{visibleJobs} = { map { $_ => 1 } keys %{ $c->stash->{jobs} } };
+		return $c->maketext('Showing all jobs.');
+	} elsif ($scope eq 'selected') {
+		$c->stash->{visibleJobs} = $c->stash->{selectedJobs};
+		return $c->maketext('Showing selected jobs.');
+	} elsif ($scope eq 'match_regex') {
+		my $regex = $c->param('action.filter.text');
+		my $field = $c->param('action.filter.field');
+		$c->stash->{visibleJobs} = {};
+		for my $jobID (keys %{ $c->stash->{jobs} }) {
+			$c->stash->{visibleJobs}{$jobID} = 1 if $c->stash->{jobs}{$jobID}{$field} =~ /^$regex/i;
+		}
+		return $c->maketext('Showing matching jobs.');
+	}
+
+	# This should never happen.  As such it is not translated.
+	return 'Not filtering. Unknown filter given.';
+}
+
+sub sort_handler ($c) {
+	if (defined $c->param('labelSortMethod')) {
+		$c->stash->{ternarySortField}   = $c->stash->{secondarySortField};
+		$c->stash->{secondarySortField} = $c->stash->{primarySortField};
+		$c->stash->{primarySortField}   = $c->param('labelSortMethod');
+		$c->param('action.sort.primary',   $c->stash->{primarySortField});
+		$c->param('action.sort.secondary', $c->stash->{secondarySortField});
+		$c->param('action.sort.ternary',   $c->stash->{ternarySortField});
+	} else {
+		$c->stash->{primarySortField}   = $c->param('action.sort.primary');
+		$c->stash->{secondarySortField} = $c->param('action.sort.secondary');
+		$c->stash->{ternarySortField}   = $c->param('action.sort.ternary');
+	}
+
+	return $c->maketext(
+		'Users sorted by [_1], then by [_2], then by [_3]',
+		$c->maketext((grep { $_->[0] eq $c->stash->{primarySortField} } @{ FIELDS() })[0][1]),
+		$c->maketext((grep { $_->[0] eq $c->stash->{secondarySortField} } @{ FIELDS() })[0][1]),
+		$c->maketext((grep { $_->[0] eq $c->stash->{ternarySortField} } @{ FIELDS() })[0][1])
+	);
+
+}
+
+sub delete_handler ($c) {
+	my $num = 0;
+	return $c->maketext('Deleted [quant,_1,job].', $num) if $c->param('action.delete.scope') eq 'none';
+
+	for my $jobID (keys %{ $c->stash->{selectedJobs} }) {
+		# If a job was inactive (not yet started) when the page was previously loaded, then it may be selected to be
+		# deleted.  By the time the delete form is submitted the job may have started and may now be active. In that
+		# case it can not be deleted.
+		if ($c->stash->{jobs}{$jobID}{state} eq 'active') {
+			$c->addbadmessage(
+				$c->maketext('Unable to delete job [_1] as it has transitioned to an active state.', $jobID));
+			next;
+		}
+		delete $c->stash->{jobs}{$jobID};
+		delete $c->stash->{visibleJobs}{$jobID};
+		delete $c->stash->{selectedJobs}{$jobID};
+		$c->minion->job($jobID)->remove;
+		++$num;
+	}
+
+	return $c->maketext('Deleted [quant,_1,job].', $num);
+}
+
+# Sort methods
+sub byJobID        { return $a->{id} <=> $b->{id} }
+sub byCourseID     { return lc $a->{courseID} cmp lc $b->{courseID} }
+sub byTask         { return $a->{task} cmp $b->{task} }
+sub byCreatedTime  { return $a->{created} <=> $b->{created} }
+sub byStartedTime  { return ($a->{started}  || 0) <=> ($b->{started}  || 0) }
+sub byFinishedTime { return ($a->{finished} || 0) <=> ($b->{finished} || 0) }
+sub byState        { return $a->{state} cmp $b->{state} }
+
+1;

--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -28,8 +28,9 @@ use constant ACTION_FORMS => [ [ filter => x('Filter') ], [ sort => x('Sort') ],
 
 # All tasks added in the Mojolicious::WeBWorK module need to be listed here.
 use constant TASK_NAMES => {
-	lti_mass_update       => x('LTI Mass Update'),
-	send_instructor_email => x('Send Instructor Email')
+	lti_mass_update        => x('LTI Mass Update'),
+	send_instructor_email  => x('Send Instructor Email'),
+	send_achievement_email => x('Send Achiement Email')
 };
 
 # This constant is not used.  It is here so that gettext adds these strings to the translation files.

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -348,11 +348,10 @@ sub initialize ($c) {
 		# we don't set the response until we're sure that email can be sent
 		$c->{response} = 'send_email';
 
-		# Do actual mailing in the after the response is sent, since it could take a long time
-		# FIXME we need to do a better job providing status notifications for long-running email jobs
+		# The emails are actually sent in the job queue, since it could take a long time.
+		# Note that the instructor can check the job manager page to see the status of the job.
 		$c->minion->enqueue(
 			send_instructor_email => [ {
-				courseName  => $c->stash('courseID'),
 				recipients  => $c->{ra_send_to},
 				subject     => $c->{subject},
 				text        => ${ $c->{r_text} // \'' },
@@ -360,7 +359,8 @@ sub initialize ($c) {
 				from        => $c->{from},
 				defaultFrom => $c->{defaultFrom},
 				remote_host => $c->{remote_host},
-			} ]
+			} ],
+			{ notes => { courseID => $c->stash('courseID') } }
 		);
 	} else {
 		$c->addbadmessage($c->maketext(q{Didn't recognize action}));

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -458,7 +458,7 @@ Comment:    $comment
 		});
 		debug('Successfully sent JITAR alert message');
 	} catch {
-		$c->log->error("Failed to send JITAR alert message: $_");
+		$c->log->error('Failed to send JITAR alert message: ' . (ref($_) ? $_->message : $_));
 	};
 
 	return '';

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -104,6 +104,8 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
 
  instructor_lti_update               /$courseID/instructor/lti_update
 
+ instructor_job_manager              /$courseID/instructor/job_manager
+
  problem_list                        /$courseID/$setID
  problem_detail                      /$courseID/$setID/$problemID
  show_me_another                     /$courseID/$setID/$problemID/show_me_another
@@ -328,6 +330,7 @@ my %routeParameters = (
 			instructor_progress
 			instructor_problem_grader
 			instructor_lti_update
+			instructor_job_manager
 		) ],
 		module => 'Instructor::Index',
 		path   => '/instructor'
@@ -486,6 +489,11 @@ my %routeParameters = (
 		title  => x('LTI Grade Update'),
 		module => 'Instructor::LTIUpdate',
 		path   => '/lti_update'
+	},
+	instructor_job_manager => {
+		title  => x('Job Manager'),
+		module => 'Instructor::JobManager',
+		path   => '/job_manager'
 	},
 
 	problem_list => {

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -11,14 +11,14 @@
 		</li>
 		% for (
 			% [
-			% 	'add_course',
-			% 	maketext('Add Courses'),
-			% 	{
-			% 		add_admin_users      => 1,
-			% 		add_config_file      => 1,
-			% 		add_dbLayout         => 'sql_single',
-			% 		add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
-			% 	}
+				% 'add_course',
+				% maketext('Add Courses'),
+				% {
+					% add_admin_users      => 1,
+					% add_config_file      => 1,
+					% add_dbLayout         => 'sql_single',
+					% add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
+				% }
 			% ],
 			% [ 'rename_course',        maketext('Rename Courses') ],
 			% [ 'delete_course',        maketext('Delete Courses') ],
@@ -27,8 +27,7 @@
 			% [ 'upgrade_course',       maketext('Upgrade Courses') ],
 			% [ 'hide_inactive_course', maketext('Hide Courses') ],
 			% [ 'manage_locations',     maketext('Manage Locations') ],
-		% )
-		% {
+		% ) {
 			<li class="list-group-item nav-item">
 				<%= $makelink->(
 					'set_list',
@@ -42,6 +41,7 @@
 		% if ($authz->hasPermissions($userID, 'send_mail')) {
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
 		% }
+		<li class="list-group-item nav-item"><%= $makelink->('instructor_job_manager') %></li>
 		<li class="list-group-item nav-item">
 			<%= $makelink->(
 				'instructor_file_manager',

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -352,6 +352,8 @@
 			% if ($authz->hasPermissions($userID, 'send_mail')) {
 				<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
 			% }
+			% # Job Manager
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_job_manager') %></li>
 			% # File Manager
 			% if ($authz->hasPermissions($userID, 'manage_course_files')) {
 				<li class="list-group-item nav-item"><%= $makelink->('instructor_file_manager') %></li>

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -1,0 +1,184 @@
+% use WeBWorK::Utils qw(getAssetURL);
+%
+% content_for css => begin
+	<%= stylesheet getAssetURL($ce, 'js/JobManager/jobmanager.css') =%>
+% end
+%
+% content_for js => begin
+	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'), defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/SelectAll/selectall.js'),   defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/JobManager/jobmanager.js'), defer => undef =%>
+% end
+%
+% unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
+	<div class="alert alert-danger p-1"><%= maketext('You are not authorized to access instructor tools.') =%></div>
+	% last;
+% }
+%
+% unless (keys %$jobs) {
+	<div><%= maketext('No jobs in queue.') %></div>
+	% last;
+% }
+%
+<%= form_for current_route, method => 'POST', name => 'joblist', begin =%>
+	<%= $c->hidden_authen_fields =%>
+	%
+	% if (keys %$visibleJobs) {
+		% for (keys %$visibleJobs) {
+			<%= hidden_field visible_jobs => $_ =%>
+		% }
+	% } else {
+		<%= hidden_field no_visible_jobs => '1' =%>
+	% }
+	%
+	<%= hidden_field primarySortField   => $primarySortField =%>
+	<%= hidden_field secondarySortField => $secondarySortField =%>
+	<%= hidden_field ternarySortField   => $ternarySortField =%>
+	%
+	% # Output action forms
+	% for my $form (@$actionForms) {
+		% my $active = $form->[0] eq 'filter' ? ' active' : '';
+		%
+		% content_for 'tab-list' => begin
+			<li class="nav-item" role="presentation">
+				<%= link_to maketext($form->[1]) => "#$form->[0]",
+					class            => "nav-link action-link$active",
+					id               => "$form->[0]-tab",
+					data             => { action => $form->[0], bs_toggle => 'tab', bs_target => "#$form->[0]" },
+					role             => 'tab',
+					'aria-controls'  => $form->[0],
+					'aria-selected'  => $active ? 'true' : 'false' =%>
+			</li>
+		% end
+		%
+		% content_for 'tab-content' => begin
+			<div class="tab-pane fade mb-2 <%= $active ? " show$active" : '' %>" id="<%= $form->[0] %>"
+				role="tabpanel" aria-labelledby="<%= $form->[0] %>-tab">
+				<%= include "ContentGenerator/Instructor/JobManager/$form->[0]_form" =%>
+			</div>
+		% end
+	% }
+	%
+	<%= hidden_field action => $actionForms->[0][0], id => 'current_action' =%>
+	<div>
+		<ul class="nav nav-tabs mb-2" role="tablist"><%= content 'tab-list' =%></ul>
+		<div class="tab-content"><%= content 'tab-content' %></div>
+	</div>
+	%
+	<div class="mb-3">
+		<%= submit_button maketext($actionForms->[0][1]), id => 'take_action', class => 'btn btn-primary' =%>
+	</div>
+	%
+	% # Show the jobs table
+	<div class="table-responsive">
+		<table class="table table-sm table-bordered caption-top font-sm">
+			<thead class="table-group-divider">
+				<tr>
+					<th>
+						<%= check_box 'select-all' => 'on', id => 'select-all',
+							'aria-label' => maketext('Select all jobs'),
+							data => { select_group => 'selected_jobs' },
+							class => 'select-all form-check-input' =%>
+					</th>
+					<th>
+						<%= label_for 'select-all' =>
+							link_to maketext('Id') => '#', class => 'sort-header', data => { sort_field => 'id' } =%>
+					</th>
+					% if ($courseID eq 'admin') {
+						<th>
+							<%= link_to maketext('Course Id') => '#', class => 'sort-header',
+								data => { sort_field => 'courseID' } =%>
+						</th>
+					% }
+					<th>
+						<%= link_to maketext('Task') => '#', class => 'sort-header',
+							data => { sort_field => 'task' } =%>
+					</th>
+					<th>
+						<%= link_to maketext('Created') => '#', class => 'sort-header',
+							data => { sort_field => 'created' } =%>
+					</th>
+					<th>
+						<%= link_to maketext('Started') => '#', class => 'sort-header',
+							data => { sort_field => 'started' } =%>
+					</th>
+					<th>
+						<%= link_to maketext('Finished') => '#', class => 'sort-header',
+							data => { sort_field => 'finished' } =%>
+					</th>
+					<th>
+						<%= link_to maketext('State') => '#', class => 'sort-header',
+							data => { sort_field => 'state' } =%>
+					</th>
+				</tr>
+			</thead>
+			<tbody class="table-group-divider">
+				% for my $jobID (@$sortedJobs) {
+					<tr>
+						% if ($jobs->{$jobID}{state} eq 'active') {
+							% # Active jobs can not be deleted, and so a checkbox is not provided to select them.
+							<td></td>
+							<td><%= $jobID =%></td>
+						% } else {
+							<td>
+								<%= check_box selected_jobs => $jobID, id => "job_${jobID}_checkbox",
+									class => 'form-check-input', $selectedJobs->{$jobID} ? (checked => undef) : () =%>
+							</td>
+							<td><%= label_for "job_${jobID}_checkbox" => $jobID =%></td>
+						% }
+						% if ($courseID eq 'admin') {
+							<td class="text-nowrap"><%= $jobs->{$jobID}{courseID} =~ s/_/ /gr =%></td>
+						% }
+						<td class="text-nowrap">
+							<%= $taskNames->{ $jobs->{$jobID}{task} }
+								? maketext($taskNames->{ $jobs->{$jobID}{task} })
+								: $jobs->{$jobID}{task} =%>
+						</td>
+						<td class="text-nowrap">
+							<%= $c->formatDateTime(
+								$jobs->{$jobID}{created}, '', 'datetime_format_medium', $ce->{language}) =%>
+						</td>
+						<td class="text-nowrap">
+							% if ($jobs->{$jobID}{started}) {
+								<%= $c->formatDateTime(
+									$jobs->{$jobID}{started}, '', 'datetime_format_medium', $ce->{language}) =%>
+							% }
+						</td>
+						<td class="text-nowrap">
+							% if ($jobs->{$jobID}{finished}) {
+								<%= $c->formatDateTime(
+									$jobs->{$jobID}{finished}, '', 'datetime_format_medium', $ce->{language}) =%>
+							% }
+						</td>
+						<td>
+							<div class="d-flex justify-content-between gap-1">
+								<%= maketext($jobs->{$jobID}{state}) =%>
+								% if (defined $jobs->{$jobID}{result}) {
+									% content_for "result_$jobID", begin
+										% if (ref($jobs->{$jobID}{result}) eq 'ARRAY') {
+											<ul class="m-0">
+												% for (@{ $jobs->{$jobID}{result} } ) {
+													<li><%= $_ %></li>
+												% }
+											</ul>
+										% } else {
+											<%= $jobs->{$jobID}{result} =%>
+										% }
+									% end
+									<a role="button" class="result-popover-btn" tabindex="0" data-bs-toggle="popover"
+										data-bs-title="<%= maketext('Result for job [_1]', $jobID) %>"
+										data-bs-content="<%= content("result_$jobID")->xml_escape %>">
+										<i class="fa-solid fa-circle-info fa-xl" aria-hidden="true"></i>
+										<span class="visually-hidden">
+											<%= maketext('Result for job [_1]', $jobID) %>
+										</span>
+									</a>
+								% }
+							</div>
+						</td>
+					</tr>
+				% }
+			</tbody>
+		</table>
+	</div>
+% end

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -32,8 +32,11 @@
 	% }
 	%
 	<%= hidden_field primarySortField   => $primarySortField =%>
+	<%= hidden_field primarySortOrder   => $primarySortOrder =%>
 	<%= hidden_field secondarySortField => $secondarySortField =%>
+	<%= hidden_field secondarySortOrder => $secondarySortOrder =%>
 	<%= hidden_field ternarySortField   => $ternarySortField =%>
+	<%= hidden_field ternarySortOrder   => $ternarySortOrder =%>
 	%
 	% # Output action forms
 	% for my $form (@$actionForms) {
@@ -74,41 +77,71 @@
 		<table class="table table-sm table-bordered caption-top font-sm">
 			<thead class="table-group-divider">
 				<tr>
-					<th>
-						<%= check_box 'select-all' => 'on', id => 'select-all',
-							'aria-label' => maketext('Select all jobs'),
-							data => { select_group => 'selected_jobs' },
-							class => 'select-all form-check-input' =%>
+					<th class="text-nowrap">
+						<%= label_for 'select-all', begin =%>
+							<%= check_box 'select-all' => 'on', id => 'select-all',
+								class => 'select-all form-check-input set-id-tooltip',
+								'aria-label' => maketext('Select all jobs'),
+								data => {
+									select_group => 'selected_jobs',
+									bs_toggle => 'tooltip',
+									bs_placement => 'right',
+									bs_title => maketext('Select all jobs')
+							} =%>
+							<i class="fa-solid fa-check-double" aria-hidden="true"></i>
+						<% end =%>
 					</th>
 					<th>
-						<%= label_for 'select-all' =>
-							link_to maketext('Id') => '#', class => 'sort-header', data => { sort_field => 'id' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('Id') => '#', class => 'sort-header',
+								data => { sort_field => 'id' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'id' =%>
+						</div>
 					</th>
 					% if ($courseID eq 'admin') {
 						<th>
-							<%= link_to maketext('Course Id') => '#', class => 'sort-header',
-								data => { sort_field => 'courseID' } =%>
+							<div class="d-flex justify-content-between align-items-end gap-1">
+								<%= link_to maketext('Course Id') => '#', class => 'sort-header',
+									data => { sort_field => 'courseID' } =%>
+								<%= include 'ContentGenerator/Instructor/JobManager/sort_button',
+									field => 'course_id' =%>
+							</div>
 						</th>
 					% }
 					<th>
-						<%= link_to maketext('Task') => '#', class => 'sort-header',
-							data => { sort_field => 'task' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('Task') => '#', class => 'sort-header',
+								data => { sort_field => 'task' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'task' =%>
+						</div>
 					</th>
 					<th>
-						<%= link_to maketext('Created') => '#', class => 'sort-header',
-							data => { sort_field => 'created' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('Created') => '#', class => 'sort-header',
+								data => { sort_field => 'created' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'created' =%>
+						</div>
 					</th>
 					<th>
-						<%= link_to maketext('Started') => '#', class => 'sort-header',
-							data => { sort_field => 'started' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('Started') => '#', class => 'sort-header',
+								data => { sort_field => 'started' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'started' =%>
+						</div>
 					</th>
 					<th>
-						<%= link_to maketext('Finished') => '#', class => 'sort-header',
-							data => { sort_field => 'finished' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('Finished') => '#', class => 'sort-header',
+								data => { sort_field => 'finished' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'finished' =%>
+						</div>
 					</th>
 					<th>
-						<%= link_to maketext('State') => '#', class => 'sort-header',
-							data => { sort_field => 'state' } =%>
+						<div class="d-flex justify-content-between align-items-end gap-1">
+							<%= link_to maketext('State') => '#', class => 'sort-header',
+								data => { sort_field => 'state' } =%>
+							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'state' =%>
+						</div>
 					</th>
 				</tr>
 			</thead>

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -1,9 +1,5 @@
 % use WeBWorK::Utils qw(getAssetURL);
 %
-% content_for css => begin
-	<%= stylesheet getAssetURL($ce, 'js/JobManager/jobmanager.css') =%>
-% end
-%
 % content_for js => begin
 	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'), defer => undef =%>
 	<%= javascript getAssetURL($ce, 'js/SelectAll/selectall.js'),   defer => undef =%>
@@ -187,25 +183,39 @@
 							<div class="d-flex justify-content-between gap-1">
 								<%= maketext($jobs->{$jobID}{state}) =%>
 								% if (defined $jobs->{$jobID}{result}) {
-									% content_for "result_$jobID", begin
-										% if (ref($jobs->{$jobID}{result}) eq 'ARRAY') {
-											<ul class="m-0">
-												% for (@{ $jobs->{$jobID}{result} } ) {
-													<li><%= $_ %></li>
-												% }
-											</ul>
-										% } else {
-											<%= $jobs->{$jobID}{result} =%>
-										% }
-									% end
-									<a role="button" class="result-popover-btn" tabindex="0" data-bs-toggle="popover"
-										data-bs-title="<%= maketext('Result for job [_1]', $jobID) %>"
-										data-bs-content="<%= content("result_$jobID")->xml_escape %>">
+									<a role="button" class="result-btn" tabindex="0" data-bs-toggle="modal" href="#"
+										data-bs-target="<%= "#result-$jobID" %>">
 										<i class="fa-solid fa-circle-info fa-xl" aria-hidden="true"></i>
 										<span class="visually-hidden">
 											<%= maketext('Result for job [_1]', $jobID) %>
 										</span>
 									</a>
+									<div class="result-modal modal fade" id="<%= "result-$jobID" %>" tabindex="-1"
+										aria-labelledby="<%= "result-$jobID-label" %>" aria-hidden="true">
+										<div class="modal-dialog modal-dialog-centered modal-lg">
+											<div class="modal-content">
+												<div class="modal-header">
+													<h1 class="modal-title fs-5" id="<%= "result-$jobID-label" %>">
+														<%= maketext('Result for job [_1]', $jobID) %>
+													</h1>
+													<button type="button" class="btn-close" data-bs-dismiss="modal"
+														aria-label="<%= maketext("Close") %>">
+													</button>
+												</div>
+												<div class="modal-body">
+													% if (ref($jobs->{$jobID}{result}) eq 'ARRAY') {
+														<ul class="list-group list-group-flush">
+															% for (@{ $jobs->{$jobID}{result} } ) {
+																<li class="list-group-item py-1"><%= $_ %></li>
+															% }
+														</ul>
+													% } else {
+														<%= $jobs->{$jobID}{result} =%>
+													% }
+												</div>
+											</div>
+										</div>
+									</div>
 								% }
 							</div>
 						</td>

--- a/templates/ContentGenerator/Instructor/JobManager/delete_form.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/delete_form.html.ep
@@ -1,0 +1,13 @@
+<div>
+	<div class="row mb-2">
+		<%= label_for delete_select => maketext('Delete which jobs?'),
+			class => 'col-form-label col-form-label-sm col-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.delete.scope' => [
+					[ maketext('no jobs')       => 'none', selected => undef ],
+					[ maketext('selected jobs') => 'selected' ]
+				],
+				id => 'delete_select', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+</div>

--- a/templates/ContentGenerator/Instructor/JobManager/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/filter_form.html.ep
@@ -1,0 +1,38 @@
+<div>
+	<div class="row mb-2">
+		<%= label_for filter_select => maketext('Show which jobs?'),
+			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.filter.scope' => [
+					[ maketext('all jobs')                          => 'all' ],
+					[ maketext('selected jobs')                     => 'selected' ],
+					[ maketext('jobs that match on selected field') => 'match_regex', selected => undef ]
+				],
+				id => 'filter_select', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div id="filter_elements">
+		<div class="row mb-2">
+			<%= label_for 'filter_type_select' => maketext('What field should filtered jobs match on?'),
+				class => 'col-form-label col-form-label-sm col-sm-auto' =%>
+			<div class="col-auto">
+				<%= select_field 'action.filter.field' => [
+						[ maketext('Id')    => 'id', selected => undef ],
+						$courseID eq 'admin' ? [ maketext('Course Id')    => 'courseID' ] : (),
+						[ maketext('Task')  => 'task' ],
+						[ maketext('State') => 'state' ]
+					],
+					id => 'filter_type_select', class => 'form-select form-select-sm' =%>
+			</div>
+		</div>
+		<div class="row mb-2">
+			<%= label_for 'filter_text', class => 'col-form-label col-form-label-sm col-sm-auto', begin =%>
+				<%= maketext('Filter by what text?') %><span class="required-field">*</span>
+			<% end =%>
+			<div class="col-auto">
+				<%= text_field 'action.filter.text' => '', id => 'filter_text', 'aria-required' => 'true',
+					class => 'form-control form-control-sm' =%>
+			</div>
+		</div>
+	</div>
+</div>

--- a/templates/ContentGenerator/Instructor/JobManager/sort_button.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/sort_button.html.ep
@@ -1,0 +1,37 @@
+% if ($primarySortField eq $field) {
+	<button type="button" data-sort-priority="primary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
+		1
+		% if ($primarySortOrder eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% } elsif ($secondarySortField eq $field) {
+	<button type="button" data-sort-priority="secondary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
+		2
+		% if ($secondarySortOrder eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% } elsif ($ternarySortField eq $field) {
+	<button type="button" data-sort-priority="ternary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
+		3
+		% if ($ternarySortOrder eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% }

--- a/templates/ContentGenerator/Instructor/JobManager/sort_form.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/sort_form.html.ep
@@ -1,41 +1,92 @@
 <div>
-	<div class="row mb-2">
-		<%= label_for sort_select_1 => maketext('Sort by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.primary' => [
-					map { [
-						maketext($_->[1]) => $_->[0],
-						$_->[0] eq 'created' ? (selected => undef) : ()
-					] } @$fields
-				],
-				id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_1 => maketext('Sort by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary' => [
+							map { [
+								maketext($_->[1]) => $_->[0],
+								$_->[0] eq 'created' ? (selected => undef) : ()
+							] } @$fields
+						],
+						id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_1 => maketext('Ordered') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
-	<div class="row mb-2">
-		<%= label_for sort_select_2 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.secondary' => [
-					map { [
-						maketext($_->[1]) => $_->[0],
-						$_->[0] eq 'task' ? (selected => undef) : ()
-					] } @$fields
-				],
-				id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_2 => maketext('Then by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary' => [
+							map { [
+								maketext($_->[1]) => $_->[0],
+								$_->[0] eq 'task' ? (selected => undef) : ()
+							] } @$fields
+						],
+						id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_2 => maketext('Ordered') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
-	<div class="row mb-2">
-		<%= label_for sort_select_3 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.ternary' => [
-					map { [
-						maketext($_->[1]) => $_->[0],
-						$_->[0] eq 'state' ? (selected => undef) : ()
-					] } @$fields
-				],
-				id => 'sort_select_3', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_3 => maketext('Then by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.ternary' => [
+							map { [
+								maketext($_->[1]) => $_->[0],
+								$_->[0] eq 'state' ? (selected => undef) : ()
+							] } @$fields
+						],
+						id => 'sort_select_3', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_3 => maketext('Ordered') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.ternary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_3', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/JobManager/sort_form.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/sort_form.html.ep
@@ -1,0 +1,41 @@
+<div>
+	<div class="row mb-2">
+		<%= label_for sort_select_1 => maketext('Sort by') . ':', class => 'col-form-label col-form-label-sm',
+			style => 'width:4.5rem' =%>
+		<div class="col-auto">
+			<%= select_field 'action.sort.primary' => [
+					map { [
+						maketext($_->[1]) => $_->[0],
+						$_->[0] eq 'created' ? (selected => undef) : ()
+					] } @$fields
+				],
+				id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="row mb-2">
+		<%= label_for sort_select_2 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
+			style => 'width:4.5rem' =%>
+		<div class="col-auto">
+			<%= select_field 'action.sort.secondary' => [
+					map { [
+						maketext($_->[1]) => $_->[0],
+						$_->[0] eq 'task' ? (selected => undef) : ()
+					] } @$fields
+				],
+				id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="row mb-2">
+		<%= label_for sort_select_3 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
+			style => 'width:4.5rem' =%>
+		<div class="col-auto">
+			<%= select_field 'action.sort.ternary' => [
+					map { [
+						maketext($_->[1]) => $_->[0],
+						$_->[0] eq 'state' ? (selected => undef) : ()
+					] } @$fields
+				],
+				id => 'sort_select_3', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+</div>

--- a/templates/ContentGenerator/Instructor/SendMail.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail.html.ep
@@ -23,8 +23,9 @@
 		% my $message = begin
 			<i>
 				<%= maketext(
-					'Email is being sent to [quant,_1,recipient]. You will be notified by email '
-						. 'when the task is completed.  This may take several minutes if the class is large.',
+					'Email is being sent to [quant,_1,recipient]. '
+						. 'This job may take several minutes to complete if the class is large. '
+						. 'Go to the "Job Manager" to see the status of this job.',
 					scalar(@{ $c->{ra_send_to} })
 				) =%>
 			</i>

--- a/templates/HelpFiles/InstructorJobManager.html.ep
+++ b/templates/HelpFiles/InstructorJobManager.html.ep
@@ -54,7 +54,8 @@
 			. 'executed. If a job is "finished" it means that the execution of the job has successfully '
 			. 'completed. If a job is "failed" it means that the execution of job has completed, but there were '
 			. 'errors in the execution of the job. If the job is in the "finished" or "failed" state, then there '
-			. 'will also be a popover containing information about what happened when the job was executed.') =%>
+			. 'will also be a button which when clicked will show a dialog containing information about what happened '
+			. 'when the job was executed.') =%>
 	</dd>
 </dl>
 %

--- a/templates/HelpFiles/InstructorJobManager.html.ep
+++ b/templates/HelpFiles/InstructorJobManager.html.ep
@@ -1,0 +1,80 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Job Manager Help');
+%
+<p>
+	<%= maketext('This page allows one to view and manage jobs in job queue. Note that completed jobs are '
+		. 'automatically removed from the job queue after two days. So there is no real need to delete jobs. '
+		. 'The importance of this page is to see the status of recently completed or in progress jobs.') =%>
+</p>
+<h2><%= maketext('Job Table Column Descriptions:') %></h2>
+<dl>
+	<dt><%= maketext('Id') %></dt>
+	<dd>
+		<%= maketext('The job id is an automatically incremented integer.  It is used internally to uniquely identify '
+			. 'jobs.  It is also used to reference jobs in messages on this page.') =%>
+	</dd>
+	<dt><%= maketext('Task') %></dt>
+	<dd>
+		<%= maketext('The name of the task.') =%>
+	</dd>
+	<dt><%= maketext('Created') %></dt>
+	<dd>
+		<%= maketext('The time that the job was added to the queue.') =%>
+	</dd>
+	<dt><%= maketext('Started') %></dt>
+	<dd>
+		<%= maketext('The time that execution of the job begins. If execution of the job has not started, '
+			. 'then this will be empty.') =%>
+	</dd>
+	<dt><%= maketext('Finished') %></dt>
+	<dd>
+		<%= maketext('The time that execution of the job completes. If execution of the job has not yet completed, '
+			. 'then this will be empty.') =%>
+	</dd>
+	<dt><%= maketext('State') %></dt>
+	<dd>
+		<%= maketext('The current state of the job.  This will be one of "inactive", "active", "finished", or '
+			. '"failed". If a job is "inactive" it means that the job has been added to the queue, but execution '
+			. 'of the job has not yet started. If a job is "active" it means that the job is currently being '
+			. 'executed. If a job is "finished" it means that the execution of the job has successfully '
+			. 'completed. If a job is "failed" it means that the execution of job has completed, but there were '
+			. 'errors in the execution of the job. If the job is in the "finished" or "failed" state, then there '
+			. 'will also be a popover containing information about what happened when the job was executed.') =%>
+	</dd>
+</dl>
+%
+<h2><%= maketext('Actions:') %></h2>
+<dl>
+	<dt><%= maketext('Filter') %></dt>
+	<dd>
+		<%= maketext('Filter jobs that are shown in the job table. Jobs can be filtered by Id, Task, or State, '
+			. 'or by selection.') =%>
+	</dd>
+	<dt><%= maketext('Sort') %></dt>
+	<dd>
+		<%= maketext('Sort jobs in the table by fields. The jobs in the table can also be sorted by clicking on '
+			. 'column headers in the table.') =%>
+	</dd>
+	<dt><%= maketext('Delete') %></dt>
+	<dd>
+		<%= maketext('Delete selected jobs.  Note that jobs that are in the "active" state can not be deleted. '
+			. 'Jobs that are in the "inactive" state can be deleted, but it is possible that by the time the request '
+			. 'to delete the job occurs the job may have transitioned into the "active" state.  In that case the job '
+			. 'will not be deleted. Jobs that are in the "finished" or "failed" states can always be deleted.') =%>
+	</dd>
+</dl>


### PR DESCRIPTION
All jobs for a course are listed on this page. The table displays the job id (this is used to reference specific jobs in action messages, otherwise it would not be shown), task name, created time, started time, finished time, and state.  Also a button that opens a popover containing the job result is in the state column if the job has completed.

Note that the Minion job queue automatically removes jobs from the job queue after two days (that is the default at least which we don't change).  So the real importance of this page is to allow the instructor to see the status of recently completed or in progress jobs.

At this point the actions available on the page are filter, sort, and delete.  Jobs can be filtered by id, task name, or state. Jobs can be sorted by clicking on the headers, or by using the sort form.  Jobs that are not active can be deleted.

Minion does not allow deletion of active jobs.  Note that an active job means a job that is currently running. As such they can not be selected on this page. Perhaps an option to stop running jobs could be added at if there is a problem with jobs hanging, but active jobs can not be directly stopped. The Minion worker is in a different process so the Mojolicious app needs to broadcast a signal to the Minion worker to do so.

An inactive job (i.e., a job that has been queued but has not started running yet) can be selected and deleted.  However, it is possible that the inactive job could start before the form is submitted.  In that case the job can not be deleted, and so an alert will show that.

In order to reliably associate a course with a job there is a new rule for tasks.  The job must pass the course id via the "notes" option of the Minion enqueue method.  The existing tasks have been updated to do this. There is also a backwards compatibility check to find jobs that passed it one of the ways the two jobs did it before in the job arguments.

Since the job fail/finish messages are now displayed in the UI, those messages are now translated. That is all except the first few messages in each task before the course environment is established, since a course environment is required to obtain the language of the course.

The send_instructor_email task no longer sends an email to the instructor after sending the emails to the students.  Instead the job result contains all of the information that would have been in that email. This is a far more reliable way of getting that information to the instructor sending the email.  The instructor just needs to go to the "Job Manager" page to see the result.  The message on the "Email" page tells the instructor this.

This page is also available for the admin course.  In the admin course all jobs for all courses are shown.  There is an additional column in the jobs table that shows the course id for the course the job was enqueued by.

Also, the errors that are reported when sending emails are made less verbose by calling the `message` method of the Mojo::Exception which does not include the traceback.