### PR TITLE
Add sort by column header click to the homework sets editor.

### DIFF
--- a/htdocs/js/ActionTabs/actiontabs.js
+++ b/htdocs/js/ActionTabs/actiontabs.js
@@ -30,6 +30,19 @@
 			header.addEventListener('keydown', (e) => {
 				if (e.key === ' ' || e.key === 'Enter') submitSortMethod(e);
 			});
+
+			const orderToggleButton = header.parentElement.querySelector('button.sort-order');
+			orderToggleButton?.addEventListener('click', () => {
+				currentAction.value = 'sort';
+
+				const sortOrderInput = document.createElement('input');
+				sortOrderInput.name = 'labelSortOrder';
+				sortOrderInput.value = orderToggleButton.dataset.sortPriority;
+				sortOrderInput.type = 'hidden';
+				currentAction.form.append(sortOrderInput);
+
+				currentAction.form.submit();
+			});
 		}
 	}
 })();

--- a/htdocs/js/ActionTabs/actiontabs.js
+++ b/htdocs/js/ActionTabs/actiontabs.js
@@ -1,11 +1,35 @@
 (() => {
 	const takeAction = document.getElementById('take_action');
+	const currentAction = document.getElementById('current_action');
 
 	document.querySelectorAll('.action-link').forEach((actionLink) => {
-		const currentAction = document.getElementById('current_action');
 		actionLink.addEventListener('show.bs.tab', () => {
 			if (takeAction) takeAction.value = actionLink.textContent;
 			if (currentAction) currentAction.value = actionLink.dataset.action;
 		});
 	});
+
+	// Submit the form when a sort header is clicked or enter or space is pressed when it has focus.
+	if (currentAction) {
+		for (const header of document.querySelectorAll('.sort-header')) {
+			const submitSortMethod = (e) => {
+				e.preventDefault();
+
+				currentAction.value = 'sort';
+
+				const sortInput = document.createElement('input');
+				sortInput.name = 'labelSortMethod';
+				sortInput.value = header.dataset.sortField;
+				sortInput.type = 'hidden';
+				currentAction.form.append(sortInput);
+
+				currentAction.form.submit();
+			};
+
+			header.addEventListener('click', submitSortMethod);
+			header.addEventListener('keydown', (e) => {
+				if (e.key === ' ' || e.key === 'Enter') submitSortMethod(e);
+			});
+		}
+	}
 })();

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -1,15 +1,14 @@
 (() => {
+	// Show/hide the filter elements depending on if the field matching option is selected.
 	const filter_select = document.getElementById('filter_select');
-	if (filter_select) {
-		const classlist_add_filter_elements = () => {
-			const filter_elements = document.getElementById('filter_elements');
-
-			if (filter_select.selectedIndex === 3) filter_elements.style.display = 'block';
+	const filter_elements = document.getElementById('filter_elements');
+	if (filter_select && filter_elements) {
+		const toggle_filter_elements = () => {
+			if (filter_select.value === 'match_regex') filter_elements.style.display = 'block';
 			else filter_elements.style.display = 'none';
 		};
-
-		filter_select.addEventListener('change', classlist_add_filter_elements);
-		classlist_add_filter_elements();
+		filter_select.addEventListener('change', toggle_filter_elements);
+		toggle_filter_elements();
 	}
 
 	const export_select_target = document.getElementById('export_select_target');
@@ -24,32 +23,5 @@
 
 		export_select_target.addEventListener('change', classlist_add_export_elements);
 		classlist_add_export_elements();
-	}
-
-	// Submit the user list form when a sort header is clicked or enter or space is pressed when it has focus.
-	const userListForm = document.forms['userlist'];
-	const currentAction = document.getElementById('current_action');
-
-	if (userListForm && currentAction) {
-		for (const header of document.querySelectorAll('.sort-header')) {
-			const submitSortMethod = (e) => {
-				e.preventDefault();
-
-				currentAction.value = '';
-
-				const sortInput = document.createElement('input');
-				sortInput.name = 'labelSortMethod';
-				sortInput.value = header.dataset.sortField;
-				sortInput.type = 'hidden';
-				userListForm.append(sortInput);
-
-				userListForm.submit();
-			};
-
-			header.addEventListener('click', submitSortMethod);
-			header.addEventListener('keydown', (e) => {
-				if (e.key === ' ' || e.key === 'Enter') submitSortMethod(e);
-			});
-		}
 	}
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -124,12 +124,10 @@ sub initialize ($c) {
 		my $actionHandler = "${actionID}_handler";
 		my ($success, $action_result) = $c->$actionHandler;
 		if ($success) {
-			$c->addgoodmessage($c->b($c->maketext('Result of last action performed: [_1]', $action_result)));
+			$c->addgoodmessage($c->b($action_result));
 		} else {
-			$c->addbadmessage($c->b($c->maketext('Result of last action performed: [_1]', $action_result)));
+			$c->addbadmessage($c->b($action_result));
 		}
-	} else {
-		$c->addgoodmessage($c->maketext('Please select action to be performed.'));
 	}
 
 	$c->stash->{formsToShow} = $c->{editMode} ? EDIT_FORMS() : $c->{exportMode} ? EXPORT_FORMS() : VIEW_FORMS();
@@ -153,9 +151,9 @@ sub edit_handler ($c) {
 	my $scope = $c->param('action.edit.scope');
 	if ($scope eq "all") {
 		$c->{selectedAchievementIDs} = $c->{allAchievementIDs};
-		$result = $c->maketext("editing all achievements");
+		$result = $c->maketext('Editing all achievements.');
 	} elsif ($scope eq "selected") {
-		$result = $c->maketext("editing selected achievements");
+		$result = $c->maketext('Editing selected achievements.');
 	}
 	$c->{editMode} = 1;
 
@@ -219,7 +217,7 @@ sub assign_handler ($c) {
 		}
 	}
 
-	return (1, $c->maketext('Assigned achievements to users'));
+	return (1, $c->maketext('Assigned achievements to users.'));
 }
 
 # Handler for scoring
@@ -311,7 +309,7 @@ sub score_handler ($c) {
 	return (
 		1,
 		$c->b($c->maketext(
-			'Achievement scores saved to [_1]',
+			'Achievement scores saved to [_1].',
 			$c->link_to(
 				$scoreFileName => $c->systemLink(
 					$c->url_for('instructor_file_manager'),
@@ -351,7 +349,7 @@ sub delete_handler ($c) {
 	$c->{selectedAchievementIDs} = [ keys %selectedAchievementIDs ];
 
 	my $num = @achievementIDsToDelete;
-	return (1, $c->maketext('Deleted [quant,_1,achievement]', $num));
+	return (1, $c->maketext('Deleted [quant,_1,achievement].', $num));
 }
 
 # Handler for creating an ahcievement
@@ -364,7 +362,7 @@ sub create_handler ($c) {
 	my $newAchievementID = $c->param('action.create.id');
 	return (0, $c->maketext("Failed to create new achievement: no achievement ID specified!"))
 		unless $newAchievementID =~ /\S/;
-	return (0, $c->maketext("Achievement [_1] exists.  No achievement created", $newAchievementID))
+	return (0, $c->maketext("Achievement [_1] exists.  No achievement created.", $newAchievementID))
 		if $db->existsAchievement($newAchievementID);
 	my $newAchievementRecord = $db->newAchievement;
 	my $oldAchievementID     = $c->{selectedAchievementIDs}->[0];
@@ -487,7 +485,7 @@ sub import_handler ($c) {
 
 	$c->{allAchievementIDs} = [ keys %allAchievementIDs ];
 
-	return (1, $c->maketext('Imported [quant,_1,achievement]', $count));
+	return (1, $c->maketext('Imported [quant,_1,achievement].', $count));
 }
 
 # Export handler
@@ -497,10 +495,10 @@ sub export_handler ($c) {
 
 	my $scope = $c->param('action.export.scope');
 	if ($scope eq "all") {
-		$result = $c->maketext("exporting all achievements");
+		$result = $c->maketext('Exporting all achievements.');
 		$c->{selectedAchievementIDs} = $c->{allAchievementIDs};
 	} elsif ($scope eq "selected") {
-		$result = $c->maketext("exporting selected achievements");
+		$result = $c->maketext('Exporting selected achievements.');
 		$c->{selectedAchievementIDs} = [ $c->param('selected_achievements') ];
 	}
 	$c->{exportMode} = 1;
@@ -512,7 +510,7 @@ sub export_handler ($c) {
 sub cancel_export_handler ($c) {
 	$c->{exportMode} = 0;
 
-	return (0, $c->maketext('export abandoned'));
+	return (0, $c->maketext('Export abandoned.'));
 }
 
 # Handler actually exporting achievements.
@@ -536,7 +534,7 @@ sub save_export_handler ($c) {
 	$FilePath = WeBWorK::Utils::surePathToFile($ce->{courseDirs}{achievements}, $FilePath);
 
 	my $fh = Mojo::File->new($FilePath)->open('>:encoding(UTF-8)')
-		or return (0, $c->maketext('Failed to open [_1]', $FilePath));
+		or return (0, $c->maketext('Failed to open [_1].', $FilePath));
 
 	my $csv = Text::CSV->new({ eol => "\n" });
 
@@ -557,13 +555,13 @@ sub save_export_handler ($c) {
 
 	$c->{exportMode} = 0;
 
-	return (1, $c->maketext('Exported achievements to [_1]', $FileName));
+	return (1, $c->maketext('Exported achievements to [_1].', $FileName));
 }
 
 # Handler for cancelling edits.
 sub cancel_edit_handler ($c) {
 	$c->{editMode} = 0;
-	return (1, $c->maketext('changes abandoned'));
+	return (1, $c->maketext('Changes abandoned.'));
 }
 
 # Handler for saving edits.
@@ -598,7 +596,7 @@ sub save_edit_handler ($c) {
 
 	$c->{editMode} = 0;
 
-	return (1, $c->maketext('changes saved'));
+	return (1, $c->maketext('Changes saved.'));
 }
 
 # Get list of files that can be imported.

--- a/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
@@ -38,17 +38,15 @@
 							$selectedAchievementIDs{ $_->achievement_id } ? (checked => undef) : () =%>
 					</td>
 					<td>
-						<div class="label-with-edit-icon">
-							<%= label_for "${achievement_id}_id", begin =%>
-								<%= $_->achievement_id %>
-								<%= link_to $c->systemLink(
-										url_for('instructor_achievement_list'),
-										params => { editMode => 1, selected_achievements => $achievement_id }
-									),
-									begin %>
-									<i class="icon fas fa-pencil-alt" data-alt="edit" aria-hidden="true"></i>
-								<% end %>
-							<% end =%>
+						<div class="d-flex justify-content-between gap-1">
+							<%= label_for "${achievement_id}_id" => $_->achievement_id =%>
+							<%= link_to $c->systemLink(
+									url_for('instructor_achievement_list'),
+									params => { editMode => 1, selected_achievements => $achievement_id }
+								),
+								begin %>
+								<i class="icon fas fa-pencil-alt" data-alt="edit" aria-hidden="true"></i>
+							<% end %>
 						</div>
 					</td>
 					<td><%= $_->enabled ? maketext('Yes') : maketext('No') %></td>

--- a/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
@@ -3,20 +3,27 @@
 		<caption><%= maketext('Achievement List') %></caption>
 		<thead class="table-group-divider">
 			<tr>
-				<th>
-					<%= check_box select_all => '',
-						id           => 'select-all',
-						class        => 'select-all form-check-input',
-						'aria-label' => maketext('Select all achievements'),
-						data         => { select_group => 'selected_achievements' } =%>
+				<th class="text-nowrap">
+					<%= label_for 'select-all', begin =%>
+						<%= check_box 'select-all' => '', id => 'select-all',
+							class => 'select-all form-check-input set-id-tooltip',
+							'aria-label' => maketext('Select all achievements'),
+							data => {
+								select_group => 'selected_achievements',
+								bs_toggle => 'tooltip',
+								bs_placement => 'right',
+								bs_title => maketext('Select all achievements')
+							} =%>
+						<i class="fa-solid fa-check-double" aria-hidden="true"></i>
+					<% end =%>
 				</th>
-				<th><%= label_for 'select-all' => maketext('Achievement ID') %></th>
+				<th><%= maketext('Achievement ID') %></th>
 				<th><%= maketext('Enabled') %></th>
 				<th><%= maketext('Name') %></th>
 				<th><%= maketext('Number') %></th>
 				<th><%= maketext('Category') %></th>
-				<th class="text-nowrap"><%= maketext('Edit Users') %></th>
-				<th class="text-nowrap"><%= maketext('Edit Evaluator') %></th>
+				<th><%= maketext('Users') %></th>
+				<th><%= maketext('Evaluator') %></th>
 			</tr>
 		</thead>
 		<tbody class="table-group-divider">

--- a/templates/ContentGenerator/Instructor/AchievementList/export_table.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/export_table.html.ep
@@ -4,13 +4,20 @@
 		<thead class="table-group-divider">
 			<tr>
 				<th>
-					<%= check_box select_all => '',
-						id           => 'select-all',
-						class        => 'select-all form-check-input',
-						'aria-label' => maketext('Select all achievements'),
-						data         => { select_group => 'selected_achievements' } =%>
+					<%= label_for 'select-all', begin =%>
+						<%= check_box 'select-all' => '', id => 'select-all',
+							class => 'select-all form-check-input set-id-tooltip',
+							'aria-label' => maketext('Select all achievements'),
+							data => {
+								select_group => 'selected_achievements',
+								bs_toggle => 'tooltip',
+								bs_placement => 'right',
+								bs_title => maketext('Select all achievements')
+							} =%>
+						<i class="fa-solid fa-check-double" aria-hidden="true"></i>
+					<% end =%>
 				</th>
-				<th class="text-nowrap"><%= label_for 'select-all' => maketext('Achievement ID') %></th>
+				<th class="text-nowrap"><%= maketext('Achievement ID') %></th>
 				<th><%= maketext('Name') %></th>
 			</tr>
 		</thead>

--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -62,7 +62,9 @@
 	<%= hidden_field editMode => $c->{editMode} =%>
 	<%= hidden_field exportMode => $c->{exportMode} =%>
 	<%= hidden_field primarySortField => $c->{primarySortField} =%>
+	<%= hidden_field primarySortOrder => $c->{primarySortOrder} =%>
 	<%= hidden_field secondarySortField => $c->{secondarySortField} =%>
+	<%= hidden_field secondarySortOrder => $c->{secondarySortOrder} =%>
 	%
 	% if ($c->{editMode}) {
 		<p><b><%= maketext('Any changes made below will be reflected in the set for ALL students.') =%></b></p>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -16,29 +16,29 @@
 		<%= check_box selected_sets => $set_id, id => "${set_id}_id", class => 'form-check-input' =%>
 	</td>
 	<td>
-		<div class="label-with-edit-icon" dir="ltr">
+		<div class="d-flex justify-content-between gap-1" dir="ltr">
 			<%= label_for "${set_id}_id", begin =%>
 				<span class="set-label set-id-tooltip <%= $visibleClass %>" data-bs-toggle="tooltip"
 					data-bs-placement="right" data-bs-title="<%= $set->description %>">
 					<%= $prettySetID =%>
 				</span>
-				% if ($authz->hasPermissions(param('user'), 'modify_problem_sets')) {
-					<%= link_to $c->systemLink(
-							url_for('instructor_set_list', setID => $set_id),
-							params => { editMode => 1, visible_sets => $set_id }
-						),
-						class => 'set-id-tooltip',
-						'aria-label' => maketext('Edit Set Data'),
-						data  => {
-							bs_toggle => 'tooltip',
-							bs_placement => 'right',
-							bs_title => maketext('Edit Set Data')
-						},
-						begin =%>
-						<i class="fas fa-pencil-alt" aria-hidden="true"></i>
-					<% end =%>
-				% }
 			<% end =%>
+			% if ($authz->hasPermissions(param('user'), 'modify_problem_sets')) {
+				<%= link_to $c->systemLink(
+						url_for('instructor_set_list', setID => $set_id),
+						params => { editMode => 1, visible_sets => $set_id }
+					),
+					class => 'set-id-tooltip',
+					'aria-label' => maketext('Edit Set Data'),
+					data  => {
+						bs_toggle => 'tooltip',
+						bs_placement => 'right',
+						bs_title => maketext('Edit Set Data')
+					},
+					begin =%>
+					<i class="fas fa-pencil-alt" aria-hidden="true"></i>
+				<% end =%>
+			% }
 		</div>
 	</td>
 	%# Problems link

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -24,10 +24,18 @@
 				</span>
 				% if ($authz->hasPermissions(param('user'), 'modify_problem_sets')) {
 					<%= link_to $c->systemLink(
-						url_for('instructor_set_list', setID => $set_id),
-						params => { editMode => 1, visible_sets => $set_id }
-					), begin =%>
-						<i class="icon fas fa-pencil-alt" data-alt="edit" aria-hidden="true"></i>
+							url_for('instructor_set_list', setID => $set_id),
+							params => { editMode => 1, visible_sets => $set_id }
+						),
+						class => 'set-id-tooltip',
+						'aria-label' => maketext('Edit Set Data'),
+						data  => {
+							bs_toggle => 'tooltip',
+							bs_placement => 'right',
+							bs_title => maketext('Edit Set Data')
+						},
+						begin =%>
+						<i class="fas fa-pencil-alt" aria-hidden="true"></i>
 					<% end =%>
 				% }
 			<% end =%>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
@@ -1,16 +1,17 @@
 % my %fieldHeaders = (
-	% set_id                 => $c->{editMode}
-								% ? maketext('Edit Set')
-								% : label_for('select-all' => maketext('Edit Set Data')),
-	% problems               => maketext('Edit Problems'),
-	% users                  => maketext('Edit Assigned Users'),
+	% set_id                 => maketext('Set Name'),
+	% problems               => maketext('Problems'),
+	% users                  => maketext('Assigned Users'),
 	% visible                => maketext('Visible'),
-	% enable_reduced_scoring => $c->{editMode} ? maketext('Enable Reduced Scoring') : maketext('Reduced Scoring'),
+	% enable_reduced_scoring => maketext('Reduced Scoring'),
 	% open_date              => maketext('Open Date'),
 	% reduced_scoring_date   => maketext('Reduced Scoring Date'),
 	% due_date               => maketext('Close Date'),
 	% answer_date            => maketext('Answer Date')
 % );
+%
+% my %sortableFields =
+	% (set_id => 1, open_date => 1, reduced_scoring_date => 1, due_date => 1, answer_date => 1, visible => 1);
 %
 <div class="table-responsive">
 	<table id="set_table_id" class="set_table table table-sm table-bordered caption-top font-sm <%=
@@ -22,12 +23,29 @@
 			<tr>
 				% if (!$c->{editMode}) {
 					<th>
-						<%= check_box 'select-all' => '', id => 'select-all', class => 'select-all form-check-input',
-							'aria-label' => maketext('Select all sets'), data => { select_group => 'selected_sets' } =%>
+						<%= label_for 'select-all', begin =%>
+							<%= check_box 'select-all' => '', id => 'select-all',
+								class => 'select-all form-check-input set-id-tooltip',
+								'aria-label' => maketext('Select all sets'),
+								data => {
+									select_group => 'selected_sets',
+									bs_toggle => 'tooltip',
+									bs_placement => 'right',
+									bs_title => maketext('Select all sets')
+								} =%>
+								<i class="fa-solid fa-check-double" aria-hidden="true"></i>
+							<% end =%>
 					</th>
 				% }
 				% for (@$fieldNames) {
-					<th id="<%= $_ %>_header"><%= $fieldHeaders{$_} =%></th>
+					<th id="<%= $_ %>_header">
+						% if (!$c->{editMode} && $sortableFields{$_}) {
+							<%= link_to $fieldHeaders{$_} => '#', class => 'sort-header',
+								data => { sort_field => $_ } =%>
+						% } else {
+							<%= $fieldHeaders{$_} =%>
+						% }
+					</th>
 				% }
 			</tr>
 		</thead>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
@@ -37,9 +37,11 @@
 				% for (@$fieldNames) {
 					<th id="<%= $_ %>_header">
 						% if (!$c->{editMode} && $sortableFields->{$_}) {
-							<%= link_to $fieldHeaders{$_} => '#', class => 'sort-header',
-								data => { sort_field => $_ } =%>
-							<%= include 'ContentGenerator/Instructor/ProblemSetList/sort_button', field => $_ =%>
+							<div class="d-flex justify-content-between align-items-end gap-1">
+								<%= link_to $fieldHeaders{$_} => '#', class => 'sort-header',
+									data => { sort_field => $_ } =%>
+								<%= include 'ContentGenerator/Instructor/ProblemSetList/sort_button', field => $_ =%>
+							</div>
 						% } else {
 							<%= $fieldHeaders{$_} =%>
 						% }

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
@@ -10,9 +10,6 @@
 	% answer_date            => maketext('Answer Date')
 % );
 %
-% my %sortableFields =
-	% (set_id => 1, open_date => 1, reduced_scoring_date => 1, due_date => 1, answer_date => 1, visible => 1);
-%
 <div class="table-responsive">
 	<table id="set_table_id" class="set_table table table-sm table-bordered caption-top font-sm <%=
 		$c->{editMode} ? 'align-middle' : '' %>">
@@ -39,9 +36,10 @@
 				% }
 				% for (@$fieldNames) {
 					<th id="<%= $_ %>_header">
-						% if (!$c->{editMode} && $sortableFields{$_}) {
+						% if (!$c->{editMode} && $sortableFields->{$_}) {
 							<%= link_to $fieldHeaders{$_} => '#', class => 'sort-header',
 								data => { sort_field => $_ } =%>
+							<%= include 'ContentGenerator/Instructor/ProblemSetList/sort_button', field => $_ =%>
 						% } else {
 							<%= $fieldHeaders{$_} =%>
 						% }

--- a/templates/ContentGenerator/Instructor/ProblemSetList/sort_button.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/sort_button.html.ep
@@ -1,0 +1,25 @@
+% if ($c->{primarySortField} eq $field) {
+	<button type="button" data-sort-priority="primary" style="font-size:0.75em"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+		1
+		% if ($c->{primarySortOrder} eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% } elsif ($c->{secondarySortField} eq $field) {
+	<button type="button" data-sort-priority="secondary" style="font-size:0.75em"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+		2
+		% if ($c->{secondarySortOrder} eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% }

--- a/templates/ContentGenerator/Instructor/ProblemSetList/sort_button.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/sort_button.html.ep
@@ -1,6 +1,6 @@
 % if ($c->{primarySortField} eq $field) {
-	<button type="button" data-sort-priority="primary" style="font-size:0.75em"
-		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+	<button type="button" data-sort-priority="primary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
 		1
 		% if ($c->{primarySortOrder} eq 'ASC') {
 			<i class="fa-solid fa-chevron-down"></i>
@@ -11,8 +11,8 @@
 		% }
 	</button>
 % } elsif ($c->{secondarySortField} eq $field) {
-	<button type="button" data-sort-priority="secondary" style="font-size:0.75em"
-		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+	<button type="button" data-sort-priority="secondary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
 		2
 		% if ($c->{secondarySortOrder} eq 'ASC') {
 			<i class="fa-solid fa-chevron-down"></i>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/sort_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/sort_form.html.ep
@@ -1,38 +1,72 @@
 <div>
-	<div class="row mb-2">
-		<%= label_for sort_select_1 => maketext('Sort by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.primary' => [
-					[ maketext('Set Name')    => 'set_id' ],
-					[ maketext('Open Date')   => 'open_date' ],
-					($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
-						? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
-						: ()
-					),
-					[ maketext('Close Date')  => 'due_date', selected => undef ],
-					[ maketext('Answer Date') => 'answer_date' ],
-					[ maketext('Visibility')  => 'visible' ]
-				],
-				id => 'sort_select_1', class   => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_1 => maketext('Sort by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary' => [
+							[ maketext('Set Name')  => 'set_id' ],
+							[ maketext('Open Date') => 'open_date' ],
+							($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+								? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
+								: ()
+							),
+							[ maketext('Close Date')  => 'due_date', selected => undef ],
+							[ maketext('Answer Date') => 'answer_date' ],
+							[ maketext('Visibility')  => 'visible' ]
+						],
+						id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_1 => maketext('Ordered') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
 	<div class="row mb-2">
-		<%= label_for sort_select_2 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.secondary' => [
-					[ maketext('Set Name')    => 'set_id' ],
-					[ maketext('Open Date')   => 'open_date', selected => undef],
-					($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
-						? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
-						: ()
-					),
-					[ maketext('Close Date')  => 'due_date' ],
-					[ maketext('Answer Date') => 'answer_date' ],
-					[ maketext('Visibility')  => 'visible' ]
-				],
-				id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_2 => maketext('Then by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary' => [
+							[ maketext('Set Name')  => 'set_id' ],
+							[ maketext('Open Date') => 'open_date', selected => undef],
+							($ce->{pg}{ansEvalDefaults}{enableReducedScoring}
+								? [ maketext('Reduced Scoring Date') => 'reduced_scoring_date' ]
+								: ()
+							),
+							[ maketext('Close Date')  => 'due_date' ],
+							[ maketext('Answer Date') => 'answer_date' ],
+							[ maketext('Visibility')  => 'visible' ]
+						],
+						id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_2 => maketext('Ordered'). ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList.html.ep
@@ -34,8 +34,11 @@
 	<%= hidden_field editMode => $c->{editMode} =%>
 	<%= hidden_field passwordMode => $c->{passwordMode} =%>
 	<%= hidden_field primarySortField => $c->{primarySortField} =%>
+	<%= hidden_field primarySortOrder => $c->{primarySortOrder} =%>
 	<%= hidden_field secondarySortField => $c->{secondarySortField} =%>
+	<%= hidden_field secondarySortOrder => $c->{secondarySortOrder} =%>
 	<%= hidden_field ternarySortField => $c->{ternarySortField} =%>
+	<%= hidden_field ternarySortOrder => $c->{ternarySortOrder} =%>
 	%
 	% # Output action forms
 	% my $default_choice;

--- a/templates/ContentGenerator/Instructor/UserList/sort_button.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/sort_button.html.ep
@@ -1,6 +1,6 @@
 % if ($c->{primarySortField} eq $field) {
-	<button type="button" data-sort-priority="primary" style="font-size:0.75em"
-		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+	<button type="button" data-sort-priority="primary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
 		1
 		% if ($c->{primarySortOrder} eq 'ASC') {
 			<i class="fa-solid fa-chevron-down"></i>
@@ -11,8 +11,8 @@
 		% }
 	</button>
 % } elsif ($c->{secondarySortField} eq $field) {
-	<button type="button" data-sort-priority="secondary" style="font-size:0.75em"
-		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+	<button type="button" data-sort-priority="secondary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
 		2
 		% if ($c->{secondarySortOrder} eq 'ASC') {
 			<i class="fa-solid fa-chevron-down"></i>
@@ -23,8 +23,8 @@
 		% }
 	</button>
 % } elsif ($c->{ternarySortField} eq $field) {
-	<button type="button" data-sort-priority="ternary" style="font-size:0.75em"
-		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+	<button type="button" data-sort-priority="ternary"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold text-nowrap font-xs">
 		3
 		% if ($c->{ternarySortOrder} eq 'ASC') {
 			<i class="fa-solid fa-chevron-down"></i>

--- a/templates/ContentGenerator/Instructor/UserList/sort_button.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/sort_button.html.ep
@@ -1,0 +1,37 @@
+% if ($c->{primarySortField} eq $field) {
+	<button type="button" data-sort-priority="primary" style="font-size:0.75em"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+		1
+		% if ($c->{primarySortOrder} eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% } elsif ($c->{secondarySortField} eq $field) {
+	<button type="button" data-sort-priority="secondary" style="font-size:0.75em"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+		2
+		% if ($c->{secondarySortOrder} eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% } elsif ($c->{ternarySortField} eq $field) {
+	<button type="button" data-sort-priority="ternary" style="font-size:0.75em"
+		class="sort-order btn btn-secondary rounded-pill btn-sm py-0 fw-bold">
+		3
+		% if ($c->{ternarySortOrder} eq 'ASC') {
+			<i class="fa-solid fa-chevron-down"></i>
+			<span class="visually-hidden"><%= maketext('ascending') %></span>
+		% } else {
+			<i class="fa-solid fa-chevron-up"></i>
+			<span class="visually-hidden"><%= maketext('descending') %></span>
+		% }
+	</button>
+% }

--- a/templates/ContentGenerator/Instructor/UserList/sort_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/sort_form.html.ep
@@ -1,42 +1,93 @@
 % my @sortFields = grep { $_ ne 'email_address' } @$fields;
 <div>
-	<div class="row mb-2">
-		<%= label_for sort_select_1 => maketext('Sort by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.primary' => [
-					map { [
-						maketext($fieldProperties->{$_}{name}) => $_,
-						$_ eq 'last_name' ? (selected => undef) : ()
-					] } @sortFields
-				],
-				id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_1 => maketext('Sort by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary' => [
+							map { [
+								maketext($fieldProperties->{$_}{name}) => $_,
+								$_ eq 'last_name' ? (selected => undef) : ()
+							] } @sortFields
+						],
+						id => 'sort_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_1 => maketext('Ordered') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.primary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_1', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
-	<div class="row mb-2">
-		<%= label_for sort_select_2 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.secondary' => [
-					map { [
-						maketext($fieldProperties->{$_}{name}) => $_,
-						$_ eq 'first_name' ? (selected => undef) : ()
-					] } @sortFields
-				],
-				id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_2 => maketext('Then by') . ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary' => [
+							map { [
+								maketext($fieldProperties->{$_}{name}) => $_,
+								$_ eq 'first_name' ? (selected => undef) : ()
+							] } @sortFields
+						],
+						id => 'sort_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_2 => maketext('Ordered'). ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.secondary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_2', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
-	<div class="row mb-2">
-		<%= label_for sort_select_3 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
-			style => 'width:4.5rem' =%>
-		<div class="col-auto">
-			<%= select_field 'action.sort.ternary' => [
-					map { [
-						maketext($fieldProperties->{$_}{name}) => $_,
-						$_ eq 'user_id' ? (selected => undef) : ()
-					] } @sortFields
-				],
-				id => 'sort_select_3', class => 'form-select form-select-sm' =%>
+	<div class="row">
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_select_3 => maketext('Then by') . ':', class => 'col-form-label col-form-label-sm',
+					style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.ternary' => [
+							map { [
+								maketext($fieldProperties->{$_}{name}) => $_,
+								$_ eq 'user_id' ? (selected => undef) : ()
+							] } @sortFields
+						],
+						id => 'sort_select_3', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
+		</div>
+		<div class="col-md-auto col-sm-12">
+			<div class="row mb-2">
+				<%= label_for sort_order_select_3 => maketext('Ordered'). ':',
+					class => 'col-form-label col-form-label-sm', style => 'width:4.5rem' =%>
+				<div class="col-auto">
+					<%= select_field 'action.sort.ternary.order' => [
+							[ maketext('Ascending')  => 'ASC' ],
+							[ maketext('Descending') => 'DESC' ],
+						],
+						id => 'sort_order_select_3', class => 'form-select form-select-sm' =%>
+				</div>
+			</div>
 		</div>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -7,12 +7,21 @@
 % unless ($c->{editMode} || $c->{passwordMode}) {
 	% content_for 'user-list-table-headings' => begin
 		<th>
-			<%= check_box 'select-all' => 'on', id => 'select-all', 'aria-label' => maketext('Select all users'),
-				data => { select_group => 'selected_users' }, class => 'select-all form-check-input' =%>
+			<%= label_for 'select-all', begin =%>
+				<%= check_box 'select-all' => 'on', id => 'select-all',
+					class => 'select-all form-check-input set-id-tooltip',
+					'aria-label' => maketext('Select all users'),
+					data => {
+						select_group => 'selected_users',
+						bs_toggle => 'tooltip',
+						bs_placement => 'right',
+						bs_title => maketext('Select all users')
+					} =%>
+					<i class="fa-solid fa-check-double" aria-hidden="true"></i>
+				<% end =%>
 		</th>
 		<th>
-			<%= label_for 'select-all' =>
-				link_to maketext('Login Name') => '#', class => 'sort-header',
+			<%= link_to maketext('Login Name') => '#', class => 'sort-header',
 					data => { sort_field => 'user_id' } =%>
 		</th>
 		<th><%= maketext('Login Status') %></th>

--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -23,41 +23,50 @@
 		<th>
 			<%= link_to maketext('Login Name') => '#', class => 'sort-header',
 					data => { sort_field => 'user_id' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'user_id' =%>
 		</th>
 		<th><%= maketext('Login Status') %></th>
 		<th><%= maketext('Assigned Sets') %></th>
 		<th>
 			<%= link_to maketext('First Name') => '#', class => 'sort-header',
 				data => { sort_field => 'first_name' } %>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'first_name' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Last Name') => '#', class => 'sort-header',
 				data => { sort_field => 'last_name' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'last_name' =%>
 		</th>
 		<th><%= maketext('Email Link') %></th>
 		<th>
 			<%= link_to maketext('Student ID') => '#', class => 'sort-header',
 				data => { sort_field => 'student_id' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'student_id' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Status') => '#', class => 'sort-header',
 				data => { sort_field => 'status' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'status' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Section') => '#', class => 'sort-header',
 				data => { sort_field => 'section' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'section' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Recitation') => '#', class => 'sort-header',
 				data => { sort_field => 'recitation' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'recitation' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Comment') => '#', class => 'sort-header',
 				data => { sort_field => 'comment' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'comment' =%>
 		</th>
 		<th>
 			<%= link_to maketext('Permission Level') => '#', class => 'sort-header',
 				data => { sort_field => 'permission' } =%>
+			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'permission' =%>
 		</th>
 	% end
 % } else {

--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -21,52 +21,70 @@
 				<% end =%>
 		</th>
 		<th>
-			<%= link_to maketext('Login Name') => '#', class => 'sort-header',
-					data => { sort_field => 'user_id' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'user_id' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Login Name') => '#', class => 'sort-header',
+						data => { sort_field => 'user_id' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'user_id' =%>
+			</div>
 		</th>
 		<th><%= maketext('Login Status') %></th>
 		<th><%= maketext('Assigned Sets') %></th>
 		<th>
-			<%= link_to maketext('First Name') => '#', class => 'sort-header',
-				data => { sort_field => 'first_name' } %>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'first_name' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('First Name') => '#', class => 'sort-header',
+					data => { sort_field => 'first_name' } %>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'first_name' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Last Name') => '#', class => 'sort-header',
-				data => { sort_field => 'last_name' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'last_name' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Last Name') => '#', class => 'sort-header',
+					data => { sort_field => 'last_name' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'last_name' =%>
+			</div>
 		</th>
 		<th><%= maketext('Email Link') %></th>
 		<th>
-			<%= link_to maketext('Student ID') => '#', class => 'sort-header',
-				data => { sort_field => 'student_id' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'student_id' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Student ID') => '#', class => 'sort-header',
+					data => { sort_field => 'student_id' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'student_id' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Status') => '#', class => 'sort-header',
-				data => { sort_field => 'status' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'status' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Status') => '#', class => 'sort-header',
+					data => { sort_field => 'status' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'status' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Section') => '#', class => 'sort-header',
-				data => { sort_field => 'section' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'section' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Section') => '#', class => 'sort-header',
+					data => { sort_field => 'section' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'section' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Recitation') => '#', class => 'sort-header',
-				data => { sort_field => 'recitation' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'recitation' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Recitation') => '#', class => 'sort-header',
+					data => { sort_field => 'recitation' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'recitation' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Comment') => '#', class => 'sort-header',
-				data => { sort_field => 'comment' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'comment' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Comment') => '#', class => 'sort-header',
+					data => { sort_field => 'comment' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'comment' =%>
+			</div>
 		</th>
 		<th>
-			<%= link_to maketext('Permission Level') => '#', class => 'sort-header',
-				data => { sort_field => 'permission' } =%>
-			<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'permission' =%>
+			<div class="d-flex justify-content-between align-items-end gap-1">
+				<%= link_to maketext('Permission Level') => '#', class => 'sort-header',
+					data => { sort_field => 'permission' } =%>
+				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'permission' =%>
+			</div>
 		</th>
 	% end
 % } else {

--- a/templates/ContentGenerator/Instructor/UserList/user_row.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_row.html.ep
@@ -11,7 +11,7 @@
 		</td>
 		% # User id
 		<td>
-			<div class="label-with-edit-icon">
+			<div class="d-flex justify-content-between gap-1">
 				% # Make the user id the label for the select user checkbox.
 				<%= label_for $user->user_id . '_checkbox', begin =%>
 					% if (!$authz->hasPermissions(param('user'), 'become_student')) {

--- a/templates/HelpFiles/InstructorProblemSetList.html.ep
+++ b/templates/HelpFiles/InstructorProblemSetList.html.ep
@@ -21,14 +21,14 @@
 		. 'The following allow editing directly of a single problem set.') =%>
 </p>
 <dl>
-	<dt><%= maketext('"Edit Problems" column') %></dt>
+	<dt><%= maketext('"Problems" column') %></dt>
 	<dd>
 		<%= maketext('Indicates the number of problems in the set. Clicking on the link opens the set detail page '
 			. 'which allows you to modify set parameters, edit set headers, and change parameters of problems in the '
 			. 'set such as the number of allowed attempts or the weight (credit value). You can also add, remove, '
 			. 'view, edit, and reorder the problems in the set.') =%>
 	</dd>
-	<dt><%= maketext('"Edit Assigned Users" column') %></dt>
+	<dt><%= maketext('"Assigned Users" column') %></dt>
 	<dd>
 		<%= maketext('Shows how many instructors and students have been assigned this problem set, out of the total '
 			. 'number in the class. Clicking on this link allows you to assign the set to users, unassign this '
@@ -37,7 +37,7 @@
 	</dd>
 	<dt><%= maketext('Changing dates') %></dt>
 	<dd>
-		<%= maketext('Dates for problem sets can be edited by clicking the pencil icon in the "Edit Set Data" column '
+		<%= maketext('Dates for problem sets can be edited by clicking the pencil icon in the "Set Name" column '
 			. 'next to the set name. To change dates for several sets at once, click the check box in the "Select" '
 			. 'column and choose "Edit selected" from the tasks above.') =%>
 	</dd>
@@ -48,7 +48,10 @@
 	<dd><%= maketext('Display sets matching a selected criteria. Useful if there are many sets.') %></dd>
 
 	<dt><%= maketext('Sort') %></dt>
-	<dd><%= maketext('Sorts the lists displayed by due date, name, etc.') %></dd>
+	<dd>
+		<%= maketext('Sorts the table rows by set name, due date, etc.  The table rows can also be sorted by '
+			. 'clicking on an active link at the top of the column.') %>
+	</dd>
 
 	<dt><%= maketext('Edit') %></dt>
 	<dd><%= maketext('The sets checked below will become available for editing the due dates and visibility.') %></dd>

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -89,12 +89,9 @@
 			<li><%= maketext('TA:') %> 5</li>
 			<li><%= maketext('Instructor:') %> 10</li>
 		</ul>
-	</dd>
 		<%= maketext('Note that if you set the permission level of a user to something other than "Student", you may '
 			. 'also want to set the status of the user to "Observer".  Users with the "Observer" status are not '
 			. 'included in statistics, scoring, or instructor emails.') =%>
-	<dd>
-
 	</dd>
 
 	<dt><%= maketext('Drop student from the course') %></dt>


### PR DESCRIPTION
This uses the same method as the classlist editor for this.  In fact the javascript used by the classlist editor for this is now in the actiontabs.js file, and is used by both the classlist editor and the homework sets editor.

The column headers in the homework sets editor did not make sense.  The headers should say what is in the column, not what clicking on an extra item in the column does.  This was made worse by making it so that clicking on the column header sorts by set name.  It doesn't make sends to click on "Edit Set Data" to sort the column by set name.  Other headers also were adjusted to remove the "Edit" wording, and reflect contents not actions.  We need to find a better way to convey what clicking on something in the column does.  A tooltip is added to the pencil icon by the set name to convey what it does.

Using the set name header as a label for the select all is problematic. So instead a double check icon is added and a tooltip on the select all input itself.  This is also done in the other tables like this (the classlist editor and achievement list).

Remove the "Please select action to be performed" messages that were displayed when the homework sets editor, classlist editor, or achievement editor pages were initially loaded.  Those messages aren't needed.  Furthermore, remove the "Result of last action performed:" prefix that was added to all action messages.  That doesn't add anything useful to the message, and the action messages are clear on their own. The messages were improved with capitalization and periods to make them look better when shown without that prefix.