### PR TITLE
When "tags written" is displayed, make it a good (green) message.

### DIFF
--- a/htdocs/js/TagWidget/tagwidget.js
+++ b/htdocs/js/TagWidget/tagwidget.js
@@ -317,7 +317,7 @@
 			if (!response.ok) return showMessage('Unable to save problem tags.');
 			const data = await response.json();
 			if (data.error) return showMessage(data.error);
-			showMessage(data.server_response);
+			showMessage(data.server_response, true);
 		}
 	}
 


### PR DESCRIPTION
Currently, when saving a tag on a problem, the toast message "tags written" shows up in red (bootstrap alert). This gives the toast message in green. 