### PR TITLE
check_modules.pl allow newer versions of node.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -209,9 +209,8 @@ sub check_apps {
 	my $node_version_str = qx/node -v/;
 	my ($node_version) = $node_version_str =~ m/v(\d+)\./;
 
-	if ($node_version != 16) {
-		print "\n\n**The version of node should be 16.  You have version $node_version";
-	}
+	print "\n\n**The version of node should be at least 16.  You have version $node_version"
+		if ($node_version < 16);
 }
 
 sub which {


### PR DESCRIPTION
Allow any version of node that is 16 or newer.  Don't insist on version 16 exactly.  I am currently using node 20 and was using 18 before that. I haven't seen any issues with these newer versions.