### PR TITLE
Delete past answers for a user when the user is deleted.

### DIFF
--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -582,6 +582,7 @@ sub deleteUser {
 	$self->deleteGlobalUserAchievement($userID);
 	$self->deletePermissionLevel($userID);
 	$self->deleteKey($userID);
+	$self->{past_answer}->delete_where({ user_id => $userID });
 	return $self->{user}->delete($userID);
 }
 


### PR DESCRIPTION
This has been something that keeps coming up.  Many webwork server administrators like to unarchive a course from previous semesters, delete all of the previous students, and then reuse the course for the new students the next semester.  If this is done repeatedly, then the past answers table starts to become a mess.  Another issue is when a student retakes a course the next semester.  Then all of the past answers from the previous time the student took the course are still shown in the past answers table for that student.