### PR TITLE
Fix the alert timeouts in two cases for the single problem grader.

### DIFF
--- a/htdocs/js/ProblemGrader/problemgrader.js
+++ b/htdocs/js/ProblemGrader/problemgrader.js
@@ -180,7 +180,7 @@
 								messageArea.innerHTML =
 									'<div>The score was saved, but there was an error saving the comment.</div>' +
 									`<div>${e}</div>`;
-								setTimeout(() => messageArea.classList.remove('alert-danger', 100));
+								setTimeout(() => messageArea.classList.remove('alert-danger'), 100);
 							}
 						} else {
 							messageArea.classList.add('alert-success');
@@ -192,7 +192,7 @@
 			} catch (e) {
 				messageArea.classList.add('alert-danger');
 				messageArea.innerHTML = `<div>Error saving score.</div><div>${e?.message ?? e}</div>`;
-				setTimeout(() => messageArea.classList.remove('alert-danger', 100));
+				setTimeout(() => messageArea.classList.remove('alert-danger'), 100);
 			}
 		});
 	})


### PR DESCRIPTION
A couple of typos prevent the bootstrap alerts from being properly shown.  The messages are displayed, but the alert styles are not. This is just a minor display issue.