### PR TITLE
Fix grading proctored test after entering incorrect proctor credentials.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -897,8 +897,8 @@ async sub pre_header_initialize ($c) {
 				# In this case there may be a past login proctor key that can be kept so that another login to continue
 				# working the test is not needed.
 				if ($c->param('past_proctor_user') && $c->param('past_proctor_key')) {
-					$c->param('proctor_user', $c->param('past_proctor_user'));
-					$c->param('proctor_key',  $c->param('past_proctor_key'));
+					$c->param('proctor_user', scalar $c->param('past_proctor_user'));
+					$c->param('proctor_key',  scalar $c->param('past_proctor_key'));
 				}
 			}
 			# This is unsubtle, but we'd rather not have bogus keys sitting around.


### PR DESCRIPTION
When grading a proctored test that is set for a finite number of graded submittsions, if you enter an incorrect username or password, then multiple hidden past_proctor_user and past_proctor_key fields are in the form (one from the `hidden_fields` method and one added in LoginProctor.html.ep).  Then if you submit the correct proctor username and password an error occurs because more than three arguments are passed to the WeBWorK::Controller `param` method on lines 900 and 901 of WeBWorK::ContentGenerator::GatewayQuiz.  So this forces the
    return value of `param` into scalar context so only the first of the
input values is returned.

To test this create a gateway test with a finite number of graded submissions per version, start the test, and click "Grade Test".  Then enter a bogus username or password and click "Continute".  Then enter the correct username and password.  On the develop branch this will give the error `Too many arguments for subroutine
'WeBWorK::Controller::param' (got 4; expected at most 3) at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm line 900`, and will work with this pull request.

This may be worthy of a hotfix.