### PR TITLE
Don't delete proctor keys for tests with unlimited number of attempts

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -879,7 +879,7 @@ async sub pre_header_initialize ($c) {
 
 	# Save results to database as appropriate
 	if ($c->{submitAnswers} || (($c->{previewAnswers} || $c->param('newPage')) && $can{recordAnswers})) {
-		# If answers are being submitted, then save the problems to the database.  If this is a preview or pages change
+		# If answers are being submitted, then save the problems to the database.  If this is a preview or page change
 		# and answers can be recorded, then save the last answer for future reference.
 		# Also save the persistent data to the database even when the last answer is not saved.
 
@@ -889,7 +889,9 @@ async sub pre_header_initialize ($c) {
 			my $proctorID = $c->param('proctor_user');
 
 			# If there are no attempts left, delete all proctor keys for this user.
-			if ($set->attempts_per_version - 1 - $problem->num_correct - $problem->num_incorrect <= 0) {
+			if ($set->attempts_per_version > 0
+				&& $set->attempts_per_version - 1 - $problem->num_correct - $problem->num_incorrect <= 0)
+			{
 				eval { $db->deleteAllProctorKeys($effectiveUserID); };
 			} else {
 				# Otherwise, delete only the grading key.


### PR DESCRIPTION
Currently if a proctored test is set to have an unlimited number of attempts per version, the user clicks to grade the test, and the proctor credentials are validly entered, then if the user tries to move to another page of the test the user is taken to the proctor login page again.  This is because of an error in the logic that causes the proctor keys to be deleted instead of the proctor grading key.

Perhaps this is worthy of  a hotfix also?