### PR TITLE
account for test that starts at a number other than 1

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -408,7 +408,7 @@ sub display_form ($c) {
 			my $the_set_version = $2;
 			$mergedSet = $db->getMergedSetVersion($user_id, $the_set_id, $the_set_version);
 			my $mergedProblem = $db->getMergedProblemVersion($user_id, $the_set_id, $the_set_version,
-				($db->listUserProblems($user_id, $the_set_id))[0]);
+				($db->listProblemVersions($user_id, $the_set_id, $the_set_version))[0]);
 
 			# Get the parameters needed to determine if correct answers may be shown.
 			my $maxAttempts  = $mergedSet->attempts_per_version()                          || 0;

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -407,7 +407,8 @@ sub display_form ($c) {
 			my $the_set_id      = $1;
 			my $the_set_version = $2;
 			$mergedSet = $db->getMergedSetVersion($user_id, $the_set_id, $the_set_version);
-			my $mergedProblem = $db->getMergedProblemVersion($user_id, $the_set_id, $the_set_version, 1);
+			my $mergedProblem = $db->getMergedProblemVersion($user_id, $the_set_id, $the_set_version,
+				($db->listUserProblems($user_id, $the_set_id))[0]);
 
 			# Get the parameters needed to determine if correct answers may be shown.
 			my $maxAttempts  = $mergedSet->attempts_per_version()                          || 0;

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -73,7 +73,7 @@ async sub initialize ($c) {
 				$c->stash->{userSet},
 				$db->getMergedProblemVersion(
 					$effectiveUserID, $c->stash->{setID},
-					$versionNum, ($db->listUserProblems($effectiveUserID, $c->stash->{setID}))[0]
+					$versionNum, ($db->listProblemVersions($effectiveUserID, $c->stash->{setID}, $versionNum))[0]
 				)
 			))
 			{

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -71,7 +71,10 @@ async sub initialize ($c) {
 				$db->getPermissionLevel($userID),
 				$c->{effectiveUser},
 				$c->stash->{userSet},
-				$db->getMergedProblemVersion($effectiveUserID, $c->stash->{setID}, $versionNum, 1)
+				$db->getMergedProblemVersion(
+					$effectiveUserID, $c->stash->{setID},
+					$versionNum, ($db->listUserProblems($effectiveUserID, $c->stash->{setID}))[0]
+				)
 			))
 			{
 				$c->stash->{userSet}->version_last_attempt_time(int($c->submitTime));


### PR DESCRIPTION
This addresses #2247, and should possibly be considered for a hotfix.

As part of checking whether it is legal for a user's scores to be recorded, the code wants to know how many times the quiz has been graded already and confirm the number of graded submissions have not been used up. We don't record the number of graded submissions anywhere. But we record the number of *attempts* on individual problems, which all get submitted simultaneously when a test is graded. So as a proxy for what we really want, there is this place in the code that checks how many attempts have been used on the first problem. The code was assuming the first problem is numbered 1, and uses that to look it up in the database to get its attempt count. This changes that code to get the actual first problem number.

To test, first reproduce the error described in #2247. Then see if this fixes that. 