### PR TITLE
fix a permission mismatch

### DIFF
--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -18,7 +18,7 @@
 	% last;
 % }
 %
-% unless ($authz->hasPermissions(param('user'), 'modify_student_data')) {
+% unless ($authz->hasPermissions(param('user'), 'modify_problem_sets')) {
 	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to modify problems.') %></div>
 	% last;
 % }


### PR DESCRIPTION
It seems to me that the wrong permission is referenced here. The problem editor page has nothing to do with student data.

What I'm changing it to seems like the best option. In some cases, the problem editor page allows you to edit a problem set. Although, if you enter it directly then it would seem that ability to edit a problem set is irrelevant, and why not let someone code a new problem? But this change is at least a better option than what is in there now, I think.

I came upon this reviewing old issues, in particular #746. For that issue to make sense, my guess is that `modify_problem_sets` is what should be here too. Assuming we don't make something better now that the problem editor is more general purpose than it once was.