### PR TITLE
Show template problem ID in tests.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -847,6 +847,11 @@ async sub pre_header_initialize ($c) {
 		push(@pg_results, $pg);
 	}
 
+	# Show the template problem ID if the problems are in random order
+	# or the template problem IDs are not in order starting at 1.
+	$c->{can}{showTemplateIds} = $c->{can}{showProblemGrader}
+		&& ($set->problem_randorder || $problems[-1]->problem_id != scalar(@problems));
+
 	# Wait for all problems to be rendered and replace the undefined entries
 	# in the pg_results array with the rendered result.
 	my @renderedPG = await Mojo::Promise->all(@renderPromises);

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -522,6 +522,10 @@
 					% # Output the problem header.
 					<h2><%= maketext('Problem [_1].', $i + 1) %></h2>
 					<span class="problem-sub-header">
+						% if ($c->{can}{showTemplateIds}) {
+							<%= '('
+								. maketext('Template ID: [_1]', $problems->[ $probOrder->[$i] ]->problem_id) . ')' %>
+						% }
 						% my $problemValue = $problems->[ $probOrder->[$i] ]->value;
 						% if (defined $problemValue) {
 							% my $points = $problemValue == 1 ? maketext('point') : maketext('points');


### PR DESCRIPTION
For users who can see the single problem grader, also show the template problem ID if the problems are in random order  or not enumerated from 1 to N. This way instructors can see what the real problem ID is in the case it is different from the problem number.

I'm unsure on the best label for this, I went with `Template ID` as `Template Problem ID` was a bit too long and I thought it was more descriptive than `Problem ID`.

This was mentioned in #2248.