### PR TITLE
Correct the problem numbers when a set definition file is imported.

### DIFF
--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -194,13 +194,13 @@ sub importSetsFromDef ($ce, $db, $setDefFiles, $existingSets = undef, $assign = 
 
 		debug("$set_definition_file: adding problems to database");
 		# Add problems
-		my $freeProblemID = WeBWorK::Utils::max($db->listGlobalProblems($setData->{setID})) + 1;
+		my $freeProblemID = WeBWorK::Utils::max(grep {$_} map { $_->{problem_id} } @{ $setData->{problemData} }) + 1;
 		for my $rh_problem (@{ $setData->{problemData} }) {
 			addProblemToSet(
 				$db, $ce->{problemDefaults},
 				setName           => $setData->{setID},
 				sourceFile        => $rh_problem->{source_file},
-				problemID         => $rh_problem->{problem_id} ? $rh_problem->{problem_id} : $freeProblemID++,
+				problemID         => $rh_problem->{problem_id} || $freeProblemID++,
 				value             => $rh_problem->{value},
 				maxAttempts       => $rh_problem->{max_attempts},
 				showMeAnother     => $rh_problem->{showMeAnother},

--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -200,7 +200,7 @@ sub importSetsFromDef ($ce, $db, $setDefFiles, $existingSets = undef, $assign = 
 				$db, $ce->{problemDefaults},
 				setName           => $setData->{setID},
 				sourceFile        => $rh_problem->{source_file},
-				problemID         => $rh_problem->{problemID} ? $rh_problem->{problemID} : $freeProblemID++,
+				problemID         => $rh_problem->{problem_id} ? $rh_problem->{problem_id} : $freeProblemID++,
 				value             => $rh_problem->{value},
 				maxAttempts       => $rh_problem->{max_attempts},
 				showMeAnother     => $rh_problem->{showMeAnother},


### PR DESCRIPTION
Currently the problem numbers in the set defintion file are completely ignored due to a minor mistake.  `problem_id` is used in the set definition file, and `problemID` is used by the `WeBWorK::Utils::Instructor::addProblemToSet` method, and I made didn't translate that correctly.

This fixes the issue noted by @Alex-Jordan in https://github.com/openwebwork/webwork2/pull/2194#issuecomment-1811899212.

Note that this does not fix the issue noted in the next comment there (https://github.com/openwebwork/webwork2/pull/2194#issuecomment-1811919002).  I tested that on both WeBWorK 2.17, 2.18, and with this pull request, and all have that issue.  With the current develop branch without this pull request this issue does not occur because of the error in translation fixed in this pull request which basically results in a set definition import always having problems numbered consecutively starting at 1.  I know why the issue occurs, and will look into finding a fix and submit another pull request for that.

Edit:  Now this does fix the issue noted above with the simplest possible approach of using the max of the valid problem ids from the set definition file plus 1 (and incrementing from there).