### PR TITLE
Trim date strings for the date picker

### DIFF
--- a/htdocs/js/DatePicker/datepicker.js
+++ b/htdocs/js/DatePicker/datepicker.js
@@ -120,7 +120,7 @@
 
 					// Next attempt to parse the datestr with the current format.  This should not be adjusted.  It is
 					// for display only.
-					const date = luxon.DateTime.fromFormat(datestr, format);
+					const date = luxon.DateTime.fromFormat(datestr.trim(), format);
 					if (date.isValid) return date.toJSDate();
 
 					// Finally, fall back to the previous value in the original input if that failed.  This is the case

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -133,7 +133,7 @@
 
 				// Next attempt to parse the datestr with the current format.  This should not be adjusted.  It is
 				// for display only.
-				const date = luxon.DateTime.fromFormat(datestr, format);
+				const date = luxon.DateTime.fromFormat(datestr.trim(), format);
 				if (date.isValid) return date.toJSDate();
 
 				// Finally, fall back to the previous value in the original input if that failed.  This is the case


### PR DESCRIPTION
When the date picker attempts to convert a date string into a numeric timestamp, trim the string.  Otherwise the `luxon.DateTime.fromFormat` method fails to parse the string into a numeric timestamp.

This most likely fixes issue #2257.