### PR TITLE
Improvements to date/time string handling.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -226,7 +226,11 @@ $pg{specialPGEnvironmentVars}{waiveExplanations} = 0;
 # Language
 ################################################################################
 
-$language = "en";   # tr = turkish,  en=english
+# This must be a language code for a language that is supported by webwork.
+# Note that this is also used for the locale for date/time formats.
+# Check the directory lib/WeBWorK/Localize to see which languages are
+# currently supported (e.g. en, es, fr, he-IL, tr, zh-HK).
+$language = "en";
 
 # $perProblemLangAndDirSettingMode controls how and whether LANG and/or DIR
 #    attributes are added to the DIV element enveloping a problem
@@ -235,6 +239,17 @@ $language = "en";   # tr = turkish,  en=english
 #    be displayed properly in a Hebrew course site, which helps select problems
 #    to be translated to Hebrew.
 $perProblemLangAndDirSettingMode = "force::ltr";
+
+################################################################################
+# Student Date Format
+################################################################################
+
+# This is the format of the dates displayed for students.  This can be created
+# from the strftime patterns documented at https://metacpan.org/pod/DateTime#strftime-Patterns,
+# or can be one of the localizable DateTime::Locale::FromData formats
+# 'datetime_format_short', 'datetime_format_medium', 'datetime_format_long', or
+# 'datetime_format_full'.  See https://metacpan.org/pod/DateTime::Locale::FromData.
+$studentDateDisplayFormat = 'datetime_format_long';
 
 ################################################################################
 # System-wide locations (directories and URLs)
@@ -1325,7 +1340,6 @@ $pg{ansEvalDefaults} = {
 	enableReducedScoring          => 0,
 	reducedScoringPeriod          => 0, # Default length of Reduced Scoring Period in minutes
 	reducedScoringValue           => .75, # Percent of score students receive in Reduced Scoring Period
-	timeAssignDue                 => "11:59pm",
 	assignOpenPriorToDue          => 14400, # a number of minutes (default is 10 days)
 	answersOpenAfterDueDate       => 2880 # number of minutes (default is 2 days)
 };
@@ -1363,16 +1377,19 @@ $webservices = {
 $pg{specialPGEnvironmentVars}{entryAssist} = 'MathQuill';
 
 ###############################################################################
-# default Homework Config settings
+# Default Set settings
 ###############################################################################
 
-# time of day the assignment is due.
+# Time of day that newly created sets are set to be due.  This should not be a
+# localized string, and is never used for display purposes.
 $pg{timeAssignDue} = '11:59pm';
 
-# number of minutes prior to due date that the assignment is open.
+# Number of minutes prior to due date that newly created sets
+# are set to open.
 $pg{assignOpenPriorToDue} = 10080;
 
-#number of minutes after due date are the answers open;
+# Number of minutes after due date that newly created sets are
+# set for answers to be made available;
 $pg{answersOpenAfterDueDate} = 2880;
 
 ###############################################################################
@@ -1443,6 +1460,19 @@ $ConfigValues = [
 			doc2   => x('WeBWorK currently has translations for the languages listed in the course configuration.'),
 			values => [qw(en tr es fr zh-HK he)],
 			type   => 'popuplist'
+		},
+		{
+			var  => 'studentDateDisplayFormat',
+			doc  => x('Format of dates that are displayed for students'),
+			doc2 => x(
+				'This is the format of the dates displayed for students.  This can be created from '
+					. '<a href="https://metacpan.org/pod/DateTime#strftime-Patterns">strftime patterns</a>, e.g., '
+					. '<span class="text-nowrap">"%a %b %d at %l:%M%P"</span>, or can be one of the '
+					. '<a href="https://metacpan.org/pod/DateTime::Locale::FromData">localizable formats</a> '
+					. '"datetime_format_short", "datetime_format_medium", "datetime_format_long", or '
+					. '"datetime_format_full".'
+			),
+			type => 'text'
 		},
 		{
 			var  => 'perProblemLangAndDirSettingMode',

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -86,9 +86,27 @@ $mail{feedbackRecipients}    = [
 # Language
 ################################################################################
 
+# This must be a language code for a language that is supported by webwork.
+# Note that this is also used for the locale for date/time formats.
+# Check the directory lib/WeBWorK/Localize to see which languages are
+# currently supported (e.g. en, es, fr, he-IL, tr, zh-HK).
+# This can be set per course in course.conf or via the course configuration.
 #$language = "en";
-# Check the directory .../webwork2/lib/WeBWorK/Localize to what languages are
-# currently supported (e.g. en, es,. fr, heb, tr, zk_hk).
+
+################################################################################
+# Student Date Format
+################################################################################
+
+# This is the format of the dates displayed for students.  This can be created
+# from the strftime patterns documented at https://metacpan.org/pod/DateTime#strftime-Patterns,
+# or can be one of the localizable DateTime::Locale::FromData formats
+# 'datetime_format_short', 'datetime_format_medium', 'datetime_format_long', or
+# 'datetime_format_full'.  See https://metacpan.org/pod/DateTime::Locale::FromData.
+# The default is 'datetime_format_long' which will display (for the English
+# language): June 27, 2023 at 10:39:00 AM EST
+# The commented out line that is demonstrated below will display (for the English
+# language): Wed Jun 27 at 10:30am
+#$studentDateDisplayFormat = "%a %b %d at %l:%M%P";
 
 ################################################################################
 # Default screen header files
@@ -386,16 +404,6 @@ $mail{feedbackRecipients}    = [
 #####################
 
 #push (@{${pg}{modules}}, [qw(LaTeXImage)]);
-################################################################################
-# Student Date Format
-################################################################################
-
-# Uncomment the following line to customize the format of the dates displayed to
-# students.  As it is written, the line below will display open, due and answer
-# dates in the following format: Wed Jun 27 at 10:30am
-# For all available options, consult the documentation for perl DateTime under
-# "strftime patterns".
-#$studentDateDisplayFormat="%a %b %d at %l:%M%P";
 
 ################################################################################
 # Using R with WeBWorK

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -371,22 +371,8 @@ $job_queue{database_dsn} = "sqlite:$webwork_dir/DATA/webwork2_job_queue.db";
 #
 #     perl -MDateTime::TimeZone -e 'print join "\n", DateTime::TimeZone::links'
 #
-# If left blank, the system timezone will be used. This is usually what you
-# want. You might want to set this if your server is NOT in the same timezone as
-# your school. If just a few courses are in a different timezone, set this in
-# course.conf for the affected courses instead.
-#
+# This can be set per course either in course.conf or via the course configuration.
 $siteDefaults{timezone} = "America/New_York";
-
-# Locale for time format localization
-# Set the following variable to localize the format of things like days
-# of the week and month names (i.e. translate them)
-# This variable must match one of the locales available on your system
-# To show the current locale in use on the system, type 'locale' at the
-# command prompt.  For a list of installed locales, type 'locale -a' and
-# enter one of the listed values here.
-# If you do not fill this in, the system will default to "en_US"
-$siteDefaults{locale}="";
 
 ################################################################################
 # Search Engine Indexing Enable/Disable

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -652,7 +652,7 @@ sub create_user {
 	$newUser->status("C");
 	$newUser->section($self->{section}       // "");
 	$newUser->recitation($self->{recitation} // "");
-	$newUser->comment(formatDateTime(time, "local"));
+	$newUser->comment(formatDateTime(time, 0, $ce->{siteDefaults}{timezone}, $ce->{language}));
 	$newUser->student_id($self->{student_id} // "");
 
 	# Allow sites to customize the user
@@ -772,7 +772,7 @@ sub maybe_update_user {
 		}
 
 		if ($change_made) {
-			$tempUser->comment(formatDateTime(time, "local"));
+			$tempUser->comment(formatDateTime(time, 0, $ce->{siteDefaults}{timezone}, $ce->{language}));
 			eval { $db->putUser($tempUser) };
 			if ($@) {
 				$self->write_log_entry("Failed to update user $userID in LTIAdvanced login: $@");

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -608,7 +608,7 @@ sub create_user ($self) {
 	$newUser->status('C');
 	$newUser->section($self->{section}       // '');
 	$newUser->recitation($self->{recitation} // '');
-	$newUser->comment(formatDateTime(time, 'local'));
+	$newUser->comment(formatDateTime(time, 0, $ce->{siteDefaults}{timezone}, $ce->{language}));
 	$newUser->student_id($self->{student_id} // '');
 
 	# Allow sites to customize the user.
@@ -716,7 +716,7 @@ sub maybe_update_user ($self) {
 		}
 
 		if ($change_made) {
-			$tempUser->comment(formatDateTime(time, 'local'));
+			$tempUser->comment(formatDateTime(time, 0, $ce->{siteDefaults}{timezone}, $ce->{language}));
 			eval { $db->putUser($tempUser) };
 			if ($@) {
 				$self->write_log_entry("Failed to update user $userID in LTIAdvantange login: $@");

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -668,19 +668,15 @@ Print links to siblings of the current object.
 
 Defined in this package.
 
-Display the current time and date using default format "3:37pm on Jan 7, 2004".
-The display format can be adjusted by giving a style in the template.
-For example,
+Display the current time and date in the 'datetime_format_long' format.  For
+example, for the 'en' language this will give "January 4, 2023 at 8:54:33 PM EST".
+Note that the "at" is replaced with a comma for the latest version of
+DateTime::Locale::FromData.
 
-  <!--#timestamp style="%m/%d/%y at %I:%M%P"-->
-
-will give standard WeBWorK time format.  Wording and other formatting
-can be done in the template itself.
 =cut
 
 sub timestamp ($c) {
-	# Need to use the formatDateTime in this file (some subclasses access Util's version).
-	return $c->formatDateTime(time);
+	return $c->formatDateTime(time, 'datetime_format_long');
 }
 
 =item message()
@@ -1265,34 +1261,29 @@ sub warningMessage ($c) {
 			. 'Please inform your instructor including the warning messages below.');
 }
 
-=item $dateTime = parseDateTime($string, $display_tz)
+=item $string = formatDateTime($date_time, $format_string, $timezone, $locale)
 
-Parses $string as a datetime. If $display_tz is given, $string is assumed to be
-in that timezone. Otherwise, the timezone defined in the course environment
-variable $siteDefaults{timezone} is used. The result, $dateTime, is an integer
-UNIX datetime (epoch) in the server's timezone.
+Formats a C<$date_time> epoch into a string in the format defined by
+C<$format_string>. If C<$format_string> is not provided, the default WeBWorK
+date/time format is used.  If C<$format_string> is a method of the
+C<< $dt->locale >> instance, then C<format_cldr> is used, and otherwise
+C<strftime> is used. The available patterns for $format_string can be found at
+L<DateTime/strftime Patterns>. The available methods for the C<< $dt->locale >>
+instance are documented at L<DateTime::Locale::FromData>. If C<$timezone> is
+given, then the formatted string that is returned is in the specified timezone.
+If C<$locale> is provided, the string returned will be in the format of that
+locale. If C<$locale> is not provided, Perl defaults to using C<en-US>.
 
-=cut
-
-sub parseDateTime ($c, $string, $display_tz = undef) {
-	return WeBWorK::Utils::parseDateTime($string, $display_tz || $c->ce->{siteDefaults}{timezone});
-}
-
-=item $string = formatDateTime($dateTime, $display_tz)
-
-Formats the UNIX datetime $dateTime in the standard WeBWorK datetime format.
-$dateTime is assumed to be in the server's time zone. If $display_tz is given,
-the datetime is converted from the server's timezone to the timezone specified.
-Otherwise, the timezone defined in the course environment variable
-$siteDefaults{timezone} is used.
+Note that the defaults for C<$timezone> and C<$locale> should almost never be
+overriden when this method is used.
 
 =cut
 
-sub formatDateTime ($c, $dateTime, $display_tz = undef, $formatString = undef, $locale = undef) {
+sub formatDateTime ($c, $date_time, $format_string = undef, $timezone = undef, $locale = undef) {
 	my $ce = $c->ce;
-	$display_tz ||= $ce->{siteDefaults}{timezone};
-	$locale     ||= $ce->{siteDefaults}{locale};
-	return WeBWorK::Utils::formatDateTime($dateTime, $display_tz, $formatString, $locale);
+	$timezone ||= $ce->{siteDefaults}{timezone};
+	$locale   ||= $ce->{language};
+	return WeBWorK::Utils::formatDateTime($date_time, $format_string, $timezone, $locale);
 }
 
 =item read_scoring_file($fileName)

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -292,10 +292,9 @@ sub format_userset ($c, $set) {
 	$result .= "Set header file:           " . $set->set_header . "\n";
 	$result .= "Hardcopy header file:      " . $set->hardcopy_header . "\n";
 
-	my $tz = $ce->{siteDefaults}{timezone};
-	$result .= "Open date:                 " . $c->formatDateTime($set->open_date,   $tz) . "\n";
-	$result .= "Due date:                  " . $c->formatDateTime($set->due_date,    $tz) . "\n";
-	$result .= "Answer date:               " . $c->formatDateTime($set->answer_date, $tz) . "\n";
+	$result .= "Open date:                 " . $c->formatDateTime($set->open_date) . "\n";
+	$result .= "Due date:                  " . $c->formatDateTime($set->due_date) . "\n";
+	$result .= "Answer date:               " . $c->formatDateTime($set->answer_date) . "\n";
 	$result .= "Visible:                   " . ($set->visible ? "yes" : "no") . "\n";
 	$result .= "Assignment type:           " . $set->assignment_type . "\n";
 	if ($set->assignment_type =~ /gateway/) {
@@ -303,7 +302,7 @@ sub format_userset ($c, $set) {
 		$result .= "Time interval:             " . $set->time_interval . "\n";
 		$result .= "Versions per interval:     " . $set->versions_per_interval . "\n";
 		$result .= "Version time limit:        " . $set->version_time_limit . "\n";
-		$result .= "Version creation time:     " . $c->formatDateTime($set->version_creation_time, $tz) . "\n";
+		$result .= "Version creation time:     " . $c->formatDateTime($set->version_creation_time) . "\n";
 		$result .= "Problem randorder:         " . $set->problem_randorder . "\n";
 		$result .= "Version last attempt time: " . $set->version_last_attempt_time . "\n";
 	}

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -27,7 +27,6 @@ use Mojo::Promise;
 use Mojo::JSON qw(encode_json decode_json);
 
 use WeBWorK::PG::ImageGenerator;
-# Use the ContentGenerator formatDateTime, not the version in Utils.
 use WeBWorK::Utils qw(writeLog writeCourseLogGivenTime encodeAnswers decodeAnswers
 	path_is_subdir before after between wwRound is_restricted);
 use WeBWorK::Utils::Instructor qw(assignSetVersionToUser);

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -263,7 +263,7 @@ sub displayStudentStats ($c, $studentID) {
 								after($set->open_date) ? $c->maketext('No versions of this test have been taken.')
 								: $c->maketext(
 									'Will open on [_1].',
-									$c->formatDateTime($set->open_date, undef, $ce->{studentDateDisplayFormat})
+									$c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat})
 								)
 							)
 						)
@@ -441,7 +441,7 @@ sub displayStudentStats ($c, $studentID) {
 								'em',
 								$c->maketext(
 									'Will open on [_1].',
-									$c->formatDateTime($set->open_date, undef, $ce->{studentDateDisplayFormat})
+									$c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat})
 								)
 							)
 						)

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1016,7 +1016,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 		if ($MergedSet->{$_}) {
 			print $FH '\\def\\webwork'
 				. underscore_to_camel($_) . '{'
-				. $c->formatDateTime($MergedSet->{$_}, $ce->{siteDefaults}{timezone}) . "}%\n";
+				. $c->formatDateTime($MergedSet->{$_}, $ce->{studentDateDisplayFormat}) . "}%\n";
 		}
 	}
 	# Leave reduced scoring date blank if it is disabled, or enabled but on (or somehow later) than the close date
@@ -1026,7 +1026,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 		&& $MergedSet->{reduced_scoring_date} < $MergedSet->{due_date})
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
-			. $c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{siteDefaults}{timezone}) . "}%\n";
+			. $c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) . "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -611,16 +611,14 @@ sub backupFile ($c, $outputFilePath) {
 	surePathToFile($ce->{courseDirs}{templates}, $backupFilePath);
 	copy($outputFilePath, $backupFilePath);
 	$c->addgoodmessage($c->maketext(
-		'Backup created on [_1]',
-		$c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat})
-	));
+		'Backup created on [_1]', $c->formatDateTime($backupTime, $ce->{studentDateDisplayFormat})));
 
 	# Delete oldest backup if option is present.
 	if ($c->param('deleteBackup')) {
 		my @backupTimes      = $c->getBackupTimes;
 		my $backupTime       = $backupTimes[-1];
 		my $backupFilePath   = $c->{backupBasePath} . $backupTime;
-		my $formatBackupTime = $c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat});
+		my $formatBackupTime = $c->formatDateTime($backupTime, $ce->{studentDateDisplayFormat});
 		if (-e $backupFilePath) {
 			unlink($backupFilePath);
 			$c->addgoodmessage($c->maketext('Deleted backup from [_1].', $formatBackupTime));
@@ -1326,7 +1324,7 @@ sub revert_handler ($c) {
 			copy($backupFilePath, $c->{tempFilePath});
 			$c->addgoodmessage($c->maketext(
 				'Restored backup from [_1].',
-				$c->formatDateTime($backupTime, undef, $ce->{studentDateDisplayFormat})
+				$c->formatDateTime($backupTime, $ce->{studentDateDisplayFormat})
 			));
 		} else {
 			$c->addbadmessage($c->maketext('Unable to read backup file "[_1]".', $c->shortPath($backupFilePath)));
@@ -1339,7 +1337,7 @@ sub revert_handler ($c) {
 			unlink($delFilePath);
 			$c->addgoodmessage($c->maketext(
 				'Deleted backup from [_1].',
-				$c->formatDateTime($delTime, undef, $ce->{studentDateDisplayFormat})
+				$c->formatDateTime($delTime, $ce->{studentDateDisplayFormat})
 			));
 		} else {
 			$c->addbadmessage($c->maketext('Unable to delete backup file "[_1]".', $c->shortPath($delFilePath)));

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -873,7 +873,7 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 	$userValue   = defined $userValue   ? ($labels{$userValue}   || $userValue)   : $blankfield;
 
 	if ($field =~ /_date/) {
-		$globalValue = $c->formatDateTime($globalValue, '', 'datetime_format_short', $c->ce->{language})
+		$globalValue = $c->formatDateTime($globalValue, 'datetime_format_short')
 			if $forUsers && defined $globalValue && $globalValue ne '';
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -291,8 +291,8 @@ sub scoreSet ($c, $setID, $format, $showIndex, $UsersRef, $sortedUserIDsRef) {
 	debug("done pre-fetching user problems for set $setID");
 
 	# Write the problem data
-	my $dueDateString = $c->formatDateTime($setRecord->due_date);
-	my ($dueDate, $dueTime) = $dueDateString =~ /^(.*) at (.*)$/;
+	my $dueDate          = $c->formatDateTime($setRecord->due_date, 'date_format_short');
+	my $dueTime          = $c->formatDateTime($setRecord->due_date, 'time_format_short');
 	my $valueTotal       = 0;
 	my %userStatusTotals = ();
 	my %userSuccessIndex = ();

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -217,14 +217,14 @@ sub gateway_body ($c) {
 		my $data = {};
 		$data->{id}        = $set->set_id . ',v' . $verSet->version_id;
 		$data->{version}   = $verSet->version_id;
-		$data->{start}     = $c->formatDateTime($verSet->version_creation_time, undef, $ce->{studentDateDisplayFormat});
+		$data->{start}     = $c->formatDateTime($verSet->version_creation_time, $ce->{studentDateDisplayFormat});
 		$data->{proctored} = $verSet->assignment_type =~ /proctored/;
 
 		# Display close date if this is not a timed test.
 		my $closeText = '';
 		if (!$timeLimit) {
-			$closeText = $c->maketext('Closes on [_1]',
-				$c->formatDateTime($verSet->due_date, undef, $ce->{studentDateDisplayFormat}));
+			$closeText =
+				$c->maketext('Closes on [_1]', $c->formatDateTime($verSet->due_date, $ce->{studentDateDisplayFormat}));
 		}
 
 		if (defined $verSet->version_last_attempt_time && $verSet->version_last_attempt_time > 0) {
@@ -238,7 +238,7 @@ sub gateway_body ($c) {
 				}
 			} else {
 				$data->{end} =
-					$c->formatDateTime($verSet->version_last_attempt_time, undef, $ce->{studentDateDisplayFormat});
+					$c->formatDateTime($verSet->version_last_attempt_time, $ce->{studentDateDisplayFormat});
 			}
 		} elsif ($timeNow < $verSet->due_date) {
 			$data->{end} = $c->maketext('Test not yet submitted.') . " $closeText";

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -164,8 +164,8 @@ sub setListRow ($c, $set) {
 	# Determine set status.
 	my $status = '';
 	if (time < $set->open_date) {
-		$status = $c->maketext('Will open on [_1].',
-			$c->formatDateTime($set->open_date, undef, $ce->{studentDateDisplayFormat}));
+		$status =
+			$c->maketext('Will open on [_1].', $c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat}));
 
 		if (@restricted) {
 			$status =
@@ -202,7 +202,7 @@ sub setListRow ($c, $set) {
 		}
 	} elsif (time < $set->answer_date) {
 		$status = $c->maketext('Closed, answers on [_1].',
-			$c->formatDateTime($set->answer_date, undef, $ce->{studentDateDisplayFormat}));
+			$c->formatDateTime($set->answer_date, $ce->{studentDateDisplayFormat}));
 	} elsif ($set->answer_date <= time and time < $set->answer_date + RECENT) {
 		$status = $c->maketext('Closed, answers recently available.');
 	} else {
@@ -292,7 +292,7 @@ sub set_due_msg ($c, $set) {
 		&& $set->reduced_scoring_date
 		&& $set->reduced_scoring_date < $set->due_date;
 	my $reduced_scoring_date      = $set->reduced_scoring_date;
-	my $beginReducedScoringPeriod = $c->formatDateTime($reduced_scoring_date, undef, $ce->{studentDateDisplayFormat});
+	my $beginReducedScoringPeriod = $c->formatDateTime($reduced_scoring_date, $ce->{studentDateDisplayFormat});
 
 	my $t = time;
 
@@ -302,7 +302,7 @@ sub set_due_msg ($c, $set) {
 			$c->tag('br'),
 			$c->maketext(
 				'Afterward reduced credit can be earned until [_1].',
-				$c->formatDateTime($set->due_date(), undef, $ce->{studentDateDisplayFormat})
+				$c->formatDateTime($set->due_date(), $ce->{studentDateDisplayFormat})
 			)
 		)->join('');
 	} else {
@@ -312,13 +312,13 @@ sub set_due_msg ($c, $set) {
 				$c->tag('br'),
 				$c->maketext(
 					'Reduced credit can still be earned until [_1].',
-					$c->formatDateTime($set->due_date(), undef, $ce->{studentDateDisplayFormat})
+					$c->formatDateTime($set->due_date(), $ce->{studentDateDisplayFormat})
 				)
 			)->join('');
 		}
 
 		return $c->maketext('Open, closes [_1].',
-			$c->formatDateTime($set->due_date(), undef, $ce->{studentDateDisplayFormat}));
+			$c->formatDateTime($set->due_date(), $ce->{studentDateDisplayFormat}));
 	}
 }
 

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -73,7 +73,12 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 	for my $date (qw(openDate dueDate answerDate)) {
 		my $db_date = $date =~ s/D/_d/r;
 		$options{$date} = $set->$db_date;
-		$options{ 'formatted' . ucfirst($date) } = formatDateTime($options{$date}, $ce->{siteDefaults}{timezone});
+		$options{ 'formatted' . ucfirst($date) } = formatDateTime(
+			$options{$date},
+			$ce->{studentDateDisplayFormat},
+			$ce->{siteDefaults}{timezone},
+			$ce->{language}
+		);
 		my $uc_date = ucfirst($date);
 		for (
 			[ 'DayOfWeek',       '%A' ],
@@ -94,11 +99,14 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 			)
 		{
 			$options{"$uc_date$_->[0]"} =
-				formatDateTime($options{$date}, $ce->{siteDefaults}{timezone}, $_->[1], $ce->{siteDefaults}{locale});
+				formatDateTime($options{$date}, $_->[1], $ce->{siteDefaults}{timezone}, $ce->{language});
 		}
 	}
 	$options{reducedScoringDate}          = $set->reduced_scoring_date;
-	$options{formattedReducedScoringDate} = formatDateTime($options{reducedScoringDate}, $ce->{siteDefaults}{timezone});
+	$options{formattedReducedScoringDate} = formatDateTime(
+		$options{reducedScoringDate},  $ce->{studentDateDisplayFormat},
+		$ce->{siteDefaults}{timezone}, $ce->{language}
+	);
 
 	# State Information
 	$options{numOfAttempts} =

--- a/lib/WebworkWebservice/SetActions.pm
+++ b/lib/WebworkWebservice/SetActions.pm
@@ -23,7 +23,7 @@ use Carp;
 use JSON;
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::Utils qw(max formatDateTime jitar_id_to_seq seq_to_jitar_id);
+use WeBWorK::Utils qw(max jitar_id_to_seq seq_to_jitar_id);
 use WeBWorK::Utils::Instructor qw(assignSetToGivenUsers assignMultipleProblemsToGivenUsers);
 use WeBWorK::Debug;
 use WeBWorK::DB::Utils qw(initializeUserProblem);
@@ -109,11 +109,6 @@ sub getSet {
 
 	my $db  = $self->db;
 	my $set = unbless($db->getGlobalSet($params->{set_id}));
-
-	# Change the date/times to user readable strings (why?).
-	$set->{due_date}    = formatDateTime($set->{due_date},    'local');
-	$set->{open_date}   = formatDateTime($set->{open_date},   'local');
-	$set->{answer_date} = formatDateTime($set->{answer_date}, 'local');
 
 	return { ra_out => $set, text => "Loaded set $params->{set_id} in " . $self->ce->{courseName} };
 }

--- a/templates/ContentGenerator/Base/footer.html.ep
+++ b/templates/ContentGenerator/Base/footer.html.ep
@@ -1,4 +1,4 @@
-<div id="last-modified"><%= maketext('Page generated at [_1]', $c->timestamp) %></div>
+<div id="last-modified"><%= maketext('Page generated [_1]', $c->timestamp) %></div>
 <div id="copyright">
 	<%== maketext(
 		'WeBWorK &copy; [_1] | theme: [_2] | ww_version: [_3] | pg_version [_4]',

--- a/templates/ContentGenerator/Base/set_status.html.ep
+++ b/templates/ContentGenerator/Base/set_status.html.ep
@@ -12,13 +12,13 @@
 		<strong>
 			% if (before($set->open_date)) {
 				<%= maketext('Set opens on [_1].',
-					$c->formatDateTime($set->open_date, undef, $ce->{studentDateDisplayFormat})) %>
+					$c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat})) %>
 			% } elsif ($useReducedScoring && before($set->reduced_scoring_date)) {
 				<%= maketext('Set is due on [_1].',
-					$c->formatDateTime($set->reduced_scoring_date, undef, $ce->{studentDateDisplayFormat})) %>
+					$c->formatDateTime($set->reduced_scoring_date, $ce->{studentDateDisplayFormat})) %>
 			% } elsif (before($set->due_date)) {
 				<%= maketext('Set closes on [_1].',
-					$c->formatDateTime($set->due_date, undef, $ce->{studentDateDisplayFormat})) %>
+					$c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat})) %>
 			% } else {
 				<%= maketext('Set is closed.') %>
 			% }
@@ -34,7 +34,7 @@
 				<%= maketext(
 					'After the due date this set enters a reduced scoring period until it closes on [_1].  All work '
 						. 'completed during the reduced scoring period counts for [_2]% of its value.',
-					$c->formatDateTime($set->due_date, undef, $ce->{studentDateDisplayFormat}), $reducedScoringPerCent
+					$c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat}), $reducedScoringPerCent
 				) =%>
 			% } elsif (between($reduced_scoring_date, $set->due_date)) {
 				<%= maketext(
@@ -45,8 +45,8 @@
 				<%= maketext(
 					'This set had a reduced scoring period that started on [_1] and ended on [_2].  '
 						. 'During that period all work counted for [_3]% of its value.',
-					$c->formatDateTime($reduced_scoring_date, undef, $ce->{studentDateDisplayFormat}),
-					$c->formatDateTime($set->due_date, undef, $ce->{studentDateDisplayFormat}),
+					$c->formatDateTime($reduced_scoring_date, $ce->{studentDateDisplayFormat}),
+					$c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat}),
 					$reducedScoringPerCent
 				) =%>
 			% }

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -150,7 +150,7 @@
 			% } else {
 				% if ($c->{set}->hide_score eq 'BeforeAnswerDate') {
 					<%= maketext('(Your score on this [_1] is not available until [_2].)',
-						$testNoun, $c->formatDateTime($c->{set}->answer_date)) =%>
+						$testNoun, $c->formatDateTime($c->{set}->answer_date, $ce->{studentDateDisplayFormat})) =%>
 				% } else {
 					<%= maketext('(Your score on this [_1] is not available.)', $testNoun) =%>
 				% }
@@ -376,7 +376,7 @@
 		% if ($c->{set}->hide_work eq 'BeforeAnswerDate') {
 			<strong>
 				<%= maketext('Completed results for this assignment are not available until [_1].',
-					$c->formatDateTime($c->{set}->answer_date)) %>
+					$c->formatDateTime($c->{set}->answer_date, $ce->{studentDateDisplayFormat})) %>
 			</strong>
 		% } else {
 			<strong><%= maketext('Completed results for this assignment are not available.') %></strong>

--- a/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
+++ b/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
@@ -31,14 +31,14 @@
 			<th><%= maketext('Last Full Update') %></th>
 			<td>
 				<%= $lastUpdate
-					? $c->formatDateTime($lastUpdate, 0, $ce->{studentDateDisplayFormat})
+					? $c->formatDateTime($lastUpdate, $ce->{studentDateDisplayFormat})
 					: maketext('Never') =%>
 			</td>
 		</tr>
 		% if ($updateInterval > -1) {
 			<tr>
 				<th><%= maketext('Next Update') %></th>
-				<td><%= $c->formatDateTime($lastUpdate + $updateInterval, 0, $ce->{studentDateDisplayFormat}) =%></td>
+				<td><%= $c->formatDateTime($lastUpdate + $updateInterval, $ce->{studentDateDisplayFormat}) =%></td>
 			</tr>
 		% }
 	</table>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/revert_form.html.ep
@@ -33,7 +33,7 @@
 					<%= scalar(@backupTimes) == 1
 						? maketext(
 							'Restore backup from [_1]',
-							$c->formatDateTime($backupTimes[0], undef, $ce->{studentDateDisplayFormat})
+							$c->formatDateTime($backupTimes[0], $ce->{studentDateDisplayFormat})
 						) : maketext('Restore backup from') =%>
 				<% end =%>
 			</div>
@@ -42,7 +42,7 @@
 			% } else {
 				<div class="col-auto">
 					<%= select_field 'action.revert.backup.time' => [
-						map { [ $c->formatDateTime($_, undef, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
+						map { [ $c->formatDateTime($_, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
 					],
 					id    => 'action_revert_backup_time_id',
 					class => 'form-select form-select-sm d-inline w-auto' =%>
@@ -58,7 +58,7 @@
 					<%= scalar(@backupTimes) == 1
 						? maketext(
 							'Delete backup from [_1]',
-							$c->formatDateTime($backupTimes[0], undef, $ce->{studentDateDisplayFormat})
+							$c->formatDateTime($backupTimes[0], $ce->{studentDateDisplayFormat})
 						) : maketext('Delete backup from') =%>
 				<% end =%>
 			</div>
@@ -67,7 +67,7 @@
 			% } else {
 				<div class="col-auto">
 					<%= select_field 'action.revert.delete.time' => [
-						map { [ $c->formatDateTime($_, undef, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
+						map { [ $c->formatDateTime($_, $ce->{studentDateDisplayFormat}) => $_ ] } @backupTimes
 					],
 					id    => 'action_revert_delete_number_id',
 					class => 'form-select form-select-sm d-inline w-auto' =%>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_field.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_field.html.ep
@@ -24,7 +24,7 @@
 		</div>
 	% } else {
 		<span dir="ltr">
-			<%= $c->formatDateTime($value, '', 'datetime_format_short', $ce->{language}) =%>
+			<%= $c->formatDateTime($value, 'datetime_format_short') =%>
 		</span>
 	% }
 % } elsif ($type eq 'check') {

--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -60,24 +60,23 @@
 			<td><%= scalar(@$score_list) %></td></tr>
 		<tr>
 			<th><%= maketext('Open Date') %></th>
-			<td><%= $c->formatDateTime($c->{setRecord}->open_date, undef, $ce->{studentDateDisplayFormat}) %></td>
+			<td><%= $c->formatDateTime($c->{setRecord}->open_date, $ce->{studentDateDisplayFormat}) %></td>
 		</tr>
 		% if ($c->{setRecord}->enable_reduced_scoring) {
 			<tr>
 				<th><%= maketext('Reduced Scoring Date') %></th>
 				<td>
-					<%= $c->formatDateTime($c->{setRecord}->reduced_scoring_date,
-						undef, $ce->{studentDateDisplayFormat}) %>
+					<%= $c->formatDateTime($c->{setRecord}->reduced_scoring_date, $ce->{studentDateDisplayFormat}) %>
 				</td>
 			</tr>
 		% }
 		<tr>
 			<th><%= maketext('Close Date') %></th>
-			<td><%= $c->formatDateTime($c->{setRecord}->due_date, undef, $ce->{studentDateDisplayFormat}) %></td>
+			<td><%= $c->formatDateTime($c->{setRecord}->due_date, $ce->{studentDateDisplayFormat}) %></td>
 		</tr>
 		<tr>
 			<th><%= maketext('Answer Date') %></th>
-			<td><%= $c->formatDateTime($c->{setRecord}->answer_date, undef, $ce->{studentDateDisplayFormat}) %></td>
+			<td><%= $c->formatDateTime($c->{setRecord}->answer_date, $ce->{studentDateDisplayFormat}) %></td>
 		</tr>
 	</table>
 </div>

--- a/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
@@ -66,7 +66,7 @@
 			</td>
 			<td class="px-1 text-nowrap">
 				<span dir="ltr">
-					<%= $c->formatDateTime($globalValue, '', 'datetime_format_short', $ce->{language}) =%>
+					<%= $c->formatDateTime($globalValue, 'datetime_format_short') =%>
 				</span>
 			</td>
 		</tr>

--- a/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
+++ b/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
@@ -62,8 +62,7 @@
 						% if (defined $userSet) {
 							<td>
 								% if ($userSet->due_date) {
-									<%= $c->formatDateTime($userSet->due_date, '',
-										'datetime_format_short', $ce->{language}) =%>
+									<%= $c->formatDateTime($userSet->due_date, 'datetime_format_short') =%>
 								% }
 							</td>
 							<td>

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -139,7 +139,7 @@
 		% my $nextTime = ($currentVersions == $maxVersions) ? $lastTime + $timeInterval : $timeNow + $timeInterval;
 		% if ($nextTime < $set->due_date) {
 			% $msg = maketext('Next test will be available by [_1].',
-				% $c->formatDateTime($nextTime, 0, $ce->{studentDateDisplayFormat}));
+				% $c->formatDateTime($nextTime, $ce->{studentDateDisplayFormat}));
 		% }
 	% }
 	%


### PR DESCRIPTION
Many issues with date/time display and parsing have been fixed.

Generally speaking, if the content generator `formatDateTime` method is used the default timezone and locale should not be overridden, and if the format string is overridden then it should be with one of the localizable `DateTime::Locale::FromData` methods,
`datetime_format_short`, `datetime_format_medium`, `datetime_format_long`, or `datetime_format_full`, or the course environment variable `$studentDateDisplayFormat`.  If it is a date displayed for students then it should always be
`$studentDateDisplayFormat`.

Note that the order of the arguments for the content generator method and the `WeBWorK::Utils` `formatDateTime` methods has been changed.  The format string is now the first optional argument (after the required date time epoch), then the timezone and locale are the last two optional arguments.

Also note that the `$siteDefaults{locale}` setting in site.conf is no more.  Now the locale is the same as the `$language` setting.  The previous documentation in site.conf was incorrect on how to determine valid values for this setting, and the stated default value was technically incorrect as well.  The `DateTime::Locale` package does not use what the shell command `locale -a` shows, and has nothing to do with what locales are available on your system.  Technically, the default setting is `en-US`, not `en_US` (although the `DateTime::Locale` does accept underscores and converts them to dashes). A valid way of obtaining available locales is
`perl -MDateTime::Locale -e 'print join "\n", DateTime::Locale->codes;'`. Note that `zh-HK` and `zh-CN` are technically not valid codes either (valid codes are `zh`, `zh-Hans-HK`, `zh-Hant-HK`, and `zh-Hans-CN`), but the `DateTime::Locale` ignores the territory code and uses `zh` in both cases.  This is the best that can be done in this case, because that is the necessary code to match flatpickr as it does not support any variants.

The default value of `$studentDateDisplayFormat` is now `datetime_format_long`, but that can be changed by uncommenting the override in localOverrides.conf (the commented out line there is the old default).  This setting can now be configured from the course configuration page as well.

If the `WeBWorK::Utils` `formatDateTime` method is used directly, then the timezone and locale should be passed from the course environment. The only exception to this is for set definition files.  The timezone can be used, but the locale absolutely can not be.  The English locale must be used.  The reason for this is that the `parseDateTime` method from `WeBWorK::Utils` does not know how to deal with localized date/time strings.  As a result if a set is exported with a localized date/time string, then it will not import correctly.  Note that currently if a set is exported and the locale is set to the now deleted `$siteDefaults{locale}` setting, then a warning will be issued if the locale uses multibyte characters for AM/PM, and when the set is imported the dates are incorrect.

There is a new method in `WeBWorK::Utils` for obtaining the default set due date for newly created sets.  It is `getDefaultSetDueDate`.  This method does not use localization and no longer creates a string and then parses it back to an epoch.  Instead it works directly with DateTime objects.  It does need to parse the `$pg{timeAssignDue}` course environment variable into its hour and minute parts, but that is the only string parsing it works with. Unfortunately, it was a bad decision to use a string like "11:59pm" for that setting instead of something like minutes into the day, but lots of bad decisions were made (that hindsight reveals were bad).

So now the `parseDateTime` method is used only for set definition importing, and should never again be used for anything else.