### PR TITLE
icons indicated exercise set type

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -139,18 +139,20 @@ sub setListRow ($c, $set) {
 
 	my $display_name = format_set_name_display($set->set_id);
 
-	# Add clock icon if timed gateway
+	# Add icons for sets that are not "Homework"
+	my $iconClass;
+	my $iconTitle;
 	if ($gwtype && $set->{version_time_limit} > 0 && time < $set->due_date) {
-		$display_name = $c->c(
-			$c->tag(
-				'i',
-				class => 'icon far fa-clock',
-				title => $c->maketext('Test/quiz with time limit.'),
-				data  => { alt => $c->maketext('Test/quiz with time limit.') }
-			),
-			' ',
-			$c->tag('span', $display_name)
-		)->join('');
+		$iconClass = 'icon far fa-clock';
+		$iconTitle = $c->maketext('Test/Quiz with time limit.');
+	} elsif ($gwtype) {
+		$iconClass = 'icon fa-solid fa-list-check';
+		$iconTitle = $c->maketext('Test/Quiz.');
+	}
+
+	if ($iconClass) {
+		$display_name = $c->c($c->tag('i', class => $iconClass, title => $iconTitle, data => { alt => $iconTitle }),
+			' ', $c->tag('span', $display_name))->join('');
 	}
 
 	# This is the link to the set, it has tooltip with the set description.

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -154,7 +154,6 @@ sub setListRow ($c, $set) {
 		)->join('');
 	}
 
-
 	# This is the link to the set, it has tooltip with the set description.
 	my $interactive = $c->link_to(
 		$display_name => $c->systemLink($c->url_for('problem_list', setID => $set->set_id)),

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -140,17 +140,20 @@ sub setListRow ($c, $set) {
 	my $display_name = format_set_name_display($set->set_id);
 
 	# Add icons for sets that are not "Homework"
-	my $iconClass;
-	my $iconTitle;
 	if ($gwtype) {
-		$iconClass = 'icon fa-solid fa-list-check';
-		$iconTitle = $c->maketext('Test/Quiz');
+		my $iconTitle = $c->maketext('Test/Quiz');
+		$display_name = $c->c(
+			$c->tag(
+				'i',
+				class => 'icon fa-solid fa-list-check',
+				title => $iconTitle,
+				data  => { alt => $iconTitle }
+			),
+			' ',
+			$c->tag('span', $display_name)
+		)->join('');
 	}
 
-	if ($iconClass) {
-		$display_name = $c->c($c->tag('i', class => $iconClass, title => $iconTitle, data => { alt => $iconTitle }),
-			' ', $c->tag('span', $display_name))->join('');
-	}
 
 	# This is the link to the set, it has tooltip with the set description.
 	my $interactive = $c->link_to(

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -144,7 +144,7 @@ sub setListRow ($c, $set) {
 	my $iconTitle;
 	if ($gwtype) {
 		$iconClass = 'icon fa-solid fa-list-check';
-		$iconTitle = $c->maketext('Test/Quiz.');
+		$iconTitle = $c->maketext('Test/Quiz');
 	}
 
 	if ($iconClass) {

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -142,10 +142,7 @@ sub setListRow ($c, $set) {
 	# Add icons for sets that are not "Homework"
 	my $iconClass;
 	my $iconTitle;
-	if ($gwtype && $set->{version_time_limit} > 0 && time < $set->due_date) {
-		$iconClass = 'icon far fa-clock';
-		$iconTitle = $c->maketext('Test/Quiz with time limit.');
-	} elsif ($gwtype) {
+	if ($gwtype) {
 		$iconClass = 'icon fa-solid fa-list-check';
 		$iconTitle = $c->maketext('Test/Quiz.');
 	}

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -3,11 +3,27 @@
 % my $visibleClass   = $set->visible ? 'font-visible' : 'font-hidden';
 % my $set_id         = $set->set_id;
 % my $prettySetID    = format_set_name_display($set_id);
+% my $gwtype         = $set->assignment_type() =~ /gateway/;
+% my $iconClass;
+% my $iconTitle;
+% if ($gwtype && $set->{version_time_limit}) {
+	% $iconClass = 'icon far fa-clock';
+	% $iconTitle = maketext('Test/Quiz with time limit.');
+% } elsif ($gwtype) {
+	% $iconClass = 'icon fa-solid fa-list-check';
+	% $iconTitle = maketext('Test/Quiz.');
+% } elsif ($set->assignment_type() eq 'jitar') {
+	% $iconClass = 'icon fa-solid fa-layer-group';
+	% $iconTitle = maketext('Assignment with just-in-time assessment and review.');
+% }
 %
 <tr>
 %
 % if ($c->{editMode}) {
 	<td dir="ltr">
+		% if ($iconClass) {
+			<i class="<%= $iconClass =%>" title="<%= $iconTitle =%>" alt="<%= $iconTitle =%>"></i>
+		% }
 		<%= link_to $prettySetID => $c->systemLink(url_for('instructor_set_detail', setID => $set_id)) %>
 	</td>
 % } else {
@@ -20,6 +36,9 @@
 			<%= label_for "${set_id}_id", begin =%>
 				<span class="set-label set-id-tooltip <%= $visibleClass %>" data-bs-toggle="tooltip"
 					data-bs-placement="right" data-bs-title="<%= $set->description %>">
+					% if ($iconClass) {
+						<i class="<%= $iconClass =%>" title="<%= $iconTitle =%>" alt="<%= $iconTitle =%>"></i>
+					% }
 					<%= $prettySetID =%>
 				</span>
 			<% end =%>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -6,10 +6,7 @@
 % my $gwtype         = $set->assignment_type() =~ /gateway/;
 % my $iconClass;
 % my $iconTitle;
-% if ($gwtype && $set->{version_time_limit}) {
-	% $iconClass = 'icon far fa-clock';
-	% $iconTitle = maketext('Test/Quiz with time limit.');
-% } elsif ($gwtype) {
+% if ($gwtype) {
 	% $iconClass = 'icon fa-solid fa-list-check';
 	% $iconTitle = maketext('Test/Quiz.');
 % } elsif ($set->assignment_type() eq 'jitar') {

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -3,10 +3,9 @@
 % my $visibleClass   = $set->visible ? 'font-visible' : 'font-hidden';
 % my $set_id         = $set->set_id;
 % my $prettySetID    = format_set_name_display($set_id);
-% my $gwtype         = $set->assignment_type() =~ /gateway/;
 % my $iconClass;
 % my $iconTitle;
-% if ($gwtype) {
+% if ($set->assignment_type() =~ /gateway/) {
 	% $iconClass = 'icon fa-solid fa-list-check';
 	% $iconTitle = maketext('Test/Quiz');
 % } elsif ($set->assignment_type() eq 'jitar') {

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_row.html.ep
@@ -8,10 +8,10 @@
 % my $iconTitle;
 % if ($gwtype) {
 	% $iconClass = 'icon fa-solid fa-list-check';
-	% $iconTitle = maketext('Test/Quiz.');
+	% $iconTitle = maketext('Test/Quiz');
 % } elsif ($set->assignment_type() eq 'jitar') {
 	% $iconClass = 'icon fa-solid fa-layer-group';
-	% $iconTitle = maketext('Assignment with just-in-time assessment and review.');
+	% $iconTitle = maketext('JITAR Set');
 % }
 %
 <tr>


### PR DESCRIPTION
We have a clock icon for sets that are timed tests which are still open to take. This appears on the main "Homework Sets" page.

This adds another icon for all other tests, so that there is an indicator that the set is a test (because that is not always clear from the name an instructor gives to the test.)

<img width="262" alt="Screenshot 2023-11-26 at 11 49 09 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/9b2ef4a8-6da5-4f3c-9d87-3780f9e5d6fc">

Additionally, these icons now appear in the Set Manager table so that the instructor can easily see where the tests are.

Lastly, the instructor might also want to see which sets are JITAR sets while in the Set Manager, so there is an icon for this too. I left that out of the "Homework Sets" page because I am not sure how useful that indicator would be for students.

<img width="273" alt="Screenshot 2023-11-26 at 11 49 22 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/ce0a3464-b8e8-41ff-849c-eb503dc433de">
