### PR TITLE
Rename several pages

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1262,18 +1262,18 @@ ${pg}{modules} = [
 ##### Problem creation defaults
 
 # The default weight (also called value) of a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.
 $problemDefaults{value} = 1;
 
 # The default max_attempts for a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.  Note that
 # setting this to -1 gives students unlimited attempts.
 $problemDefaults{max_attempts} = -1;
 
 # The default showMeAnother for a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.  Note that
 # setting this to -1 disables the showMeAnother button
 $problemDefaults{showMeAnother} = -2;
@@ -1597,7 +1597,7 @@ $ConfigValues = [
 			doc  => x('Enable Course Achievements'),
 			doc2 => x(
 				'Activiating this will enable Mathchievements for webwork.  Mathchievements can be managed '
-					. 'by using the Achievement Editor link.'
+					. 'by using the Achievements Manager link.'
 			),
 			type => 'boolean'
 		},
@@ -1659,7 +1659,7 @@ $ConfigValues = [
 					. 'is 50% and a student views a problem during the Reduced Scoring Period, they will see the '
 					. 'message "You are in the Reduced Scoring Period: All additional work done counts 50% of the '
 					. 'original." </p><p>To use this, you also have to enable Reduced Scoring and set the Reduced '
-					. 'Scoring Date for individual assignments by editing the set data using the Set Manager.</p>'
+					. 'Scoring Date for individual assignments by editing the set data using the Sets Manager.</p>'
 					. '<p>This works with the avg_problem_grader (which is the the default grader) and the '
 					. 'std_problem_grader (the all or nothing grader). It will work with custom graders if they '
 					. 'are written appropriately.</p>'
@@ -1871,9 +1871,9 @@ $ConfigValues = [
 		{ var => 'permissionLevels{navigation_allowed}',
 		  doc => 'Allowed to view course home page',
 		  doc2 => 'If a user does not have this permission, then the user will not be allowed to navigate to the '
-			. 'course home page, i.e., the Homework Sets page.  This should only be used for a course when LTI '
+			. 'course home page, i.e., the Assignments page.  This should only be used for a course when LTI '
 			. 'authentication is used, and is most useful when LTIGradeMode is set to homework.  In this case the '
-			. 'Homework Sets page is not useful and can even be confusing to students.  To use this feature set '
+			. 'Assignments page is not useful and can even be confusing to students.  To use this feature set '
 			. 'this permission to "login_proctor".',
 		  type => 'permission'
 		},

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -235,7 +235,7 @@ $mail{feedbackRecipients}    = [
 # List of enabled display modes. Comment out any modes you don't wish to make
 # available for use.
 # The first uncommented option is the default for instructors rendering problems
-# in the homework sets editor.
+# in the Library Browser and Set Detail page.
 #$pg{displayModes} = [
 	#"MathJax",     # render TeX math expressions on the client side using MathJax
 	                # we strongly recommend people install and use MathJax, and it is required if you want to use mathview
@@ -513,7 +513,7 @@ $mail{feedbackRecipients}    = [
 ################################################################################
 # Searching for set.def files to import
 ################################################################################
-## Uncomment below so that when the homework sets editor searches for set def
+## Uncomment below so that when the Library Browser searches for set def
 ## files, it searches beyond templates; it can search deeper subfolders of
 ## templates, and optionally also descend into Library
 

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -269,20 +269,20 @@ $mail{feedbackRecipients}    = [
 ################################################################################
 
 # The default weight (also called value) of a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.
 
 #$problemDefaults{value} = 1;
 
 # The default max_attempts for a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.  Note that
 # setting this to -1 gives students unlimited attempts.
 
 #$problemDefaults{max_attempts} = -1;
 
 # The default showMeAnother for a problem to use when using the
-# Library Browser, Problem Editor or Set Manager to add problems to a set
+# Library Browser, Problem Editor, or Sets Manager to add problems to a set
 # or when this value is left blank in an imported set definition file.  Note that
 # setting this to -1 disables the showMeAnother button
 #$problemDefaults{showMeAnother} = -1;

--- a/courses.dist/modelCourse/templates/email/welcome.msg
+++ b/courses.dist/modelCourse/templates/email/welcome.msg
@@ -12,7 +12,7 @@ Your username/password is:
 $LOGIN/$SID
 
 You should change your password once you have logged in by visiting
-User Settings in the sidebar navigation.
+Account Settings in the sidebar navigation.
 
 Have fun,
 Jan

--- a/courses.dist/modelCourse/templates/setOrientation/course_info.txt
+++ b/courses.dist/modelCourse/templates/setOrientation/course_info.txt
@@ -5,7 +5,7 @@
 If you haven't already done so, you should change your password to
 something other than your student ID or whatever your instructor
 used as your initial password.  To do this, click on the
-User Settings link in the sidebar navigation at the far left,
+Account Settings link in the sidebar navigation at the far left,
 and follow the directions on that page. Note you can collapse and
 uncollapse the sidebar navigation by clicking on the three bars "hamburger"
 icon at the top left. So if you don't see the sidebar navigation, click

--- a/courses.dist/modelCourse/templates/setOrientation/options_info.txt
+++ b/courses.dist/modelCourse/templates/setOrientation/options_info.txt
@@ -5,7 +5,7 @@
 If you haven't already changed your password, you should do so now.
 To do this, type your OLD password in the top box at the left and
 your NEW password in the two lower boxes at the left,
-then press the "Change User Options" button.
+then press the "Change Account Settings" button.
 
 <p align="justify">
 
@@ -27,5 +27,5 @@ automatically if you wish.
 <p align="justify">
 
 Finally, when you have made the changes that you want to make, select
-the "Homework Sets" link at the top of the red panel at the far left
+the "Assignments" link at the top of the red panel at the far left
 to get back to the list of homework sets.

--- a/courses.dist/modelCourse/templates/setOrientation/prob02.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/prob02.pg
@@ -42,7 +42,7 @@ understands your answer the way you intend it to. And it does not count
 as an attempt on the problem. (This is discussed further in a later problem.)
 $PAR
 
-The ${LQ}User Settings$RQ link under the sidebar navigation at the left
+The ${LQ}Account Settings$RQ link under the sidebar navigation at the left
 has a ${LQ}Change Display Options$RQ section that allows you to
 change how the problem is displayed.  The equations within the problem
 can be represented in two different ways:
@@ -69,8 +69,8 @@ Choose whichever mode is most comfortable for you.  You can always
 select a different mode if a particular problem needs it.  Here is a
 sample of some simple mathematics, \(x^2 + 3\), and a more complicated
 expression, \(\frac{x(1-x)}{2x + 1}\).  Try changing the display mode
-by clicking the ${LQ}User Settings$RQ link, selecting the  ${LQ}images${RQ}
-radio button, pressing the ${LQ}Change User Settings${RQ} button and then
+by clicking the ${LQ}Account Settings$RQ link, selecting the  ${LQ}images${RQ}
+radio button, pressing the ${LQ}Change Account Settings${RQ} button and then
 displaying problem 2 again.  Then change the display mode to back to
 ${LQ}MathJax$RQ mode for the rest of the homework set.
 $PAR

--- a/courses.dist/modelCourse/templates/setOrientation/setHeader.pg
+++ b/courses.dist/modelCourse/templates/setOrientation/setHeader.pg
@@ -50,12 +50,12 @@ menu, click the three bars to make it reappear.
 
 $PAR
 On the left, in the sidebar navigation, you have already
-seen the ${LQ}Homework Sets${RQ} page,
+seen the ${LQ}Assignments${RQ} page,
 which lists all the homework assignments that have
 been assigned to you.  Links allow you to go to any assignment
 you want to work on.
 $PAR
-The ${LQ}User Settings${RQ} page lets you change your password,
+The ${LQ}Account Settings${RQ} page lets you change your password,
 email address and display options. Display Options gives you control
 over how you want math equations displayed.  For example with
 ${LQ}MathJax${RQ} you can control the size of equations, have access

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -512,7 +512,7 @@ ul.courses-list {
 	}
 }
 
-/* Homework Sets */
+/* Assignments page */
 .problem_set_table {
 	td a {
 		font-weight: bold;

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1129,7 +1129,7 @@ sub save_as_handler ($c) {
 			$c->shortPath($outputFilePath)
 		));
 		$c->addbadmessage(
-			$c->maketext('You can change the file path for this problem manually from the "Set Manager" page'))
+			$c->maketext('You can change the file path for this problem manually from the "Sets Manager" page'))
 			if defined $c->{setID};
 		$c->addgoodmessage($c->maketext(
 			'The text box now contains the source of the original problem. '

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -285,7 +285,7 @@ use constant FIELD_PROPERTIES => {
 		help_text => x(
 			'This sets a number of minutes for each version of a test, once it is started.  Use "0" to indicate no '
 				. 'time limit.  If there is a time limit, then there will be an indication that this is a timed '
-				. 'test on the main "Homework Sets" page.  Additionally the student will be sent to a confirmation '
+				. 'test on the main "Assignments" page.  Additionally the student will be sent to a confirmation '
 				. 'page beefore they can begin.'
 		)
 	},

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -103,9 +103,9 @@ sub nav ($c, $args) {
 	return '' unless $c->authz->hasPermissions($c->param('user'), 'navigation_allowed');
 
 	my @links = (
-		$c->maketext('Homework Sets'),
+		$c->maketext('Assignments'),
 		$c->url_for($c->app->routes->lookup($c->current_route)->parent->name),
-		$c->maketext('Homework Sets')
+		$c->maketext('Assignments')
 	);
 	return $c->tag(
 		'div',

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -246,7 +246,7 @@ my %routeParameters = (
 		path   => '/logout'
 	},
 	options => {
-		title        => x('User Settings'),
+		title        => x('Account Settings'),
 		module       => 'Options',
 		path         => '/options',
 		unrestricted => 1
@@ -332,7 +332,7 @@ my %routeParameters = (
 		path   => '/instructor'
 	},
 	instructor_user_list => {
-		title    => x('User Manager'),
+		title    => x('Accounts Manager'),
 		children => [qw(instructor_user_detail)],
 		module   => 'Instructor::UserList',
 		path     => '/users'
@@ -343,7 +343,7 @@ my %routeParameters = (
 		path   => '/#userID'
 	},
 	instructor_set_list => {
-		title    => x('Set Manager'),
+		title    => x('Sets Manager'),
 		children => [qw(instructor_set_detail)],
 		module   => 'Instructor::ProblemSetList',
 		path     => '/sets'
@@ -370,7 +370,7 @@ my %routeParameters = (
 		path   => '/add_users'
 	},
 	instructor_set_assigner => {
-		title  => x('Set Assigner'),
+		title  => x('Assigner Tool'),
 		module => 'Instructor::Assigner',
 		path   => '/assigner'
 	},
@@ -460,7 +460,7 @@ my %routeParameters = (
 		path   => '/student/#userID'
 	},
 	instructor_achievement_list => {
-		title    => x('Achievement Editor'),
+		title    => x('Achievements Manager'),
 		children => [qw(instructor_achievement_editor instructor_achievement_user_editor)],
 		module   => 'Instructor::AchievementList',
 		path     => '/achievement_list'

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -6,12 +6,12 @@
 % }
 <ul class="nav flex-column">
 	% if (defined $courseID && $authen->was_verified) {
-		% # Homework Sets or Course Administration
+		% # Assignments or Course Administration
 		<li class="list-group-item nav-item">
 			% if ($restricted_navigation) {
-				<span class="nav-link disabled"><%= maketext('Homework Sets') %></span>
+				<span class="nav-link disabled"><%= maketext('Assignments') %></span>
 			% } else {
-				<%= $makelink->('set_list', text => maketext('Homework Sets')) %>
+				<%= $makelink->('set_list', text => maketext('Assignments')) %>
 			% }
 		</li>
 		%
@@ -88,7 +88,9 @@
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
 			<li><hr class="site-nav-separator"></li>
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
-			% # Class list editor
+			% # Assigner Tool
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_assigner') %></li>
+			% # Accounts Manager
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
 			% # User Assignments
 			% if (defined $eUserID && $eUserID ne $userID || defined $urlUserID) {
@@ -117,9 +119,7 @@
 					</ul>
 				</li>
 			% }
-			% # Set assigner
-			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_assigner') %></li>
-			% # Homework Set Editor
+			% # Sets Manager
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_list') %></li>
 			% # Editor link.  Only shown for non-versioned sets
 			% if (defined $setID && $setID !~ /,v\d+$/) {

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -88,8 +88,6 @@
 		% if ($authz->hasPermissions($userID, 'access_instructor_tools')) {
 			<li><hr class="site-nav-separator"></li>
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_tools') %></li>
-			% # Assigner Tool
-			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_assigner') %></li>
 			% # Accounts Manager
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
 			% # User Assignments
@@ -136,6 +134,8 @@
 					</ul>
 				</li>
 			% }
+			% # Assigner Tool
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_assigner') %></li>
 			% # Problem Editor
 			<li class="list-group-item nav-item">
 				<%= $makelink->(

--- a/templates/ContentGenerator/Hardcopy/form.html.ep
+++ b/templates/ContentGenerator/Hardcopy/form.html.ep
@@ -8,7 +8,7 @@
 	% if ($multiuser) {
 		<p>
 			<%= maketext(
-				'Select the homework sets for which to generate hardcopy versions. You may'
+				'Select the assignments for which to generate hardcopy versions. You may'
 					. ' also select multiple users from the users list. You will receive hardcopy'
 					. ' for each (set, user) pair.') =%>
 		</p>
@@ -65,7 +65,7 @@
 		<div class="col-md-8 font-sm mb-2">
 			<%= maketext(
 				'You may choose to show any of the following data. Correct answers, hints, and solutions '
-					. 'are only available [_1] after the answer date of the homework set.',
+					. 'are only available [_1] after the answer date of the assignment.',
 				$multiuser ? 'to privileged users or' : ''
 			) =%>
 		</div>

--- a/templates/ContentGenerator/Instructor/Assigner.html.ep
+++ b/templates/ContentGenerator/Instructor/Assigner.html.ep
@@ -6,7 +6,7 @@
 % }
 %
 % unless ($authz->hasPermissions(param('user'), 'assign_problem_sets')) {
-	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to assign homework sets.') %></div>
+	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to assign sets.') %></div>
 	% last;
 % }
 %

--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -34,7 +34,7 @@
 % }
 %
 % unless ($authz->hasPermissions(param('user'), 'score_sets')) {
-	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to grade homework sets.') %></div>
+	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to grade assignments.') %></div>
 	% last;
 % }
 %

--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -32,7 +32,7 @@
 % }
 %
 % if ($c->{editMode} && !$authz->hasPermissions(param('user'), 'modify_problem_sets')) {
-	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to modify homework sets.') %></div>
+	<div class="alert alert-danger p-1 mb-0"><%= maketext('You are not authorized to modify sets.') %></div>
 	% last;
 % }
 %

--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -46,7 +46,7 @@
 						data-bs-toggle="popover"
 						data-bs-content="<%= maketext(
 							'Answer availability for tests depends on multiple settings.  This only indicates the '
-								. 'template answer date has passed.  See set editor for actual availability.'
+								. 'template answer date has passed.  See Set Detail page for actual availability.'
 						) =%>">
 						<i class="icon fas fa-question-circle" data-alt="<%= maketext('Help Icon') =%>"
 							aria-hidden="true">

--- a/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
+++ b/templates/ContentGenerator/Instructor/UsersAssignedToSet.html.ep
@@ -6,7 +6,7 @@
 % }
 %
 % unless ($authz->hasPermissions(param('user'), 'assign_problem_sets')) {
-	<div class="alert alert-danger p-1"><%= maketext('You are not authorized to assign homework sets.') %></div>
+	<div class="alert alert-danger p-1"><%= maketext('You are not authorized to assign sets.') %></div>
 	% last;
 % }
 %
@@ -22,7 +22,7 @@
 	</div>
 	<div class="mb-2">
 		<%== maketext(
-			"When you unassign by unchecking a student's name, you destroy all of the data for homework set [_1] "
+			"When you unassign by unchecking a student's name, you destroy all of the data for assignment [_1] "
 				. 'for this student. You will then need to reassign the set to these students and they will receive '
 				. 'new versions of the problems. Make sure this is what you want to do before unchecking students.',
 			tag('b', dir => 'ltr', format_set_name_display($setID))
@@ -89,7 +89,7 @@
 			<%== maketext(
 				'There is NO undo for this function.  Do not use it unless you know what you are doing!  '
 					. 'When you unassign a student using this button, or by unchecking their name, you destroy all '
-					. 'of the data for homework set [_1] for this student.',
+					. 'of the data for assignment [_1] for this student.',
 				tag('span', dir => 'ltr', format_set_name_display($setID))
 			) =%>
 		</div>

--- a/templates/ContentGenerator/Options.html.ep
+++ b/templates/ContentGenerator/Options.html.ep
@@ -166,5 +166,5 @@
 		% }
 	% }
 	%
-	<%= submit_button maketext('Change User Settings'), name => 'changeOptions', class => 'btn btn-primary' =%>
+	<%= submit_button maketext('Change Account Settings'), name => 'changeOptions', class => 'btn btn-primary' =%>
 % end

--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -16,7 +16,7 @@
 	% # Create the set table.
 	<div class="table-responsive">
 		<table class="problem_set_table table table-sm caption-top font-sm">
-			<caption><%= maketext('Homework Sets') %></caption>
+			<caption><%= maketext('Assignments') %></caption>
 			%
 			% # Setlist table headers
 			% my $sort = param('sort') || 'status';

--- a/templates/HelpFiles/InstructorAchievementList.html.ep
+++ b/templates/HelpFiles/InstructorAchievementList.html.ep
@@ -14,7 +14,7 @@
 %################################################################################
 %
 % layout 'help_macro';
-% title maketext('Achievement Editor Help');
+% title maketext('Achievements Manager Help');
 %
 <p>
 	<%= maketext('Manage achievements for the course.  The actions allow one to edit, assign, import, export, score, '

--- a/templates/HelpFiles/InstructorAssigner.html.ep
+++ b/templates/HelpFiles/InstructorAssigner.html.ep
@@ -14,7 +14,7 @@
 %################################################################################
 %
 % layout 'help_macro';
-% title maketext('Set Assigner Help');
+% title maketext('Assigner Tool Help');
 %
 <p>
 	<%= maketext('Select Users from the left column and sets from the right column and assign or '

--- a/templates/HelpFiles/InstructorFileManager.html.ep
+++ b/templates/HelpFiles/InstructorFileManager.html.ep
@@ -46,7 +46,7 @@
 		<%== maketext('These are stored in the templates directory. The format of '
 			. '<strong>Set Definition files</strong> is described in the <a [_1]>Set Definition specification</a>. '
 			. 'Set definition files are mainly useful for transferring set assignments from one course to another '
-			. 'and are created when exporting a problem set from the "Set Manager". Each set definition file '
+			. 'and are created when exporting a problem set from the "Sets Manager". Each set definition file '
 			. 'contains a list of problems used and the dates and times. These definitions can be imported into the '
 			. 'current course.',
 			'href="https://webwork.maa.org/wiki/Set_Definition_Files" target="Webworkdocs"') =%>
@@ -75,7 +75,7 @@
 	<dd>
 		<%= maketext('These are the files from which problems are generated and are located in the templates '
 			. 'directory or in subdirectories. They can be edited directly using the "Edit" link on each problem '
-			. 'page or from the "Set Manager". The File Manager allows you to upload or download these files. 	'
+			. 'page or from the "Sets Manager". The File Manager allows you to upload or download these files. 	'
 			. 'Directories that start with "set" contain pg files and are generated when exporting a problem set in '
 			. 'which there are local versions of a problem.') =%>
 	</dd>

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -159,7 +159,7 @@
 		<p>
 			<%= maketext('You may want to create an unattached problem if you are using the current problem as a model '
 				. 'for a new problem. You can add the new file to a homework set from the Library Browser or via the '
-				. 'set detail page of the "Set Manager".') =%>
+				. 'set detail page of the "Sets Manager".') =%>
 		</p>
 		<p>
 			<%= maketext('If the original problem can not be edited than the path name must be changed in order to be '
@@ -177,7 +177,7 @@
 	<dd>
 		<%= maketext('Add this problem as the last problem of an existing set, either as a problem or as the set '
 			. 'header (the text that appears on the home page of a homework set). You can rearrange the order of the '
-			. 'problems later using the "Set Manager".') =%>
+			. 'problems later using the "Sets Manager".') =%>
 	</dd>
 
 	<dt><%= maketext('Revert') %></dt>

--- a/templates/HelpFiles/InstructorProblemSetList.html.ep
+++ b/templates/HelpFiles/InstructorProblemSetList.html.ep
@@ -14,7 +14,7 @@
 %################################################################################
 %
 % layout 'help_macro';
-% title maketext('Set Manager Help');
+% title maketext('Sets Manager Help');
 %
 <p>
 	<%= maketext('This page manages all problem sets (including quizzes/tests). '

--- a/templates/HelpFiles/InstructorScoring.html.ep
+++ b/templates/HelpFiles/InstructorScoring.html.ep
@@ -21,8 +21,8 @@
 		. 'application.') =%>
 </p>
 <p>
-	<%= maketext('What WeBWorK does have is good support for summarizing the scores on WeBWorK homework sets and '
-		. 'tests and exporting them in a form (.csv) which any spreadsheet can use. WeBWorK reports all of the '
+	<%= maketext('What WeBWorK does have is good support for summarizing the scores on WeBWorK assignments '
+		. 'and exporting them in a form (.csv) which any spreadsheet can use. WeBWorK reports all of the '
 		. 'homework grades with options shown below.') =%>
 </p>
 <p>

--- a/templates/HelpFiles/InstructorSetMaker.html.ep
+++ b/templates/HelpFiles/InstructorSetMaker.html.ep
@@ -55,6 +55,6 @@
 	</dd>
 </dl>
 <p class="mb-0">
-	<%= maketext('The "Edit Target Set" button at the top of the page will take you to the Problem Set Editor '
+	<%= maketext('The "Edit Target Set" button at the top of the page will take you to the Set Detail page '
 		. 'which will allow you to edit dates, assign users and other information about the problem set.') =%>
 </p>

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -14,7 +14,7 @@
 %################################################################################
 %
 % layout 'help_macro';
-% title maketext('User Manager Help');
+% title maketext('Accounts Manager Help');
 %
 <p>
 	<%== maketext('From this page you can <strong>add new students</strong>, <strong>edit</strong> user data '

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -23,7 +23,7 @@
 		. 'another course. You can also delete students from the class roster, but this cannot be undone.') =%>
 </p>
 <p>
-	<%= maketext('This page gives access to information about the student, independent of the homework sets '
+	<%= maketext('This page gives access to information about the student, independent of the assignments '
 		. 'assigned to them.') =%>
 </p>
 <p><%= maketext('To perform an action select the desired action tab and click the submit button.') %></p>
@@ -59,11 +59,11 @@
 
 	<dt><%= maketext('Add a few students to the course.') %></dt>
 	<dd>
-		<%= maketext('Click the "Add x student(s)" radio button and then click "Take action". This will take you to a '
+		<%= maketext('Enter a number of students to add, and then click "Add". This will take you to a '
 			. 'new page where the data can be entered for one or more students. It is also possible to assign the '
-			. 'student to one or more problem sets as they are being entered: simply select the homework sets from the '
+			. 'student(s) to one or more sets as they are being entered: simply select the sets from the '
 			. 'list below the data entry table. Use "command" or "control" click to select more than one '
-			. 'homework set.') =%>
+			. 'set.') =%>
 	</dd>
 
 	<dt><%= maketext('Add many students to a course from a class list.') %></dt>
@@ -98,8 +98,8 @@
 	<dd>
 		<%= maketext('To drop a student or students, select them for editing as described above and then set the '
 			. 'pop-up list to enrolled,drop, or audit. Dropped students cannot log in to the course, are not assigned '
-			. 'new homework sets and are not sent email. They can be re-enrolled simply by changing their status back '
-			. 'to enrolled. No data is lost, any homework sets assigned before they were dropped are restored '
+			. 'new sets and are not sent email. They can be re-enrolled simply by changing their status back '
+			. 'to enrolled. No data is lost, any assignments assigned before they were dropped are restored '
 			. 'unchanged.') =%>
 	</dd>
 
@@ -107,20 +107,20 @@
 	<dd>
 		<%= maketext('This should be done cautiously. Once a student is deleted from a course their data is lost '
 			. 'forever and cannot be recovered. They can be added to the course as a new student, but all of their '
-			. 'homework set assignments and homework has been permanently deleted.') =%>
+			. 'assignment data has been permanently deleted.') =%>
 	</dd>
 
 	<dt><%= maketext('Assign sets to one student') %></dt>
 	<dd>
 		<%= maketext('To assign one or more sets to an individual student click in the column "Assigned Sets" in the '
-			. q{student's row. This will take you to a page where you can assign and unassign homework sets and }
+			. q{student's row. This will take you to a page where you can assign and unassign sets and }
 			. 'change the due dates for homework on an individual basis.') =%>
 	</dd>
 
 	<dt><%= maketext('Change the due date for one student') %></dt>
 	<dd>
 		<%= maketext(q{Click on the column "Assigned Sets" in the student's row. This will take you to a page where }
-			. 'you can assign and unassign homework sets and change the due dates for homework on an '
+			. 'you can assign and unassign sets and change the due dates for homework on an '
 			. 'individual basis.') =%>
 	</dd>
 
@@ -135,42 +135,42 @@
 			. 'upper right corner of the window.') =%>
 	</dd>
 
-	<dt><%= maketext('Change the grades on a homework set for one student.') %></dt>
+	<dt><%= maketext('Change the grades on an assignment for one student.') %></dt>
 	<dd>
 		<%= maketext(q{Click first in the "Assigned Sets" column in the student's row. This will take you to a new }
-			. 'page where you will click on the link to the homework set where the grade change is to be made. (The '
+			. 'page where you will click on the link to the assignment where the grade change is to be made. (The '
 			. 'grade for each problem is listed as "status" on this third page).') =%>
 	</dd>
 
 	<dt><%= maketext('Extend the number of attempts allowed a student on a given problem.') %></dt>
 	<dd>
 		<%= maketext(q{Click first in the "Assigned Sets" column in the student's row. This will take you to a new }
-			. 'page where you will click on the link to the homework set where the grade change is to be made.') =%>
+			. 'page where you will click on the link to the assignment where the grade change is to be made.') =%>
 	</dd>
 
 	<dt><%= maketext('Assign sets to many students') %></dt>
 	<dd>
-		<%= maketext('This is done from the "Set Manager" or from the "Instructor Tools" page if you wish to '
-			. 'assign a homework set to all students or a large group of students (e.g. a section).') =%>
+		<%= maketext('This is done from the "Sets Manager" or from the "Instructor Tools" page if you wish to '
+			. 'assign a set to all students or a large group of students (e.g. a section).') =%>
 	</dd>
 
-	<dt><%= maketext('Change dates for a homework set for the whole class.') %></dt>
-	<dd><%= maketext('This is done from the "Set Manager" or from the "Instructor Tools" page.') %></dd>
+	<dt><%= maketext('Change dates for a set for the whole class.') %></dt>
+	<dd><%= maketext('This is done from the "Sets Manager" or from the "Instructor Tools" page.') %></dd>
 
-	<dt><%= maketext('Change the grading on a homework set for an entire class.') %></dt>
+	<dt><%= maketext('Change the grading on a set for an entire class.') %></dt>
 	<dd>
 		<%= maketext('You might want to do this if you want to give full credit to everyone on a particular problem '
-			. q{that was not worded correctly, or wasn't working properly. This is done from the "Set Manager" }
+			. q{that was not worded correctly, or wasn't working properly. This is done from the "Sets Manager" }
 			. 'page or the "Instructor Tools" page.') =%>
 	</dd>
 
 	<dt><%= maketext('Change the number of atttempts allowed on a problem.') %></dt>
-	<dd><%= maketext('This is done from the "Set Manager" page or the "Instructor tools" page.') %></dd>
+	<dd><%= maketext('This is done from the "Sets Manager" page or the "Instructor tools" page.') %></dd>
 </dl>
 
 <p>
 	<%= maketext('Many of these editing activities can also be done more quickly from the "Instructor Tools" page '
-		. 'where students and homework sets can be selected simultaneously. The "Instructor Tools" page is useful for '
+		. 'where students and sets can be selected simultaneously. The "Instructor Tools" page is useful for '
 		. 'quick editing of one or two students. The initial setup of the class can be done best from this page. '
 		. 'Importing and exporting class lists can only be done from this page. Deleting students can only be '
 		. 'done from this page.') =%>
@@ -190,7 +190,7 @@
 	<li>
 		<%== maketext('The <strong>Assigned sets</strong> column (x/y) indicates that x sets out of y sets avaiable '
 			. 'have been assigned to this student. Click this link to assign or unassign sets to this student, to '
-			. 'adjust due dates, or to adjust the grades on a homework set for a student.') =%>
+			. 'adjust due dates, or to adjust the grades on an assignment for a student.') =%>
 	</li>
 	<li>
 		<%== maketext('Clicking the <strong>email address</strong> link will bring up your standard email application '

--- a/templates/HelpFiles/Options.html.ep
+++ b/templates/HelpFiles/Options.html.ep
@@ -14,7 +14,7 @@
 %################################################################################
 %
 % layout 'help_macro';
-% title maketext('User Settings Help');
+% title maketext('Account Settings Help');
 %
 <p>
 	<%= maketext('This page allows users to change their password, email address, and display settings used in '

--- a/templates/HelpFiles/admin_links.html.ep
+++ b/templates/HelpFiles/admin_links.html.ep
@@ -25,7 +25,7 @@
 </p>
 
 <dl>
-	<dt><%= maketext('User Settings') %></dt>
+	<dt><%= maketext('Account Settings') %></dt>
 	<dd><%= maketext('Use this page to change your password.') =%></dd>
 	<dt><%= maketext('Course Listings') %></dt>
 	<dd><%= maketext('View/access current and archived courses.') =%></dd>
@@ -45,7 +45,7 @@
 	<dd><%= maketext('Configure which course links appear on the site landing page.') =%></dd>
 	<dt><%= maketext('Manage Locations') %></dt>
 	<dd><%= maketext('Configure ip ranges (locations) that can be used to restrict set access.') =%></dd>
-	<dt><%= maketext('User Manager') %></dt>
+	<dt><%= maketext('Accounts Manager') %></dt>
 	<dd>
 		<%= maketext('Manage instructors.  When instructors are added to a newly created course, they are also '
 			. 'added to the admin course with username "userID_courseID".') =%>

--- a/templates/HelpFiles/instructor_links.html.ep
+++ b/templates/HelpFiles/instructor_links.html.ep
@@ -34,14 +34,14 @@
 			. '<strong>Assign individual sets</strong> '
 			. 'and <strong>Edit individual due dates</strong>.') =%>
 	</dd>
-	<dt><%= maketext('User Manager') %></dt>
+	<dt><%= maketext('Accounts Manager') %></dt>
 	<dd>
 		<%= maketext('Edit class roster data. Add students, edit student data, drop students from class, import '
 			. 'students from a classlist, and give user professor privileges. Access to individual homework sets.') =%>
 	</dd>
-	<dt><%= maketext('Set Assigner') %></dt>
+	<dt><%= maketext('Assigner Tool') %></dt>
 	<dd><%= maketext('Assign and unassign selected exercise sets to selected users.') %></dd>
-	<dt><%= maketext('Set Manager') %></dt>
+	<dt><%= maketext('Sets Manager') %></dt>
 	<dd>
 		<%= maketext('Edit homework sets for entire class. Change homework set due dates, create new sets from a set '
 			. 'definition file, create new homework sets, make sets visible/invisible, score homework sets. Assign '
@@ -57,10 +57,10 @@
 	<dd><%= maketext('View details of student perofrmance either by individual or by set.') %></dd>
 	<dt><%= maketext('Scoring Tools') %></dt>
 	<dd>
-		<%= maketext('Score one or more sets. This can also be done from the "Set Manager" or from the '
+		<%= maketext('Score one or more sets. This can also be done from the "Sets Manager" or from the '
 			. '"Instructor Tools", but the "Scoring Tools" page allows control over parameters.') =%>
 	</dd>
-	<dt><%= maketext('Achievement Editor') %></dt>
+	<dt><%= maketext('Achievements Manager') %></dt>
 	<dd>
 		<%= maketext('Edit achivements for the course. This link is only present if achievements '
 			. 'are enabled for the course.') =%>

--- a/templates/HelpFiles/instructor_links.html.ep
+++ b/templates/HelpFiles/instructor_links.html.ep
@@ -37,20 +37,20 @@
 	<dt><%= maketext('Accounts Manager') %></dt>
 	<dd>
 		<%= maketext('Edit class roster data. Add students, edit student data, drop students from class, import '
-			. 'students from a classlist, and give user professor privileges. Access to individual homework sets.') =%>
+			. 'students from a classlist, and give user professor privileges. Access to individual assignments.') =%>
 	</dd>
 	<dt><%= maketext('Assigner Tool') %></dt>
 	<dd><%= maketext('Assign and unassign selected exercise sets to selected users.') %></dd>
 	<dt><%= maketext('Sets Manager') %></dt>
 	<dd>
-		<%= maketext('Edit homework sets for entire class. Change homework set due dates, create new sets from a set '
-			. 'definition file, create new homework sets, make sets visible/invisible, score homework sets. Assign '
-			. 'homework sets to the class.') =%>
+		<%= maketext('Edit sets for the entire class. Change set due dates, create new sets from a set '
+			. 'definition file, create new sets, make sets visible/invisible, score assignments. Assign '
+			. 'sets to the class.') =%>
 	</dd>
 	<dt><%= maketext('Problem Editor') %></dt>
 	<dd><%= maketext('Write a new PG problem file or edit an existing one.') %></dd>
 	<dt><%= maketext('Library Browser') %></dt>
-	<dd><%= maketext('Choose problems from a library and add them to a homework set.') %></dd>
+	<dd><%= maketext('Choose problems from a library and add them to a set.') %></dd>
 	<dt><%= maketext('Statistics') %></dt>
 	<dd><%= maketext(q{View statistics of students' performance on homework either by individual or by set.}) %></dd>
 	<dt><%= maketext('Student Progress') %></dt>


### PR DESCRIPTION
This makes more name changes discussed at #1992.
```
'Homework Sets'      => 'Assignments',
'User Settings'      => 'Account Settings',
'User Manager'       => 'Accounts Manager'
'Set Assigner'       => 'Assigner Tool',
'Set Manager'        => 'Sets Manager',
'Achievement Editor' => 'Achievements Manager'
```

It also changes the order of nav items a little, moving "Assigner Tool" (formerly "Set Assigner") higher up.

Lastly, while reviewing all the places to make name changes, I found a few vestiges of previous names that had never been changed.