### PR TITLE
improvements to Instructor Tools

### DIFF
--- a/htdocs/js/SendMail/sendmail.js
+++ b/htdocs/js/SendMail/sendmail.js
@@ -1,6 +1,6 @@
 (() => {
 	const previewUserNameSpan = document.getElementById('preview-user');
-	const classListSelect = document.getElementById('classList');
+	const classListSelect = document.getElementById('selected_users');
 	if (previewUserNameSpan && classListSelect) {
 		const setPreviewUser = () => {
 			if (classListSelect.selectedIndex !== -1)

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -493,6 +493,21 @@ ul.courses-list {
 	}
 }
 
+/* Instructor Tools page */
+#instructor-tools-nav {
+	input[name="number_of_students"] {
+		max-width: 7em;
+	}
+
+	#pills-tabContent input.btn {
+		min-width: 7em;
+	}
+
+	span.input-group-text {
+		white-space: pre;
+	}
+}
+
 /* past answers page */
 .past-answer-table {
 	td {

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -83,13 +83,6 @@ sub pre_header_initialize ($c) {
 		} else {
 			push @error, E_ONE_SET;
 		}
-	} elsif (defined $c->param('edit_sets')) {
-		if ($nsets == 1) {
-			$route = 'instructor_set_detail';
-			$args{setID} = $firstSetID;
-		} else {
-			push @error, E_ONE_SET;
-		}
 	} elsif (defined $c->param('prob_lib')) {
 		if ($nsets == 1) {
 			$route = 'instructor_set_maker';
@@ -153,10 +146,11 @@ sub pre_header_initialize ($c) {
 			$route               = 'instructor_set_detail';
 			$args{setID}         = $firstSetID;
 			$params{editForUser} = \@selectedUserIDs;
+		} elsif ($nsets == 1) {
+			$route = 'instructor_set_detail';
+			$args{setID} = $firstSetID;
 		} else {
-			push @error, E_MIN_ONE_USER unless $nusers >= 1;
-			push @error, E_ONE_SET      unless $nsets == 1;
-
+			push @error, E_ONE_SET unless $nsets == 1;
 		}
 	} elsif (defined $c->param('create_set')) {
 		my $setname = format_set_name_internal($c->param('new_set_name') // '');
@@ -174,6 +168,7 @@ sub pre_header_initialize ($c) {
 		}
 	} elsif (defined $c->param('add_users')) {
 		$route = 'instructor_add_users';
+		$params{number_of_students} = $c->param('number_of_students') // 1;
 	} elsif (defined $c->param('email_users')) {
 		$route = 'instructor_mail_merge';
 	} elsif (defined $c->param('transfer_files')) {
@@ -183,7 +178,7 @@ sub pre_header_initialize ($c) {
 	push @error, x('You are not allowed to act as a student.')
 		if (defined $c->param('act_as_user') && !$authz->hasPermissions($userID, 'become_student'));
 	push @error, x('You are not allowed to modify homework sets.')
-		if ((defined $c->param('edit_sets') || defined $c->param('edit_set_for_users'))
+		if (defined $c->param('edit_set_for_users')
 			&& !$authz->hasPermissions($userID, 'modify_problem_sets'));
 	push @error, x('You are not allowed to assign homework sets.')
 		if ((defined $c->param('sets_assigned_to_user') || defined $c->param('users_assigned_to_set'))

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -16,6 +16,8 @@
 package WeBWorK::ContentGenerator::Instructor::ProblemSetDetail;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
+use Exporter qw(import);
+
 =head1 NAME
 
 WeBWorK::ContentGenerator::Instructor::ProblemSetDetail - Edit general set and
@@ -25,6 +27,8 @@ specific user/set information as well as problem information
 
 use WeBWorK::Utils qw(cryptPassword jitar_id_to_seq seq_to_jitar_id x format_set_name_internal format_set_name_display);
 use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
+
+our @EXPORT_OK = ('FIELD_PROPERTIES');
 
 # These constants determine which fields belong to what type of record.
 use constant SET_FIELDS => [

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -16,8 +16,6 @@
 package WeBWorK::ContentGenerator::Instructor::ProblemSetDetail;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
-use Exporter qw(import);
-
 =head1 NAME
 
 WeBWorK::ContentGenerator::Instructor::ProblemSetDetail - Edit general set and
@@ -25,10 +23,12 @@ specific user/set information as well as problem information
 
 =cut
 
+use Exporter qw(import);
+
 use WeBWorK::Utils qw(cryptPassword jitar_id_to_seq seq_to_jitar_id x format_set_name_internal format_set_name_display);
 use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
 
-our @EXPORT_OK = ('FIELD_PROPERTIES');
+our @EXPORT_OK = qw(FIELD_PROPERTIES);
 
 # These constants determine which fields belong to what type of record.
 use constant SET_FIELDS => [

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -96,7 +96,7 @@ sub initialize ($c) {
 	$c->{defaultSubject}     = $c->stash('courseID') . ' notice';
 	$c->{merge_file}         = $mergefile // '';
 
-	my @classList = $c->param('classList') // ($user);
+	my @classList = $c->param('selected_users') // ($user);
 	$c->{preview_user} = $c->db->getUser($classList[0] || $user);
 
 	# Gather database data
@@ -129,7 +129,7 @@ sub initialize ($c) {
 	if ($recipients eq 'all_students') {
 		@send_to = map { $_->user_id } @Users;
 	} elsif ($recipients eq 'studentID') {
-		@send_to = $c->param('classList');
+		@send_to = $c->param('selected_users');
 	}
 
 	$c->{ra_send_to} = \@send_to;

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -25,7 +25,7 @@ WeBWorK::ContentGenerator::Instructor::ShowAnswers.pm  -- display past answers o
 use Text::CSV;
 use Mojo::File;
 
-use WeBWorK::Utils qw(sortByName jitar_id_to_seq);
+use WeBWorK::Utils qw(sortByName jitar_id_to_seq prob_id_sort);
 use WeBWorK::Utils::Rendering qw(renderPG);
 
 use constant PAST_ANSWERS_FILENAME => 'past_answers';
@@ -312,47 +312,9 @@ sub getInstructorData ($c) {
 	return (
 		users                => \@users,
 		expandedGlobalSetIDs => \@expandedGlobalSetIDs,
-		globalProblemIDs     => [ sort prob_id_sort keys %all_problems ],
+		globalProblemIDs     => [ prob_id_sort keys %all_problems ],
 		filename             => PAST_ANSWERS_FILENAME . '.csv'
 	);
-}
-
-sub byData {
-	my ($A, $B) = ($a, $b);
-	$A =~ s/\|[01]*\t([^\t]+)\t.*/|$1/;    # remove answers and correct/incorrect status
-	$B =~ s/\|[01]*\t([^\t]+)\t.*/|$1/;
-	return $A cmp $B;
-}
-
-# Sorts problem ID's so that all just-in-time like ids are at the bottom
-# of the list in order and other problems
-sub prob_id_sort {
-
-	my @seqa = split(/\./, $a);
-	my @seqb = split(/\./, $b);
-
-	# go through problem number sequence
-	for (my $i = 0; $i <= $#seqa; $i++) {
-		# if at some point two numbers are different return the comparison.
-		# e.g. 2.1.3 vs 1.2.6
-		if ($seqa[$i] != $seqb[$i]) {
-			return $seqa[$i] <=> $seqb[$i];
-		}
-
-		# if all of the values are equal but b is shorter then it comes first
-		# i.e. 2.1.3 vs 2.1
-		if ($i == $#seqb) {
-			return 1;
-		}
-	}
-
-	# if all of the values are equal and a and b are the same length then equal
-	# otherwise a was shorter than b so a comes first.
-	if ($#seqa == $#seqb) {
-		return 0;
-	} else {
-		return -1;
-	}
 }
 
 1;

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -56,6 +56,14 @@ sub scrollingRecordList ($options, @records) {
 
 		$sorts   = getSortsForClass($class, $options{default_sort});
 		$formats = getFormatsForClass($class, $options{default_format});
+		# Remove sorts that are irrelevant for our formats
+		my @format_keywords;
+		for my $format (@$formats) {
+			push(@format_keywords, (split /\W+/, $format->[0]));
+		}
+		my $format_keywords = join('|', @format_keywords);
+		@$sorts = grep { $_->[0] =~ /$format_keywords/ } @$sorts;
+
 		$filters = getFiltersForClass(@records);
 
 		my @selected_filters;

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -75,6 +75,7 @@ sub scrollingRecordList ($options, @records) {
 		}
 
 		$formattedRecords = formatRecords(
+			$c,
 			$c->param("$name!format") || $options{default_format},
 			sortRecords(
 				$c->param("$name!sort") || $options{default_sort} || (@$sorts ? $sorts->[0][1] : ''),

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -79,7 +79,7 @@ sub scrollingRecordList ($options, @records) {
 			$c->param("$name!format") || $options{default_format},
 			sortRecords(
 				$c->param("$name!sort") || $options{default_sort} || (@$sorts ? $sorts->[0][1] : ''),
-				filterRecords($c, \@selected_filters, @records)
+				filterRecords($c, $c->param("$name!filter_combine") // 'intersect', \@selected_filters, @records)
 			)
 		);
 	}

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -64,7 +64,7 @@ sub scrollingRecordList ($options, @records) {
 		my $format_keywords = join('|', @format_keywords);
 		@$sorts = grep { $_->[0] =~ /$format_keywords/ } @$sorts;
 
-		$filters = getFiltersForClass(@records);
+		$filters = getFiltersForClass($c, @records);
 
 		my @selected_filters;
 		if (defined $c->param("$name!filter")) {
@@ -79,7 +79,7 @@ sub scrollingRecordList ($options, @records) {
 			$c->param("$name!format") || $options{default_format},
 			sortRecords(
 				$c->param("$name!sort") || $options{default_sort} || (@$sorts ? $sorts->[0][1] : ''),
-				filterRecords(\@selected_filters, @records)
+				filterRecords($c, \@selected_filters, @records)
 			)
 		);
 	}

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -79,7 +79,7 @@ sub scrollingRecordList ($options, @records) {
 			$c->param("$name!format") || $options{default_format},
 			sortRecords(
 				$c->param("$name!sort") || $options{default_sort} || (@$sorts ? $sorts->[0][1] : ''),
-				filterRecords($c, $c->param("$name!filter_combine") // 'intersect', \@selected_filters, @records)
+				filterRecords($c, $c->param("$name!filter_combine") // 0, \@selected_filters, @records)
 			)
 		);
 	}

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -96,6 +96,7 @@ our @EXPORT_OK = qw(
 	runtime_use
 	sortAchievements
 	sortByName
+	prob_id_sort
 	surePathToFile
 	textDateTime
 	timeToSec
@@ -1254,6 +1255,43 @@ sub sortAchievements {
 
 	return @Achievements;
 
+}
+
+################################################################################
+# Sorts problem ID's so that all just-in-time like ids are at the bottom
+# of the list in order and other problems
+################################################################################
+sub prob_id_sort_comparator {
+
+	my @seqa = split(/\./, $a);
+	my @seqb = split(/\./, $b);
+
+	# go through problem number sequence
+	for (my $i = 0; $i <= $#seqa; $i++) {
+		# if at some point two numbers are different return the comparison.
+		# e.g. 2.1.3 vs 1.2.6
+		if ($seqa[$i] != $seqb[$i]) {
+			return $seqa[$i] <=> $seqb[$i];
+		}
+
+		# if all of the values are equal but b is shorter then it comes first
+		# i.e. 2.1.3 vs 2.1
+		if ($i == $#seqb) {
+			return 1;
+		}
+	}
+
+	# if all of the values are equal and a and b are the same length then equal
+	# otherwise a was shorter than b so a comes first.
+	if ($#seqa == $#seqb) {
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+sub prob_id_sort {
+	return sort prob_id_sort_comparator @_;
 }
 
 ################################################################################

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -96,7 +96,6 @@ our @EXPORT_OK = qw(
 	runtime_use
 	sortAchievements
 	sortByName
-	prob_id_sort
 	surePathToFile
 	textDateTime
 	timeToSec
@@ -121,6 +120,7 @@ our @EXPORT_OK = qw(
 	is_jitar_problem_closed
 	jitar_problem_adjusted_status
 	jitar_problem_finished
+	prob_id_sort
 	role_and_above
 	fetchEmailRecipients
 	processEmailMessage
@@ -1258,43 +1258,6 @@ sub sortAchievements {
 }
 
 ################################################################################
-# Sorts problem ID's so that all just-in-time like ids are at the bottom
-# of the list in order and other problems
-################################################################################
-sub prob_id_sort_comparator {
-
-	my @seqa = split(/\./, $a);
-	my @seqb = split(/\./, $b);
-
-	# go through problem number sequence
-	for (my $i = 0; $i <= $#seqa; $i++) {
-		# if at some point two numbers are different return the comparison.
-		# e.g. 2.1.3 vs 1.2.6
-		if ($seqa[$i] != $seqb[$i]) {
-			return $seqa[$i] <=> $seqb[$i];
-		}
-
-		# if all of the values are equal but b is shorter then it comes first
-		# i.e. 2.1.3 vs 2.1
-		if ($i == $#seqb) {
-			return 1;
-		}
-	}
-
-	# if all of the values are equal and a and b are the same length then equal
-	# otherwise a was shorter than b so a comes first.
-	if ($#seqa == $#seqb) {
-		return 0;
-	} else {
-		return -1;
-	}
-}
-
-sub prob_id_sort {
-	return sort prob_id_sort_comparator @_;
-}
-
-################################################################################
 # Validate strings and labels
 ################################################################################
 
@@ -1885,6 +1848,42 @@ ID: foreach my $id (@problemIDs) {
 
 	# if we got here then the problem is finished
 	return 1;
+}
+
+# Sorts problem ID's so that all just-in-time like ids are at the bottom
+# of the list in order and other problems
+
+sub prob_id_sort_comparator {
+
+	my @seqa = split(/\./, $a);
+	my @seqb = split(/\./, $b);
+
+	# go through problem number sequence
+	for (my $i = 0; $i <= $#seqa; $i++) {
+		# if at some point two numbers are different return the comparison.
+		# e.g. 2.1.3 vs 1.2.6
+		if ($seqa[$i] != $seqb[$i]) {
+			return $seqa[$i] <=> $seqb[$i];
+		}
+
+		# if all of the values are equal but b is shorter then it comes first
+		# i.e. 2.1.3 vs 2.1
+		if ($i == $#seqb) {
+			return 1;
+		}
+	}
+
+	# if all of the values are equal and a and b are the same length then equal
+	# otherwise a was shorter than b so a comes first.
+	if ($#seqa == $#seqb) {
+		return 0;
+	} else {
+		return -1;
+	}
+}
+
+sub prob_id_sort {
+	return sort prob_id_sort_comparator @_;
 }
 
 # Get the array of all permission levels at or above a given level

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -148,11 +148,12 @@ sub getFiltersForClass {
 	return \@filters;
 }
 
-=item filterRecords($c, $filter_combine, $filters, @records)
+=item filterRecords($c, $intersect, $filters, @records)
 
 Given a list of filters and a list of records, returns a list of the records
-after the selected filters are applied. C<$filter_combine> should be 'union'
-or 'intersect'.
+after the selected filters are applied. If C<$intersect> is true then the
+intersection of the records that match the filters is returned.  Otherwise the
+union of the records that match the filters is returned.
 
 C<$filters> should be a reference to an array of filters or be undefined.
 
@@ -161,7 +162,7 @@ C<$filters> should be a reference to an array of filters or be undefined.
 =cut
 
 sub filterRecords {
-	my ($c, $filter_combine, $filters, @records) = @_;
+	my ($c, $intersect, $filters, @records) = @_;
 
 	return unless @records;
 
@@ -180,7 +181,6 @@ sub filterRecords {
 			$c->db->getPermissionLevelsWhere({ user_id => { not_like => 'set_id:%' } }))
 		: ();
 
-	my $intersect       = ($filter_combine eq 'intersect');
 	my @filteredRecords = $intersect ? @records : ();
 	if ($intersect) {
 		for my $filter (@filtersToUse) {

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -113,7 +113,7 @@ sub getFiltersForClass {
 			for my $role (sortByName(undef, keys %roles)) {
 				my @statuses = keys %{ $c->ce->{statuses} };
 				for (@statuses) {
-					push @filters, [ "Role: $_" => "status:$role" ] if ($c->ce->{statuses}{$_}{abbrevs}[0] eq $role);
+					push @filters, [ "Enrollment Status: $_" => "status:$role" ] if ($c->ce->{statuses}{$_}{abbrevs}[0] eq $role);
 				}
 			}
 		}

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -51,7 +51,7 @@ use warnings;
 use Carp;
 
 use WeBWorK::Utils qw(sortByName);
-use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw/FIELD_PROPERTIES/;
+use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw(FIELD_PROPERTIES);
 
 our @EXPORT_OK = qw(
 	getFiltersForClass
@@ -118,7 +118,7 @@ sub getFiltersForClass {
 
 		if (keys %visibles > 1) {
 			for my $vis (sortByName(undef, keys %visibles)) {
-				push @filters, [ ($vis ? 'Visible' : "Not Visible") => "visible:$vis" ];
+				push @filters, [ ($vis ? 'Visible' : 'Not Visible') => "visible:$vis" ];
 			}
 		}
 	}

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -113,7 +113,8 @@ sub getFiltersForClass {
 			for my $role (sortByName(undef, keys %roles)) {
 				my @statuses = keys %{ $c->ce->{statuses} };
 				for (@statuses) {
-					push @filters, [ "Enrollment Status: $_" => "status:$role" ] if ($c->ce->{statuses}{$_}{abbrevs}[0] eq $role);
+					push @filters, [ "Enrollment Status: $_" => "status:$role" ]
+						if ($c->ce->{statuses}{$_}{abbrevs}[0] eq $role);
 				}
 			}
 		}

--- a/lib/WeBWorK/Utils/FormatRecords.pm
+++ b/lib/WeBWorK/Utils/FormatRecords.pm
@@ -55,7 +55,8 @@ use warnings;
 
 use Carp;
 
-use WeBWorK::Utils qw/format_set_name_display/;
+use WeBWorK::Utils qw/format_set_name_display formatDateTime/;
+use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw/FIELD_PROPERTIES/;
 
 our @EXPORT_OK = qw(
 	getFormatsForClass
@@ -65,23 +66,9 @@ our @EXPORT_OK = qw(
 use constant PRESET_FORMATS => {
 	'WeBWorK::DB::Record::User' => [
 		[
-			'uid_lnfn' => {
-				name          => 'user_id - last_name, first_name',
-				field_order   => [qw/user_id last_name first_name/],
-				format_string => '%s - %s, %s',
-			}
-		],
-		[
-			'lnfn_uid' => {
-				name          => 'last_name, first_name (user_id)',
-				field_order   => [qw/last_name first_name user_id/],
-				format_string => '%s, %s (%s)',
-			}
-		],
-		[
-			'lnfn_section' => {
-				name          => 'last_name, first_name (section)',
-				field_order   => [qw/last_name first_name section/],
+			'lnfn_email' => {
+				name          => 'last_name, first_name (email_address)',
+				field_order   => [qw/last_name first_name email_address/],
 				format_string => '%s, %s (%s)',
 			}
 		],
@@ -93,6 +80,13 @@ use constant PRESET_FORMATS => {
 			}
 		],
 		[
+			'lnfn_section' => {
+				name          => 'last_name, first_name (section)',
+				field_order   => [qw/last_name first_name section/],
+				format_string => '%s, %s (%s)',
+			}
+		],
+		[
 			'lnfn_secrec' => {
 				name          => 'last_name, first_name (section/recitation)',
 				field_order   => [qw/last_name first_name section recitation/],
@@ -100,14 +94,42 @@ use constant PRESET_FORMATS => {
 			}
 		],
 		[
-			'lnfn_email' => {
-				name          => 'last_name, first_name (email_address)',
-				field_order   => [qw/last_name first_name email_address/],
+			'lnfn_uid' => {
+				name          => 'last_name, first_name (user_id)',
+				field_order   => [qw/last_name first_name user_id/],
 				format_string => '%s, %s (%s)',
+			}
+		],
+		[
+			'uid_lnfn' => {
+				name          => 'user_id - last_name, first_name',
+				field_order   => [qw/user_id last_name first_name/],
+				format_string => '%s - %s, %s',
 			}
 		],
 	],
 	'WeBWorK::DB::Record::Set' => [
+		[
+			'type_sid_due' => {
+				name            => 'assignment_type: set_id, due_date',
+				field_order     => [qw/assignment_type set_id due_date/],
+				format_function => sub {
+					join('',
+						FIELD_PROPERTIES()->{assignment_type}{labels}{ $_[0] },
+						': ', format_set_name_display($_[1]),
+						', ', formatDateTime($_[2]));
+				}
+			}
+		],
+		[
+			'due_sid' => {
+				name            => 'due_date: set_id',
+				field_order     => [qw/due_date set_id/],
+				format_function => sub {
+					join('', formatDateTime($_[0]), ': ', format_set_name_display($_[1]));
+				}
+			}
+		],
 		[
 			'sid' => {
 				name            => 'set_id',

--- a/lib/WeBWorK/Utils/SortRecords.pm
+++ b/lib/WeBWorK/Utils/SortRecords.pm
@@ -57,7 +57,7 @@ use constant PRESET_SORTS => {
 	'WeBWorK::DB::Record::User' => [
 		[
 			'lnfn' => {
-				name   => 'last name, first name',
+				name   => 'last_name, first_name',
 				fields => [qw/last_name first_name/],
 			}
 		],
@@ -89,9 +89,9 @@ sub getSortsForClass {
 
 	my @class_presets = exists PRESET_SORTS->{$class} ? @{ PRESET_SORTS->{$class} } : ();
 
-	my @fields  = map { [ "Field: $_" => $_, $_ eq $default_sort ? (selected => undef) : () ] } $class->FIELDS;
-	my @presets = map { [ "Preset: $_->[1]{name}" => $_->[0], $_->[0] eq $default_sort ? (selected => undef) : () ] }
-		@class_presets;
+	my @fields = map { [ $_ => $_, $_ eq $default_sort ? (selected => undef) : () ] } $class->FIELDS;
+	my @presets =
+		map { [ $_->[1]{name} => $_->[0], $_->[0] eq $default_sort ? (selected => undef) : () ] } @class_presets;
 
 	return [ @fields, @presets ];
 }

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -62,7 +62,7 @@
 	<div class="row">
 		% # TODO: When bootstrap is upgraded to 5.3 switch the "column-gap" style to the "column-gap-3" class.
 		<div class="col-xl-10 col-md-12 d-flex justify-content-around flex-wrap" style="column-gap:1rem">
-			<div style="min-width:350px">
+			<div style="min-width:370px">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
@@ -80,7 +80,7 @@
 						formaction => $c->systemLink(url_for 'instructor_user_list'),
 						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
 					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-						<%== maketext('account data for <b>all selected</b> users') =%>\
+						<%== maketext('account data for <b>selected</b> users') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
@@ -102,6 +102,15 @@
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Email'),
+						name  => 'email_users',
+						class => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('<strong>selected</strong> users') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary w-25' =%>
 					<%= number_field number_of_students => 1, min => 1, max => 100,
 						class => 'form-control form-control-sm text-center' =%>
@@ -110,7 +119,7 @@
 					</span>
 				</div>
 			</div>
-			<div style="min-width:350px">
+			<div style="min-width:370px">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Assign'),
@@ -126,7 +135,7 @@
 							error_sets   => maketext($E_MIN_ONE_SET)
 						} =%>
 					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-						<%== maketext('<strong>all selected</strong> users to <strong>all selected</strong> sets') =%>\
+						<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
@@ -156,17 +165,34 @@
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name       => 'show_answers',
+						class      => 'btn btn-sm btn-secondary w-25' =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('answers for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Generate'),
+						name       => 'hardcopy',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'hardcopy') =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('PDF for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Score'),
 						name       => 'score_sets',
 						class      => 'btn btn-sm btn-secondary w-25',
 						formaction => $c->systemLink(url_for 'instructor_scoring'),
 						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
 					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-						<%== maketext('<strong>all selected</strong> sets for <strong>all</strong> users') =%>\
+						<%== maketext('<strong>selected</strong> sets for <strong>all</strong> users') =%>\
 					</span>
 				</div>
 			</div>
-			<div style="min-width:350px">
+			<div style="min-width:370px">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -16,7 +16,7 @@
 			. 'or select a tool from the list to the left.'
 	) =%>
 	<br>
-	<%= maketext('Select user(s) and/or set(s) below and click the action button of your choice.') =%>
+	<%= maketext('Select user(s) and/or sets(s) below and click the action button of your choice.') =%>
 </p>
 %
 <%= form_for current_route, method => 'POST', id => 'instructor-tools-form', begin =%>
@@ -60,132 +60,73 @@
 		</div>
 	</div>
 	<div class="row gx-3">
-		<div class="col-xl-5 col-md-6 mb-2">
+		<div class="col-xl-3 col-md-6">
+			<hr class="divider pb-1 bg-dark my-2">
 			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View/Edit'),
+				<%= submit_button maketext('Edit'),
 					name  => 'sets_assigned_to_user',
-					class => 'btn btn-sm btn-secondary',
+					class => 'btn btn-sm btn-secondary col-3',
 					data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('all set dates for one <b>user</b>') =%>\
+					<%== maketext('Assignments and Dates') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> user') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
 				<%= submit_button maketext('Edit'),
 					name       => 'edit_users',
-					class      => 'btn btn-sm btn-secondary',
+					class      => 'btn btn-sm btn-secondary col-3',
 					formaction => $c->systemLink(url_for 'instructor_user_list'),
 					data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('class list data for selected <b>users</b>') =%>\
+					<%== maketext('Account Data') =%>\
 				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Statistics'),
-					name  => 'user_stats',
-					class => 'btn btn-sm btn-secondary',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text"><%= maketext('or') %></span>
-				<%= submit_button maketext('progress'),
-					name  => 'user_progress',
-					class => 'btn btn-sm btn-secondary',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for one <b>user</b>') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Change Password'),
-					name  => 'user_options',
-					class => 'btn btn-sm btn-secondary',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for one <b>user</b>') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary' =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%= maketext('new users') =%>\
-				</span>
-			</div>
-		</div>
-		<div class="col-xl-5 col-md-6 mb-2 font-sm">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View/Edit'),
-					name  => 'users_assigned_to_set',
-					class => 'btn btn-sm btn-secondary',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('all users for one <b>set</b>') =%>
+					<%== maketext('for <b>all selected</b> users') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
 				<%= submit_button maketext('Edit'),
-					name  => 'edit_sets',
-					class => 'btn btn-sm btn-secondary',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text" style="white-space:pre;"><%== maketext('one <b>set</b>') =%></span>
-				<span class="input-group-text"><%= maketext('or') %></span>
-				<%= submit_button maketext('add problems'),
-					name  => 'prob_lib',
-					class => 'btn btn-sm btn-secondary',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					name  => 'user_options',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('to one <b>set</b>') =%>\
+					<%== maketext('Account Settings') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> user') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Statistics'),
-					name  => 'set_stats',
-					class => 'btn btn-sm btn-secondary',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text"><%= maketext('or') %></span>
-				<%= submit_button maketext('progress'),
-					name  => 'set_progress',
-					class => 'btn btn-sm btn-secondary',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+				<%= submit_button maketext('View'),
+					name  => 'user_progress',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for one <b>set</b>') =%>\
+					<%== maketext('Progress') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> user') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Score'),
-					name       => 'score_sets',
-					class      => 'btn btn-sm btn-secondary',
-					formaction => $c->systemLink(url_for 'instructor_scoring'),
-					data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+				<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-3' =%>
+				%= number_field number_of_students => 1, min => 1, max => 100, class => 'col-2 flex-grow-1 text-center'
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('selected <b>sets</b>') =%>\
+					<%== maketext('new user accounts') =%>\
 				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Create'),
-					name  => 'create_set',
-					class => 'btn btn-sm btn-secondary',
-					data  => {
-						set_name_needed        => 'true',
-						error_set_name         => maketext($E_SET_NAME),
-						error_invalid_set_name => maketext($E_BAD_NAME)
-				   	} =%>
-				<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
-				<%= text_field new_set_name => '',
-					id          => 'new_set_name',
-					placeholder => maketext('Name for new set here'),
-					size        => 20,
-					class       => 'form-control form-control-sm',
-					dir         => 'ltr' =%>
 			</div>
 		</div>
-	</div>
-	<div class="row gx-3">
-		<div class="col-xl-4 col-md-6 offset-md-3">
+		<div class="col-xl-4 col-md-6">
+			<hr class="divider pb-1 bg-dark my-2">
 			<div class="input-group input-group-sm mb-2">
 				<%= submit_button maketext('Assign'),
 					# This name is the same as the name of the submit button in Assigner.pm and the form is
 					# directly submitted to that module without modification.
 					name       => 'assign',
-					class      => 'btn btn-sm btn-secondary',
+					class      => 'btn btn-sm btn-secondary col-2',
 					formaction => $c->systemLink(url_for 'instructor_set_assigner'),
 					data => {
 						users_needed => 'at least one',
@@ -194,13 +135,16 @@
 						error_sets   => maketext($E_MIN_ONE_SET)
 					} =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('selected <b>users</b> to selected <b>sets</b>') =%>\
+					<%== maketext('<strong>all selected</strong> users') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('to <strong>all selected</strong> sets') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Act as'),
+				<%= submit_button maketext('Act'),
 					name  => 'act_as_user',
-					class => 'btn btn-sm btn-secondary',
+					class => 'btn btn-sm btn-secondary col-2',
 					data  => {
 						users_needed => 'exactly one',
 						error_users  => maketext($E_ONE_USER),
@@ -208,38 +152,108 @@
 						error_sets   => maketext($E_MAX_ONE_SET)
 					} =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('one <b>user</b> (on one <b>set</b>)') =%>\
+					<%== maketext('as <strong>one</strong> user') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('on <strong>up to one</strong> set') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
 				<%= submit_button maketext('Edit'),
 					name  => 'edit_set_for_users',
-					class => 'btn btn-sm btn-secondary',
+					class => 'btn btn-sm btn-secondary col-2',
 					data  => {
-						users_needed => 'at least one',
-						error_users  => maketext($E_MIN_ONE_USER),
 						sets_needed  => 'exactly one',
 						error_sets   => maketext($E_ONE_SET)
 					} =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('one <b>set</b> for <b>users</b>') =%>\
+					<%== maketext('Set Detail for <strong>one</strong> set') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>zero or more</strong> users') =%>\
 				</span>
 			</div>
 			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Email'), name => 'email_users', class => 'btn btn-sm btn-secondary' =%>
+				<%= submit_button maketext('Score'),
+					name       => 'score_sets',
+					class      => 'btn btn-sm btn-secondary col-2',
+					formaction => $c->systemLink(url_for 'instructor_scoring'),
+					data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
 				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%= maketext('your students') =%>\
+					<%== maketext('<strong>all selected</strong> sets') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext(' for <strong>all</strong> users') =%>\
 				</span>
 			</div>
-			% if ($authz->hasPermissions(param('user'), 'manage_course_files')) {
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Transfer'), name => 'transfer_files',
-						class => 'btn btn-sm btn-secondary' =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-						<%= maketext('course files') =%>\
-					</span>
-				</div>
-			% }
+		</div>
+		<div class="col-xl-3 col-md-6 font-sm">
+			<hr class="divider pb-1 bg-dark my-2">
+			<div class="input-group input-group-sm mb-2">
+				<%= submit_button maketext('Edit'),
+					name  => 'users_assigned_to_set',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('Assigned Users') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> set') =%>\
+				</span>
+			</div>
+			<div class="input-group input-group-sm mb-2">
+				<%= submit_button maketext('Add'),
+					name  => 'prob_lib',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('Library Browser Exercises') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('to <strong>one</strong> set') =%>\
+				</span>
+			</div>
+			<div class="input-group input-group-sm mb-2">
+				<%= submit_button maketext('View'),
+					name  => 'set_stats',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('Statistics') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> set') =%>\
+				</span>
+			</div>
+			<div class="input-group input-group-sm mb-2">
+				<%= submit_button maketext('View'),
+					name  => 'set_progress',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('Progress') =%>\
+				</span>
+				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<%== maketext('for <strong>one</strong> set') =%>\
+				</span>
+			</div>
+			<div class="input-group input-group-sm mb-2">
+				<%= submit_button maketext('Create'),
+					name  => 'create_set',
+					class => 'btn btn-sm btn-secondary col-3',
+					data  => {
+						set_name_needed        => 'true',
+						error_set_name         => maketext($E_SET_NAME),
+						error_invalid_set_name => maketext($E_BAD_NAME)
+					} =%>
+				<%= label_for new_set_name => maketext('New Set:'), class => 'input-group-text' =%>
+				<%= text_field new_set_name => '',
+					id          => 'new_set_name',
+					placeholder => maketext('Name for new set here'),
+					size        => 20,
+					class       => 'form-control form-control-sm',
+					dir         => 'ltr' =%>
+			</div>
 		</div>
 	</div>
 <% end =%>

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -59,74 +59,116 @@
 			) =%>
 		</div>
 	</div>
-	<div class="row">
-		% # TODO: When bootstrap is upgraded to 5.3 switch the "column-gap" style to the "column-gap-3" class.
-		<div class="col-xl-10 col-md-12 d-flex justify-content-around flex-wrap" style="column-gap:1rem">
-			<div style="min-width:28em">
-				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+
+	<div id="instructor-tools-nav" class="col-10">
+		<ul class="nav nav-pills nav-justified mb-3" id="pills-tab" role="tablist">
+			<li class="nav-item" role="presentation">
+				<button
+					class="nav-link active border rounded-pill"
+					id="pills-user-actions-tab"
+					data-bs-toggle="pill"
+					data-bs-target="#user-actions"
+					type="button"
+					"role="tab"
+					aria-controls="pills-user-actions"
+					aria-selected="true">\
+					<%== maketext('User Actions') =%>\
+				</button>
+			</li>
+			<li class="nav-item" role="presentation">
+				<button
+					class="nav-link border rounded-pill"
+					id="pills-user-set-actions-tab"
+					data-bs-toggle="pill"
+					data-bs-target="#user-set-actions"
+					type="button"
+					"role="tab"
+					aria-controls="pills-user-set-actions"
+					aria-selected="false">\
+					<%== maketext('User-Set Actions') =%>\
+				</button>
+			</li>
+			<li class="nav-item" role="presentation">
+				<button
+					class="nav-link border rounded-pill"
+					id="pills-set-actions-tab"
+					data-bs-toggle="pill"
+					data-bs-target="#set-actions"
+					type="button"
+					"role="tab"
+					aria-controls="pills-set-actions"
+					aria-selected="false">\
+					<%== maketext('Set Actions') =%>\
+				</button>
+			</li>
+		</ul>
+
+		<div class="tab-content row" id="pills-tabContent">
+			<div id="user-actions" class="tab-pane fade show active col-6" role="tabpanel"
+				aria-labelledby="pills-user-actions-tab" tabindex="0" >
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'sets_assigned_to_user',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name       => 'edit_users',
-						class      => 'btn btn-sm btn-secondary w-25',
+						class      => 'btn btn-sm btn-secondary col-2',
 						formaction => $c->systemLink(url_for 'instructor_user_list'),
 						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('account data for <b>selected</b> users') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'user_options',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('account settings for <strong>one</strong> user') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('View'),
 						name  => 'user_progress',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('progress for <strong>one</strong> user') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Email'),
 						name  => 'email_users',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('<strong>selected</strong> users') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary w-25' =%>
+					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-2' =%>
 					<%= number_field number_of_students => 1, min => 1, max => 100,
 						class => 'form-control form-control-sm text-center' =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('new user accounts') =%>\
 					</span>
 				</div>
 			</div>
-			<div style="min-width:28em">
-				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+			<div class="tab-pane fade show offset-md-3 col-6" id="user-set-actions" role="tabpanel"
+				aria-labelledby="pills-user-set-actions-tab" tabindex="0">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Assign'),
 						# This name is the same as the name of the submit button in Assigner.pm and the form is
 						# directly submitted to that module without modification.
 						name       => 'assign',
-						class      => 'btn btn-sm btn-secondary w-25',
+						class      => 'btn btn-sm btn-secondary col-2',
 						formaction => $c->systemLink(url_for 'instructor_set_assigner'),
 						data => {
 							users_needed => 'at least one',
@@ -134,106 +176,106 @@
 							sets_needed  => 'at least one',
 							error_sets   => maketext($E_MIN_ONE_SET)
 						} =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Act'),
 						name  => 'act_as_user',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => {
 							users_needed => 'exactly one',
 							error_users  => maketext($E_ONE_USER),
 							sets_needed  => 'at most one',
 							error_sets   => maketext($E_MAX_ONE_SET)
 						} =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('as <strong>one</strong> user on <strong>up to one</strong> set') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'edit_set_for_users',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => {
 							sets_needed  => 'exactly one',
 							error_sets   => maketext($E_ONE_SET)
 						} =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users}) =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('View'),
 						name       => 'show_answers',
-						class      => 'btn btn-sm btn-secondary w-25' =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						class      => 'btn btn-sm btn-secondary col-2' =%>
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('answers for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Generate'),
 						name       => 'hardcopy',
-						class      => 'btn btn-sm btn-secondary w-25',
+						class      => 'btn btn-sm btn-secondary col-2',
 						formaction => $c->systemLink(url_for 'hardcopy') =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('PDF for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Score'),
-						name       => 'score_sets',
-						class      => 'btn btn-sm btn-secondary w-25',
-						formaction => $c->systemLink(url_for 'instructor_scoring'),
-						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-						<%== maketext('<strong>selected</strong> sets for <strong>all</strong> users') =%>\
-					</span>
-				</div>
 			</div>
-			<div style="min-width:28em">
-				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+			<div class="tab-pane fade show row offset-md-6 col-6" id="set-actions" role="tabpanel"
+				aria-labelledby="pills-set-actions-tab" tabindex="0">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'users_assigned_to_set',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('assigned users for <strong>one</strong> set') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Add'),
 						name  => 'prob_lib',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('problems to <strong>one</strong> set') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('View'),
 						name  => 'set_stats',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('statistics for <strong>one</strong> set') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('View'),
 						name  => 'set_progress',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+					<span class="input-group-text flex-grow-1">\
 						<%== maketext('progress for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Score'),
+						name       => 'score_sets',
+						class      => 'btn btn-sm btn-secondary col-2',
+						formaction => $c->systemLink(url_for 'instructor_scoring'),
+						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1">\
+						<%== maketext('<strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Create'),
 						name  => 'create_set',
-						class => 'btn btn-sm btn-secondary w-25',
+						class => 'btn btn-sm btn-secondary col-2',
 						data  => {
 							set_name_needed        => 'true',
 							error_set_name         => maketext($E_SET_NAME),

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -37,7 +37,7 @@
 				@$users
 			) =%>
 		</div>
-		<div class="col-xl-5 col-md-6 mb-2">
+		<div class="col-xl-5 col-md-6 mb-3">
 			<div class="fw-bold text-center"><%= label_for selected_sets => maketext('Sets') %></div>
 			<%= scrollingRecordList(
 				{
@@ -56,235 +56,240 @@
 			) =%>
 		</div>
 	</div>
+	%
+	<div class="row">
+		<div id="instructor-tools-nav" class="col-xl-10 col-md-12">
+			<ul class="nav nav-pills nav-justified mb-3" id="pills-tab" role="tablist">
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link active border rounded-pill"
+						id="pills-user-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#user-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-user-actions"
+						aria-selected="true">\
+						<%== maketext('User Actions') =%>\
+					</button>
+				</li>
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link border rounded-pill"
+						id="pills-user-set-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#user-set-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-user-set-actions"
+						aria-selected="false">\
+						<%== maketext('User-Set Actions') =%>\
+					</button>
+				</li>
+				<li class="nav-item mx-1" role="presentation">
+					<button
+						class="nav-link border rounded-pill"
+						id="pills-set-actions-tab"
+						data-bs-toggle="pill"
+						data-bs-target="#set-actions"
+						type="button"
+						role="tab"
+						aria-controls="pills-set-actions"
+						aria-selected="false">\
+						<%== maketext('Set Actions') =%>\
+					</button>
+				</li>
+			</ul>
 
-	<div id="instructor-tools-nav" class="col-10">
-		<ul class="nav nav-pills nav-justified mb-3" id="pills-tab" role="tablist">
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link active border rounded-pill"
-					id="pills-user-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#user-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-user-actions"
-					aria-selected="true">\
-					<%== maketext('User Actions') =%>\
-				</button>
-			</li>
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link border rounded-pill"
-					id="pills-user-set-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#user-set-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-user-set-actions"
-					aria-selected="false">\
-					<%== maketext('User-Set Actions') =%>\
-				</button>
-			</li>
-			<li class="nav-item" role="presentation">
-				<button
-					class="nav-link border rounded-pill"
-					id="pills-set-actions-tab"
-					data-bs-toggle="pill"
-					data-bs-target="#set-actions"
-					type="button"
-					role="tab"
-					aria-controls="pills-set-actions"
-					aria-selected="false">\
-					<%== maketext('Set Actions') =%>\
-				</button>
-			</li>
-		</ul>
-
-		<div class="tab-content row" id="pills-tabContent">
-			<div id="user-actions" class="tab-pane fade show active col-6" role="tabpanel"
-				aria-labelledby="pills-user-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'sets_assigned_to_user',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
-					</span>
+			<div class="tab-content row" id="pills-tabContent">
+				<div class="tab-pane fade show active col-lg-6 col-sm-8" id="user-actions" role="tabpanel"
+					aria-labelledby="pills-user-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'sets_assigned_to_user',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name       => 'edit_users',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_user_list'),
+							data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('account data for <b>selected</b> users') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'user_options',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('account settings for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'user_progress',
+							class => 'btn btn-sm btn-secondary',
+							data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('progress for <strong>one</strong> user') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Email'),
+							name  => 'email_users',
+							class => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> users') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Add'), name => 'add_users',
+							class => 'btn btn-sm btn-secondary' =%>
+						<%= number_field number_of_students => 1, min => 1, max => 100,
+							class => 'form-control form-control-sm text-center' =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('new user accounts') =%>\
+						</span>
+					</div>
 				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name       => 'edit_users',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_user_list'),
-						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('account data for <b>selected</b> users') =%>\
-					</span>
+				<div class="tab-pane fade show offset-xxl-3 offset-lg-2 offset-sm-1 col-xxl-6 col-lg-8 col-sm-10"
+					id="user-set-actions" role="tabpanel" aria-labelledby="pills-user-set-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Assign'),
+							# This name is the same as the name of the submit button in Assigner.pm and the form is
+							# directly submitted to that module without modification.
+							name       => 'assign',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_set_assigner'),
+							data => {
+								users_needed => 'at least one',
+								error_users  => maketext($E_MIN_ONE_USER),
+								sets_needed  => 'at least one',
+								error_sets   => maketext($E_MIN_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Act'),
+							name  => 'act_as_user',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								users_needed => 'exactly one',
+								error_users  => maketext($E_ONE_USER),
+								sets_needed  => 'at most one',
+								error_sets   => maketext($E_MAX_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('as <strong>one</strong> user on <strong>up to one</strong> set')
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'edit_set_for_users',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								sets_needed  => 'exactly one',
+								error_sets   => maketext($E_ONE_SET)
+							} =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users})
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name       => 'show_answers',
+							class      => 'btn btn-sm btn-secondary' =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('answer log for <strong>selected</strong> users, '
+								. 'for <strong>selected</strong> sets')
+						=%></span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Generate'),
+							name       => 'hardcopy',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'hardcopy') =%>
+						<span class="input-group-text flex-grow-1"><%==
+							maketext('PDF hardcopy for <strong>selected</strong> users, '
+								. 'for <strong>selected</strong> sets')
+						=%></span>
+					</div>
 				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'user_options',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('account settings for <strong>one</strong> user') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'user_progress',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('progress for <strong>one</strong> user') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Email'),
-						name  => 'email_users',
-						class => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_mail_merge') =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> users') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-2' =%>
-					<%= number_field number_of_students => 1, min => 1, max => 100,
-						class => 'form-control form-control-sm text-center' =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('new user accounts') =%>\
-					</span>
-				</div>
-			</div>
-			<div class="tab-pane fade show offset-md-3 col-6" id="user-set-actions" role="tabpanel"
-				aria-labelledby="pills-user-set-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Assign'),
-						# This name is the same as the name of the submit button in Assigner.pm and the form is
-						# directly submitted to that module without modification.
-						name       => 'assign',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_set_assigner'),
-						data => {
-							users_needed => 'at least one',
-							error_users  => maketext($E_MIN_ONE_USER),
-							sets_needed  => 'at least one',
-							error_sets   => maketext($E_MIN_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> users to <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Act'),
-						name  => 'act_as_user',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							users_needed => 'exactly one',
-							error_users  => maketext($E_ONE_USER),
-							sets_needed  => 'at most one',
-							error_sets   => maketext($E_MAX_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('as <strong>one</strong> user on <strong>up to one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'edit_set_for_users',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							sets_needed  => 'exactly one',
-							error_sets   => maketext($E_ONE_SET)
-						} =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users}) =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name       => 'show_answers',
-						class      => 'btn btn-sm btn-secondary col-2' =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('answer log for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Generate'),
-						name       => 'hardcopy',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'hardcopy') =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('PDF hardcopy for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-			</div>
-			<div class="tab-pane fade show row offset-md-6 col-6" id="set-actions" role="tabpanel"
-				aria-labelledby="pills-set-actions-tab" >
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Edit'),
-						name  => 'users_assigned_to_set',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('assigned users for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Add'),
-						name  => 'prob_lib',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('problems to <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'set_stats',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('statistics for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('View'),
-						name  => 'set_progress',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('progress for <strong>one</strong> set') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Score'),
-						name       => 'score_sets',
-						class      => 'btn btn-sm btn-secondary col-2',
-						formaction => $c->systemLink(url_for 'instructor_scoring'),
-						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
-					<span class="input-group-text flex-grow-1">\
-						<%== maketext('<strong>selected</strong> sets') =%>\
-					</span>
-				</div>
-				<div class="input-group input-group-sm mb-2">
-					<%= submit_button maketext('Create'),
-						name  => 'create_set',
-						class => 'btn btn-sm btn-secondary col-2',
-						data  => {
-							set_name_needed        => 'true',
-							error_set_name         => maketext($E_SET_NAME),
-							error_invalid_set_name => maketext($E_BAD_NAME)
-						} =%>
-					<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
-					<%= text_field new_set_name => '',
-						id          => 'new_set_name',
-						placeholder => maketext('New set name'),
-						size        => 20,
-						class       => 'form-control form-control-sm',
-						dir         => 'ltr' =%>
+				<div class="tab-pane fade show row offset-lg-6 offset-sm-4 col-lg-6 col-sm-8"
+					id="set-actions" role="tabpanel" aria-labelledby="pills-set-actions-tab">
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Edit'),
+							name  => 'users_assigned_to_set',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('assigned users for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Add'),
+							name  => 'prob_lib',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('problems to <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'set_stats',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('statistics for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('View'),
+							name  => 'set_progress',
+							class => 'btn btn-sm btn-secondary',
+							data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('progress for <strong>one</strong> set') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Score'),
+							name       => 'score_sets',
+							class      => 'btn btn-sm btn-secondary',
+							formaction => $c->systemLink(url_for 'instructor_scoring'),
+							data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+						<span class="input-group-text flex-grow-1">\
+							<%== maketext('<strong>selected</strong> sets') =%>\
+						</span>
+					</div>
+					<div class="input-group input-group-sm mb-2">
+						<%= submit_button maketext('Create'),
+							name  => 'create_set',
+							class => 'btn btn-sm btn-secondary',
+							data  => {
+								set_name_needed        => 'true',
+								error_set_name         => maketext($E_SET_NAME),
+								error_invalid_set_name => maketext($E_BAD_NAME)
+							} =%>
+						<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
+						<%= text_field new_set_name => '',
+							id          => 'new_set_name',
+							placeholder => maketext('New set name'),
+							size        => 20,
+							class       => 'form-control form-control-sm',
+							dir         => 'ltr' =%>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -16,13 +16,13 @@
 			. 'or select a tool from the list to the left.'
 	) =%>
 	<br>
-	<%= maketext('Select user(s) and/or sets(s) below and click the action button of your choice.') =%>
+	<%= maketext('Select user(s) and/or set(s) below and click the action button of your choice.') =%>
 </p>
 %
 <%= form_for current_route, method => 'POST', id => 'instructor-tools-form', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%
-	<div class="row gx-3">
+	<div class="row">
 		<div class="col-xl-5 col-md-6 mb-2">
 			<div class="fw-bold text-center"><%= label_for selected_users => maketext('Users') %></div>
 			<%= scrollingRecordList(
@@ -59,200 +59,168 @@
 			) =%>
 		</div>
 	</div>
-	<div class="row gx-3">
-		<div class="col-xl-3 col-md-6">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'sets_assigned_to_user',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Assignments and Dates') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
+	<div class="row">
+		% # TODO: When bootstrap is upgraded to 5.3 switch the "column-gap" style to the "column-gap-3" class.
+		<div class="col-xl-10 col-md-12 d-flex justify-content-around flex-wrap" style="column-gap:1rem">
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'sets_assigned_to_user',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users  => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('assignments and dates for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name       => 'edit_users',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_user_list'),
+						data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('account data for <b>all selected</b> users') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'user_options',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('account settings for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'user_progress',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('progress for <strong>one</strong> user') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary w-25' =%>
+					<%= number_field number_of_students => 1, min => 1, max => 100,
+						class => 'form-control form-control-sm text-center' =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('new user accounts') =%>\
+					</span>
+				</div>
 			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name       => 'edit_users',
-					class      => 'btn btn-sm btn-secondary col-3',
-					formaction => $c->systemLink(url_for 'instructor_user_list'),
-					data => { users_needed => 'at least one', error_users => maketext($E_MIN_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Account Data') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <b>all selected</b> users') =%>\
-				</span>
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Assign'),
+						# This name is the same as the name of the submit button in Assigner.pm and the form is
+						# directly submitted to that module without modification.
+						name       => 'assign',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_set_assigner'),
+						data => {
+							users_needed => 'at least one',
+							error_users  => maketext($E_MIN_ONE_USER),
+							sets_needed  => 'at least one',
+							error_sets   => maketext($E_MIN_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('<strong>all selected</strong> users to <strong>all selected</strong> sets') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Act'),
+						name  => 'act_as_user',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							users_needed => 'exactly one',
+							error_users  => maketext($E_ONE_USER),
+							sets_needed  => 'at most one',
+							error_sets   => maketext($E_MAX_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('as <strong>one</strong> user on <strong>up to one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'edit_set_for_users',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							sets_needed  => 'exactly one',
+							error_sets   => maketext($E_ONE_SET)
+						} =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext(q{<strong>one</strong> set's details for <strong>some or all</strong> users}) =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Score'),
+						name       => 'score_sets',
+						class      => 'btn btn-sm btn-secondary w-25',
+						formaction => $c->systemLink(url_for 'instructor_scoring'),
+						data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('<strong>all selected</strong> sets for <strong>all</strong> users') =%>\
+					</span>
+				</div>
 			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'user_options',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Account Settings') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'user_progress',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { users_needed => 'exactly one', error_users => maketext($E_ONE_USER) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Progress') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> user') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Add'), name => 'add_users', class => 'btn btn-sm btn-secondary col-3' =%>
-				%= number_field number_of_students => 1, min => 1, max => 100, class => 'col-2 flex-grow-1 text-center'
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('new user accounts') =%>\
-				</span>
-			</div>
-		</div>
-		<div class="col-xl-4 col-md-6">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Assign'),
-					# This name is the same as the name of the submit button in Assigner.pm and the form is
-					# directly submitted to that module without modification.
-					name       => 'assign',
-					class      => 'btn btn-sm btn-secondary col-2',
-					formaction => $c->systemLink(url_for 'instructor_set_assigner'),
-					data => {
-						users_needed => 'at least one',
-						error_users  => maketext($E_MIN_ONE_USER),
-						sets_needed  => 'at least one',
-						error_sets   => maketext($E_MIN_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('<strong>all selected</strong> users') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('to <strong>all selected</strong> sets') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Act'),
-					name  => 'act_as_user',
-					class => 'btn btn-sm btn-secondary col-2',
-					data  => {
-						users_needed => 'exactly one',
-						error_users  => maketext($E_ONE_USER),
-						sets_needed  => 'at most one',
-						error_sets   => maketext($E_MAX_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('as <strong>one</strong> user') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('on <strong>up to one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'edit_set_for_users',
-					class => 'btn btn-sm btn-secondary col-2',
-					data  => {
-						sets_needed  => 'exactly one',
-						error_sets   => maketext($E_ONE_SET)
-					} =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Set Detail for <strong>one</strong> set') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>zero or more</strong> users') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Score'),
-					name       => 'score_sets',
-					class      => 'btn btn-sm btn-secondary col-2',
-					formaction => $c->systemLink(url_for 'instructor_scoring'),
-					data => { sets_needed => 'at least one', error_sets => maketext($E_MIN_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('<strong>all selected</strong> sets') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext(' for <strong>all</strong> users') =%>\
-				</span>
-			</div>
-		</div>
-		<div class="col-xl-3 col-md-6 font-sm">
-			<hr class="divider pb-1 bg-dark my-2">
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Edit'),
-					name  => 'users_assigned_to_set',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Assigned Users') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Add'),
-					name  => 'prob_lib',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Library Browser Exercises') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('to <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'set_stats',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Statistics') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('View'),
-					name  => 'set_progress',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('Progress') =%>\
-				</span>
-				<span class="input-group-text flex-grow-1" style="white-space:pre;">\
-					<%== maketext('for <strong>one</strong> set') =%>\
-				</span>
-			</div>
-			<div class="input-group input-group-sm mb-2">
-				<%= submit_button maketext('Create'),
-					name  => 'create_set',
-					class => 'btn btn-sm btn-secondary col-3',
-					data  => {
-						set_name_needed        => 'true',
-						error_set_name         => maketext($E_SET_NAME),
-						error_invalid_set_name => maketext($E_BAD_NAME)
-					} =%>
-				<%= label_for new_set_name => maketext('New Set:'), class => 'input-group-text' =%>
-				<%= text_field new_set_name => '',
-					id          => 'new_set_name',
-					placeholder => maketext('Name for new set here'),
-					size        => 20,
-					class       => 'form-control form-control-sm',
-					dir         => 'ltr' =%>
+			<div style="min-width:350px">
+				<hr class="divider pb-1 bg-dark mt-0 mb-2">
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Edit'),
+						name  => 'users_assigned_to_set',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('assigned users for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Add'),
+						name  => 'prob_lib',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('problems to <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'set_stats',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('statistics for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('View'),
+						name  => 'set_progress',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => { sets_needed => 'exactly one', error_sets => maketext($E_ONE_SET) } =%>
+					<span class="input-group-text flex-grow-1" style="white-space:pre;">\
+						<%== maketext('progress for <strong>one</strong> set') =%>\
+					</span>
+				</div>
+				<div class="input-group input-group-sm mb-2">
+					<%= submit_button maketext('Create'),
+						name  => 'create_set',
+						class => 'btn btn-sm btn-secondary w-25',
+						data  => {
+							set_name_needed        => 'true',
+							error_set_name         => maketext($E_SET_NAME),
+							error_invalid_set_name => maketext($E_BAD_NAME)
+						} =%>
+					<%= label_for new_set_name => maketext('new set:'), class => 'input-group-text' =%>
+					<%= text_field new_set_name => '',
+						id          => 'new_set_name',
+						placeholder => maketext('New set name'),
+						size        => 20,
+						class       => 'form-control form-control-sm',
+						dir         => 'ltr' =%>
+				</div>
 			</div>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -62,7 +62,7 @@
 	<div class="row">
 		% # TODO: When bootstrap is upgraded to 5.3 switch the "column-gap" style to the "column-gap-3" class.
 		<div class="col-xl-10 col-md-12 d-flex justify-content-around flex-wrap" style="column-gap:1rem">
-			<div style="min-width:370px">
+			<div style="min-width:28em">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
@@ -119,7 +119,7 @@
 					</span>
 				</div>
 			</div>
-			<div style="min-width:370px">
+			<div style="min-width:28em">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Assign'),
@@ -192,7 +192,7 @@
 					</span>
 				</div>
 			</div>
-			<div style="min-width:370px">
+			<div style="min-width:28em">
 				<hr class="divider pb-1 bg-dark mt-0 mb-2">
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -11,12 +11,9 @@
 % }
 %
 <p>
-	<%= maketext(
-		'Use the interface below to quickly access commonly-used instructor tools, '
-			. 'or select a tool from the list to the left.'
-	) =%>
+	<%= maketext('Use the interface below to quickly access commonly-used instructor tools.') =%>
 	<br>
-	<%= maketext('Select user(s) and/or set(s) below and click the action button of your choice.') =%>
+	<%= maketext('Select user(s) and/or set(s), and click the action button of your choice below.') =%>
 </p>
 %
 <%= form_for current_route, method => 'POST', id => 'instructor-tools-form', begin =%>
@@ -211,7 +208,7 @@
 						name       => 'show_answers',
 						class      => 'btn btn-sm btn-secondary col-2' =%>
 					<span class="input-group-text flex-grow-1">\
-						<%== maketext('answers for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
+						<%== maketext('answer log for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 				<div class="input-group input-group-sm mb-2">
@@ -220,7 +217,7 @@
 						class      => 'btn btn-sm btn-secondary col-2',
 						formaction => $c->systemLink(url_for 'hardcopy') =%>
 					<span class="input-group-text flex-grow-1">\
-						<%== maketext('PDF for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
+						<%== maketext('PDF hardcopy for <strong>selected</strong> users, for <strong>selected</strong> sets') =%>\
 					</span>
 				</div>
 			</div>

--- a/templates/ContentGenerator/Instructor/Index.html.ep
+++ b/templates/ContentGenerator/Instructor/Index.html.ep
@@ -69,7 +69,7 @@
 					data-bs-toggle="pill"
 					data-bs-target="#user-actions"
 					type="button"
-					"role="tab"
+					role="tab"
 					aria-controls="pills-user-actions"
 					aria-selected="true">\
 					<%== maketext('User Actions') =%>\
@@ -82,7 +82,7 @@
 					data-bs-toggle="pill"
 					data-bs-target="#user-set-actions"
 					type="button"
-					"role="tab"
+					role="tab"
 					aria-controls="pills-user-set-actions"
 					aria-selected="false">\
 					<%== maketext('User-Set Actions') =%>\
@@ -95,7 +95,7 @@
 					data-bs-toggle="pill"
 					data-bs-target="#set-actions"
 					type="button"
-					"role="tab"
+					role="tab"
 					aria-controls="pills-set-actions"
 					aria-selected="false">\
 					<%== maketext('Set Actions') =%>\
@@ -105,7 +105,7 @@
 
 		<div class="tab-content row" id="pills-tabContent">
 			<div id="user-actions" class="tab-pane fade show active col-6" role="tabpanel"
-				aria-labelledby="pills-user-actions-tab" tabindex="0" >
+				aria-labelledby="pills-user-actions-tab" >
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'sets_assigned_to_user',
@@ -162,7 +162,7 @@
 				</div>
 			</div>
 			<div class="tab-pane fade show offset-md-3 col-6" id="user-set-actions" role="tabpanel"
-				aria-labelledby="pills-user-set-actions-tab" tabindex="0">
+				aria-labelledby="pills-user-set-actions-tab" >
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Assign'),
 						# This name is the same as the name of the submit button in Assigner.pm and the form is
@@ -225,7 +225,7 @@
 				</div>
 			</div>
 			<div class="tab-pane fade show row offset-md-6 col-6" id="set-actions" role="tabpanel"
-				aria-labelledby="pills-set-actions-tab" tabindex="0">
+				aria-labelledby="pills-set-actions-tab" >
 				<div class="input-group input-group-sm mb-2">
 					<%= submit_button maketext('Edit'),
 						name  => 'users_assigned_to_set',

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -68,7 +68,7 @@
 <%= $fileInfo->() %>
 %
 <%= form_for current_route, method => 'POST', id => 'editor', name => 'editor',
-   	enctype => 'application/x-www-form-urlencoded', class => 'col-12', begin =%>
+	enctype => 'application/x-www-form-urlencoded', class => 'col-12', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	<%= hidden_field file_type => $c->{file_type} =%>
 	<%= hidden_field courseID => $c->{courseID} =%>

--- a/templates/ContentGenerator/Instructor/ProblemGrader/siblings.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader/siblings.html.ep
@@ -2,7 +2,7 @@
 %
 % unless ($set
 	% && $authz->hasPermissions(param('user'), 'access_instructor_tools')
-   	% && $authz->hasPermissions(param('user'), 'score_sets'))
+	% && $authz->hasPermissions(param('user'), 'score_sets'))
 % {
 	% last;
 % }

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -126,7 +126,7 @@
 					<div class="mb-2">
 						<%= scrollingRecordList(
 							{
-								name            => 'classList',
+								name            => 'selected_users',
 								controller      => $c,
 								default_sort    => 'lnfn',
 								default_format  => 'lnfn_uid',

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -126,13 +126,12 @@
 					<div class="mb-2">
 						<%= scrollingRecordList(
 							{
-								name                => 'classList',
-								controller          => $c,
-								default_sort        => 'lnfn',
-								default_format      => 'lnfn_uid',
-								default_filters     => ['all'],
-								refresh_button_name => maketext('Change Display Settings'),
-								attrs               => { size => 5, multiple => undef }
+								name            => 'classList',
+								controller      => $c,
+								default_sort    => 'lnfn',
+								default_format  => 'lnfn_uid',
+								default_filters => ['all'],
+								attrs           => { size => 5, multiple => undef }
 							},
 							@{ $c->{ra_user_records} }
 						) =%>

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel.html.ep
@@ -20,7 +20,7 @@
 % # Now check which version to use.
 % my $libraryVersion = $ce->{problemLibrary}{version} || 2;
 % if ($libraryVersion == 1) {
- 	<div class="alert alert-danger p-1 mb-2 text-center">Problem library version 1 is no longer supported.</div>
+	<div class="alert alert-danger p-1 mb-2 text-center">Problem library version 1 is no longer supported.</div>
 % } elsif ($libraryVersion >= 2) {
 	% if ($c->{library_basic} == 1) {
 		<%= include 'ContentGenerator/Instructor/SetMaker/browse_library_panel_simple' =%>

--- a/templates/ContentGenerator/Instructor/ShowAnswers/instructor-selectors.html.ep
+++ b/templates/ContentGenerator/Instructor/ShowAnswers/instructor-selectors.html.ep
@@ -23,12 +23,12 @@
 		<div class="col-sm-4 mb-2">
 			<div class="fw-bold text-center"><%= label_for selected_sets => maketext('Sets') %></div>
 			<%= select_field selected_sets => [ map { [ format_set_name_display($_) => $_ ] } @$expandedGlobalSetIDs ],
-				id => 'selected_sets', size => 23, multiple => undef, class => 'form-select form-select-sm',
+				id => 'selected_sets', size => 24, multiple => undef, class => 'form-select form-select-sm',
 				dir => 'ltr' =%>
 		</div>
 		<div class="col-sm-2 mb-2">
 			<div class="fw-bold text-center"><%= label_for selected_problems => maketext('Problems') %></div>
-			<%= select_field selected_problems => $globalProblemIDs, id => 'selected_problems', size => 23,
+			<%= select_field selected_problems => $globalProblemIDs, id => 'selected_problems', size => 24,
 				multiple => undef, class => 'form-select form-select-sm' =%>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -209,5 +209,5 @@
 	[ 95, 75, 50, 25, 5, 1 ],
 	$attemptsList,
 	[ map { link_to maketext('Problem [_1]', $_->{prettyID}) => $_->{statsLink} } @$problems ],
-   	reverse => 1
+	reverse => 1
 ) =%>

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -1,7 +1,7 @@
 % use WeBWorK::Utils::Instructor qw(getCSVList);
 %
 <div>
-   	<div class="row mb-2">
+	<div class="row mb-2">
 		<%= label_for export_select_scope => maketext('Export which users?'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">

--- a/templates/ContentGenerator/ProblemSet.html.ep
+++ b/templates/ContentGenerator/ProblemSet.html.ep
@@ -19,7 +19,7 @@
 % }
 %
 % my $set = $c->{set};
-% 
+%
 % # Stats message displays the current status of the set and states the next important date.
 <%= include 'ContentGenerator/Base/set_status', set => $set =%>
 %

--- a/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
+++ b/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
@@ -1,6 +1,6 @@
 <div class="card p-2">
 	<div class="row mb-2">
-		<%= label_for "$name!sort" => maketext('Sort:'),
+		<%= label_for "$name!sort" => maketext('Sort By:'),
 			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
 		<div class="col-10">
 			<%= select_field "$name!sort" => $sorts, id => "$name!sort", class => 'form-select form-select-sm' =%>
@@ -22,7 +22,7 @@
 		</div>
 	</div>
 	<div>
-		<%= submit_button $options->{refresh_button_name} // maketext('Change Display Settings'),
+		<%= submit_button $options->{refresh_button_name} // maketext('Refresh List'),
 			name => "$name!refresh", class => 'btn btn-secondary btn-sm mb-2' =%>
 	</div>
 	<%= select_field $name => $formattedRecords, id => $name, class => 'form-select form-select-sm',

--- a/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
+++ b/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
@@ -1,37 +1,37 @@
 <div class="card p-2">
 	<div class="row mb-2">
 		<%= label_for "$name!sort" => maketext('Sort By:'),
-			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
-		<div class="col-10">
+			class => 'col-form-label col-form-label-sm col-2 col-lg-2 col-md-12 pe-1 text-nowrap' =%>
+		<div class="col-10 col-lg-10 col-md-12">
 			<%= select_field "$name!sort" => $sorts, id => "$name!sort", class => 'form-select form-select-sm' =%>
 		</div>
 	</div>
 	<div class="row mb-2">
 		<%= label_for "$name!format" => maketext('Format:'),
-			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
-		<div class="col-10">
+			class => 'col-form-label col-form-label-sm col-2 col-lg-2 col-md-12 pe-1 text-nowrap' =%>
+		<div class="col-10 col-lg-10 col-md-12">
 			<%= select_field "$name!format" => $formats, id => "$name!format", class => 'form-select form-select-sm' =%>
 		</div>
 	</div>
 	<div class="row mb-2">
 		<%= label_for "$name!filter" => maketext('Filter(s):'),
-			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
-		<div class="col-10">
+			class => 'col-form-label col-form-label-sm col-2 col-lg-2 col-md-12 pe-1 text-nowrap' =%>
+		<div class="col-10 col-lg-10 col-md-12">
 			<%= select_field "$name!filter" => $filters, id => "$name!filter", class => 'form-select form-select-sm',
 				multiple => undef, size => 5 =%>
 		</div>
 	</div>
 	<div class="row mb-2">
-		<div class="offset-2 col-10">
+		<div class="offset-lg-2 col-10 col-lg-10 col-md-12">
 			<div class="form-check form-check-inline">
 				<%= radio_button "$name!filter_combine" => 1, id => "$name!intersect_check", checked => undef,
 					class => 'form-check-input' =%>
-				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'form-check-label' =%>
+				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'form-check-label font-sm' =%>
 			</div>
 			<div class="form-check form-check-inline">
 				<%= radio_button "$name!filter_combine" => 0, id => "$name!union_check",
 					class => 'form-check-input' =%>
-				<%= label_for "$name!union_check" => maketext('Union'), class => 'form-check-label' =%>
+				<%= label_for "$name!union_check" => maketext('Union'), class => 'form-check-label font-sm' =%>
 			</div>
 		</div>
 	</div>

--- a/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
+++ b/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
@@ -19,9 +19,11 @@
 				class => 'col-form-label col-form-label-sm pe-1 text-nowrap' =%>
 			<div class="form-check p-0">
 				<%= radio_button "$name!filter_combine" => 'intersect', id => "$name!intersect_check", checked => undef =%>
-				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'col-form-label-sm' =%>
+				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'col-form-label-sm p-1 pt-0' =%>
+			</div>
+			<div class="form-check p-0">
 				<%= radio_button "$name!filter_combine" => 'union', id => "$name!union_check" =%>
-				<%= label_for "$name!union_check" => maketext('Union'), class => 'col-form-label-sm' =%>
+				<%= label_for "$name!union_check" => maketext('Union'), class => 'col-form-label-sm p-1 pt-0' =%>
 			</div>
 		</div>
 		<div class="col-10">

--- a/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
+++ b/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
@@ -14,8 +14,16 @@
 		</div>
 	</div>
 	<div class="row mb-2">
-		<%= label_for "$name!filter" => maketext("Filter:"),
-			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
+		<div class="col-2">
+			<%= label_for "$name!filter" => maketext('Filter(s):'),
+				class => 'col-form-label col-form-label-sm pe-1 text-nowrap' =%>
+			<div class="form-check p-0">
+				<%= radio_button "$name!filter_combine" => 'intersect', id => "$name!intersect_check", checked => undef =%>
+				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'col-form-label-sm' =%>
+				<%= radio_button "$name!filter_combine" => 'union', id => "$name!union_check" =%>
+				<%= label_for "$name!union_check" => maketext('Union'), class => 'col-form-label-sm' =%>
+			</div>
+		</div>
 		<div class="col-10">
 			<%= select_field "$name!filter" => $filters, id => "$name!filter", class => 'form-select form-select-sm',
 				multiple => undef, size => 5 =%>

--- a/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
+++ b/templates/HTML/ScrollingRecordList/scrollingRecordList.html.ep
@@ -14,21 +14,25 @@
 		</div>
 	</div>
 	<div class="row mb-2">
-		<div class="col-2">
-			<%= label_for "$name!filter" => maketext('Filter(s):'),
-				class => 'col-form-label col-form-label-sm pe-1 text-nowrap' =%>
-			<div class="form-check p-0">
-				<%= radio_button "$name!filter_combine" => 'intersect', id => "$name!intersect_check", checked => undef =%>
-				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'col-form-label-sm p-1 pt-0' =%>
-			</div>
-			<div class="form-check p-0">
-				<%= radio_button "$name!filter_combine" => 'union', id => "$name!union_check" =%>
-				<%= label_for "$name!union_check" => maketext('Union'), class => 'col-form-label-sm p-1 pt-0' =%>
-			</div>
-		</div>
+		<%= label_for "$name!filter" => maketext('Filter(s):'),
+			class => 'col-form-label col-form-label-sm col-2 pe-1 text-nowrap' =%>
 		<div class="col-10">
 			<%= select_field "$name!filter" => $filters, id => "$name!filter", class => 'form-select form-select-sm',
 				multiple => undef, size => 5 =%>
+		</div>
+	</div>
+	<div class="row mb-2">
+		<div class="offset-2 col-10">
+			<div class="form-check form-check-inline">
+				<%= radio_button "$name!filter_combine" => 1, id => "$name!intersect_check", checked => undef,
+					class => 'form-check-input' =%>
+				<%= label_for "$name!intersect_check" => maketext('Intersect'), class => 'form-check-label' =%>
+			</div>
+			<div class="form-check form-check-inline">
+				<%= radio_button "$name!filter_combine" => 0, id => "$name!union_check",
+					class => 'form-check-input' =%>
+				<%= label_for "$name!union_check" => maketext('Union'), class => 'form-check-label' =%>
+			</div>
 		</div>
 	</div>
 	<div>

--- a/templates/HelpFiles/Hardcopy.html.ep
+++ b/templates/HelpFiles/Hardcopy.html.ep
@@ -23,7 +23,7 @@
 </p>
 <p>
 	<%= maketext('In both cases, one can select the sort field, the format of the display list, and the filter. '
-		. '"Change Display Settings" must be clicked to update the list.') =%>
+		. '"Refresh List" must be clicked to update the list.') =%>
 </p>
 <p>
 	<%= maketext('There are many options available at the bottom:') =%>

--- a/templates/HelpFiles/Hardcopy.html.ep
+++ b/templates/HelpFiles/Hardcopy.html.ep
@@ -23,6 +23,9 @@
 </p>
 <p>
 	<%= maketext('In both cases, one can select the sort field, the format of the display list, and the filter. '
+		. 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+		. 'be applied in sequence, narrowing the results list. If the "Union" button is used, the updated '
+		. 'list will be the union of all results lists from the multiple filters. '
 		. '"Refresh List" must be clicked to update the list.') =%>
 </p>
 <p>

--- a/templates/HelpFiles/InstructorAssigner.html.ep
+++ b/templates/HelpFiles/InstructorAssigner.html.ep
@@ -21,7 +21,7 @@
 		. 'unassign the given sets. The list of users or the list of sets can be reordered under the "sort" '
 		. 'option or the format of the user or set list.  Additionally, the set lists can be filtered '
 		. '(by section number or recitation).  The displayed user and set lists will only be updated '
-		. 'upon clicking "Change Display Settings".') =%>
+		. 'upon clicking "Refresh List".') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Multiple users or sets may be selected by holding down the shift key or the ctrl key while '

--- a/templates/HelpFiles/InstructorAssigner.html.ep
+++ b/templates/HelpFiles/InstructorAssigner.html.ep
@@ -17,11 +17,13 @@
 % title maketext('Set Assigner Help');
 %
 <p>
-	<%= maketext('Select Users from the left column and sets from the right column and assign or '
-		. 'unassign the given sets. The list of users or the list of sets can be reordered under the "sort" '
-		. 'option or the format of the user or set list.  Additionally, the set lists can be filtered '
-		. '(by section number or recitation).  The displayed user and set lists will only be updated '
-		. 'upon clicking "Refresh List".') =%>
+	<%= maketext('Select users from the left column and sets from the right column and assign or '
+		. 'unassign the given sets. The list of users or the list of sets can be reordered using the "Sort By" '
+		. 'option, and presented using a chosen "Format".  Additionally, the user and set lists can be filtered. '
+                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+                . 'list will be the union of all results lists from the multiple filters.'
+		. 'The displayed user and set lists will only be updated upon clicking "Refresh List".') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Multiple users or sets may be selected by holding down the shift key or the ctrl key while '

--- a/templates/HelpFiles/InstructorAssigner.html.ep
+++ b/templates/HelpFiles/InstructorAssigner.html.ep
@@ -20,9 +20,9 @@
 	<%= maketext('Select users from the left column and sets from the right column and assign or '
 		. 'unassign the given sets. The list of users or the list of sets can be reordered using the "Sort By" '
 		. 'option, and presented using a chosen "Format".  Additionally, the user and set lists can be filtered. '
-                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
-                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
-                . 'list will be the union of all results lists from the multiple filters.'
+		. 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+		. 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+		. 'list will be the union of all results lists from the multiple filters.'
 		. 'The displayed user and set lists will only be updated upon clicking "Refresh List".') =%>
 </p>
 <p class="mb-0">

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -27,9 +27,9 @@
 <p>
 	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on. '
 		. 'In both cases, one can select the sort field, the format of the display list, and the filter. '
-                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
-                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
-                . 'list will be the union of all results lists from the multiple filters.') =%>
+		. 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+		. 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+		. 'list will be the union of all results lists from the multiple filters.') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Multiple users and sets can be selected using ctrl-click or shift-click.  The action buttons are '

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -21,14 +21,14 @@
 		. 'common actions that allow selecting multiple users or sets to act on at once.  Because multiple users '
 		. 'and sets can be acted on at the same time, it is often more efficient to use this page when modifying '
 		. 'multiple items.  For example, after selecting several users and a set you can change the close date for '
-		. 'all selected users for that set.  This page also gives access to "Edit Assignments and Dates for one user", '
+		. 'all selected users for that set.  This page also gives access to "Edit assignments and dates for one user", '
 		. 'which can be used to access settings for all sets including test versions for that user.') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on.  Multiple items can be '
 		. 'selected using ctrl-click or shift-click.  The action buttons are grouped into three categories.  The '
-		. 'first is a set of actions that act on the selected users, the last is a set of actions that act on the '
-		. 'selected sets, and the middle is a set of actions for acting on a combination of sets and users.  If an '
+		. 'first is a set of actions that act on the selected users, the second is a set of actions for acting on a '
+		. 'combination of sets and users, and the third is a set of actions that act on the selected sets.  If an '
 		. 'invalid number of users or sets are selected, the action will not be preformed, and an error message '
 		. 'will be placed on the page.') =%>
 </p>

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -29,6 +29,6 @@
 		. 'selected using ctrl-click or shift-click.  The action buttons are grouped into three categories.  The '
 		. 'first is a set of actions that act on the selected users, the second is a set of actions for acting on a '
 		. 'combination of sets and users, and the third is a set of actions that act on the selected sets.  If an '
-		. 'invalid number of users or sets are selected, the action will not be preformed, and an error message '
+		. 'invalid number of users or sets are selected, the action will not be performed, and an error message '
 		. 'will be placed on the page.') =%>
 </p>

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -20,15 +20,21 @@
 	<%= maketext('This page is a collection of tools to modify users and sets.  These tools are shortcuts for '
 		. 'common actions that allow selecting multiple users or sets to act on at once.  Because multiple users '
 		. 'and sets can be acted on at the same time, it is often more efficient to use this page when modifying '
-		. 'multiple items.  For example, after selecting several users and a set you can change the close date for '
-		. 'all selected users for that set.  This page also gives access to "Edit assignments and dates for one user", '
+		. 'multiple items.  For example, you can change the close date for several users for an assignment. '
+		. 'This page also gives access to "Edit assignments and dates for one user", '
 		. 'which can be used to access settings for all sets including test versions for that user.') =%>
 </p>
+<p>
+	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on. '
+		. 'In both cases, one can select the sort field, the format of the display list, and the filter. '
+                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+                . 'list will be the union of all results lists from the multiple filters.') =%>
+</p>
 <p class="mb-0">
-	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on.  Multiple items can be '
-		. 'selected using ctrl-click or shift-click.  The action buttons are grouped into three categories.  The '
-		. 'first is a set of actions that act on the selected users, the second is a set of actions for acting on a '
-		. 'combination of sets and users, and the third is a set of actions that act on the selected sets.  If an '
-		. 'invalid number of users or sets are selected, the action will not be performed, and an error message '
-		. 'will be placed on the page.') =%>
+	<%= maketext('Multiple users and sets can be selected using ctrl-click or shift-click.  The action buttons are '
+		. 'grouped into three categories.  The first is a set of actions that act on the selected users, the second is '
+		. 'a set of actions for acting on a combination of sets and users, and the third is a set of actions that act '
+		. 'on the selected sets.  If an invalid number of users or sets are selected, the action will not be '
+		. 'performed, and an error message will be placed on the page.') =%>
 </p>

--- a/templates/HelpFiles/InstructorIndex.html.ep
+++ b/templates/HelpFiles/InstructorIndex.html.ep
@@ -17,18 +17,18 @@
 % title maketext('Instructor Tools Help');
 %
 <p>
-	<%= maketext('This page is a collection of tools to modify users and sets.  These tools are short cuts for '
+	<%= maketext('This page is a collection of tools to modify users and sets.  These tools are shortcuts for '
 		. 'common actions that allow selecting multiple users or sets to act on at once.  Because multiple users '
 		. 'and sets can be acted on at the same time, it is often more efficient to use this page when modifying '
 		. 'multiple items.  For example, after selecting several users and a set you can change the close date for '
-		. 'all selected users for that set.  This page also gives access to "View/Edit all sets for one user", '
+		. 'all selected users for that set.  This page also gives access to "Edit Assignments and Dates for one user", '
 		. 'which can be used to access settings for all sets including test versions for that user.') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Use the "Users" and "Sets" forms to select which users and sets to act on.  Multiple items can be '
 		. 'selected using ctrl-click or shift-click.  The action buttons are grouped into three categories.  The '
-		. 'first is a set of actions that act on the selected users, the second is a set of actions that act on the '
-		. 'selected sets, and the third is a set of actions for acting on a combination of sets and users.  If an '
+		. 'first is a set of actions that act on the selected users, the last is a set of actions that act on the '
+		. 'selected sets, and the middle is a set of actions for acting on a combination of sets and users.  If an '
 		. 'invalid number of users or sets are selected, the action will not be preformed, and an error message '
 		. 'will be placed on the page.') =%>
 </p>

--- a/templates/HelpFiles/InstructorSendMail.html.ep
+++ b/templates/HelpFiles/InstructorSendMail.html.ep
@@ -19,7 +19,7 @@
 <p>
 	<%= maketext('Use this page to send emails to active (enrolled or auditing) students.  Emails can be sent to '
 		. 'all active students or selected students.  Use the "Students" form to sort, filter, or format how '
-		. 'the user name is displayed.  Click "Change Display Settings" to apply any changes.  Use control-click '
+		. 'the user name is displayed.  Click "Refresh List" to apply any changes.  Use control-click '
 		. 'or shift-click to select multiple students to email.') =%>
 </p>
 <p>

--- a/templates/HelpFiles/InstructorSendMail.html.ep
+++ b/templates/HelpFiles/InstructorSendMail.html.ep
@@ -19,8 +19,10 @@
 <p>
 	<%= maketext('Use this page to send emails to active (enrolled or auditing) students.  Emails can be sent to '
 		. 'all active students or selected students.  Use the "Students" form to sort, filter, or format how '
-		. 'the user name is displayed.  Click "Refresh List" to apply any changes.  Use control-click '
-		. 'or shift-click to select multiple students to email.') =%>
+		. 'the user name is displayed. If multiple filters are selected and the "Intersection" radio button is used, '
+		. 'the filters will  be applied in sequence, narrowing the results list.  If the "Union" button is used, the '
+		. 'updated list will be the union of all results lists from the multiple filters.  Click "Refresh List" to '
+		. 'apply any changes.  Use control-click or shift-click to select multiple students to email.')=%>
 </p>
 <p>
 	<%= maketext('Emails can contain personalized data, such as name, section, or status.  Click "List of insertable '

--- a/templates/HelpFiles/InstructorShowAnswers.html.ep
+++ b/templates/HelpFiles/InstructorShowAnswers.html.ep
@@ -17,8 +17,12 @@
 % title maketext('Answer Log Help');
 %
 <p class="m-0">
-	<%= maketext('Show past answers.  Students can only see their past answers, and they will not be able to see '
+	<%= maketext('Show past answers.  Students can only see their own past answers, and they will not be able to see '
 		. 'which parts are correct.  Instructors can use the form to select any combination of users, sets, and '
-		. 'problems to view.  The table below will list the past answers colored according to correctness '
+		. 'problems to view. For users, one can select the sort field, the format of the display list, and the filter. '
+                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+                . 'list will be the union of all results lists from the multiple filters.'
+		. 'The table below will list the past answers colored according to correctness '
 		. '(green is correct).  Use control + click to select multiple users, sets, or problems.') =%>
 </p>

--- a/templates/HelpFiles/InstructorShowAnswers.html.ep
+++ b/templates/HelpFiles/InstructorShowAnswers.html.ep
@@ -20,9 +20,9 @@
 	<%= maketext('Show past answers.  Students can only see their own past answers, and they will not be able to see '
 		. 'which parts are correct.  Instructors can use the form to select any combination of users, sets, and '
 		. 'problems to view. For users, one can select the sort field, the format of the display list, and the filter. '
-                . 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
-                . 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
-                . 'list will be the union of all results lists from the multiple filters.'
+		. 'If multiple filters are selected and the "Intersection" radio button is used, the filters will '
+		. 'be applied in sequence, narrowing the results list.  If the "Union" button is used, the updated '
+		. 'list will be the union of all results lists from the multiple filters.'
 		. 'The table below will list the past answers colored according to correctness '
 		. '(green is correct).  Use control + click to select multiple users, sets, or problems.') =%>
 </p>


### PR DESCRIPTION
This makes changes to Instructor Tools. Also it makes changes to `scrollingRecordList` which is used by Instructor Tools, and also by the Assigner Tool, Email, Hardcopy, and Past Answer pages. So testing should look at all five pages.

There are cosmetic changes that could be better. I won't describe them here; feel free to make suggestions for improving anything cosmetic. The functional improvements are:

* The sort options are only ones that make sense for the available display formats.
* There are now three format options for displaying sets. (There was only one before.) The two I added might not be best, but it's clear how to change them or add more. *Note:* the new format methods for sets include displaying the set's due date. This calls on `formatDateTime` and presently generates an error message. But #2263 will make that go away.
* Previously there were no filter options for sets. Now you can filter by type (e.g. "Proctored Test") and you can filter by Visible/NotVisible. Note that you have to have at least two types to see those filtering options. And you have to have both visible and not visible sets present to see those filtering options.
* I tried to make the functionality of all buttons more clear with changes to the wording.
* "Statistics for one user" is a silly thing, that is really just "Progress for one user". So I removed "Statistics for one user".
* If you are using this to add new users, you can choose ahead of time how many you want to add. Previously it was fixedat 5.
* Previously there was a button to take you to the Set Detail page for a set, and a separate button to take you to the Set Detail page for a set but with some subset of users selected. I combined these into one button. De-select all users if you want the regular Set Detail page.

A screenshot of what to expect:

<img width="1149" alt="Screenshot 2023-11-27 at 10 00 55 PM" src="https://github.com/openwebwork/webwork2/assets/4732672/c1a4c6f0-3091-4341-b98c-66c10c3bb070">


