### PR TITLE
Update third party JavaScript dependencies.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,42 +7,42 @@
             "name": "webwork.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@fortawesome/fontawesome-free": "^6.2.1",
-                "bootstrap": "~5.2.3",
-                "codemirror": "^5.65.11",
+                "@fortawesome/fontawesome-free": "^6.4.2",
+                "bootstrap": "~5.3.2",
+                "codemirror": "^5.65.15",
                 "flatpickr": "^4.6.13",
-                "iframe-resizer": "^4.3.2",
-                "jquery": "^3.6.3",
+                "iframe-resizer": "^4.3.7",
+                "jquery": "^3.7.1",
                 "jquery-ui-dist": "^1.13.2",
-                "luxon": "^3.2.1",
+                "luxon": "^3.4.3",
                 "mathjax": "^3.2.2",
                 "shortcut-buttons-flatpickr": "^0.4.0",
                 "sortablejs": "^1.15.0"
             },
             "devDependencies": {
-                "autoprefixer": "^10.4.13",
+                "autoprefixer": "^10.4.16",
                 "chokidar": "^3.5.3",
-                "cssnano": "^6.0.0",
+                "cssnano": "^6.0.1",
                 "postcss": "^8.4.31",
-                "rtlcss": "^4.0.0",
-                "sass": "^1.57.1",
-                "terser": "^5.16.1",
-                "yargs": "^17.6.2"
+                "rtlcss": "^4.1.1",
+                "sass": "^1.69.5",
+                "terser": "^5.24.0",
+                "yargs": "^17.7.2"
             }
         },
         "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz",
-            "integrity": "sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
+            "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg==",
             "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/set-array": "^1.0.1",
@@ -54,9 +54,9 @@
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
@@ -72,9 +72,9 @@
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/gen-mapping": "^0.3.0",
@@ -82,25 +82,25 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "node_modules/@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "peer": true,
             "funding": {
                 "type": "opencollective",
@@ -117,9 +117,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -166,9 +166,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.13",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-            "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+            "version": "10.4.16",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+            "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
             "dev": true,
             "funding": [
                 {
@@ -178,12 +178,16 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.21.4",
-                "caniuse-lite": "^1.0.30001426",
-                "fraction.js": "^4.2.0",
+                "browserslist": "^4.21.10",
+                "caniuse-lite": "^1.0.30001538",
+                "fraction.js": "^4.3.6",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -214,9 +218,9 @@
             "dev": true
         },
         "node_modules/bootstrap": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
-            "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
             "funding": [
                 {
                     "type": "github",
@@ -228,7 +232,7 @@
                 }
             ],
             "peerDependencies": {
-                "@popperjs/core": "^2.11.6"
+                "@popperjs/core": "^2.11.8"
             }
         },
         "node_modules/braces": {
@@ -244,9 +248,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.21.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-            "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "dev": true,
             "funding": [
                 {
@@ -256,13 +260,17 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001400",
-                "electron-to-chromium": "^1.4.251",
-                "node-releases": "^2.0.6",
-                "update-browserslist-db": "^1.0.9"
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
+                "node-releases": "^2.0.13",
+                "update-browserslist-db": "^1.0.13"
             },
             "bin": {
                 "browserslist": "cli.js"
@@ -290,9 +298,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001547",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-            "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
+            "version": "1.0.30001565",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+            "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
             "dev": true,
             "funding": [
                 {
@@ -351,9 +359,9 @@
             }
         },
         "node_modules/codemirror": {
-            "version": "5.65.11",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.11.tgz",
-            "integrity": "sha512-Gp62g2eKSCHYt10axmGhKq3WoJSvVpvhXmowNq7pZdRVowwtvBR/hi2LSP5srtctKkRT33T6/n8Kv1UGp7JW4A=="
+            "version": "5.65.15",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
+            "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -389,9 +397,9 @@
             }
         },
         "node_modules/css-declaration-sorter": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
-            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+            "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
             "dev": true,
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -454,12 +462,12 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.0.tgz",
-            "integrity": "sha512-RGlcbzGhzEBCHuQe3k+Udyj5M00z0pm9S+VurHXFEOXxH+y0sVrJH2sMzoyz2d8N1EScazg+DVvmgyx0lurwwA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
+            "integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
             "dev": true,
             "dependencies": {
-                "cssnano-preset-default": "^6.0.0",
+                "cssnano-preset-default": "^6.0.1",
                 "lilconfig": "^2.1.0"
             },
             "engines": {
@@ -474,14 +482,14 @@
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.0.tgz",
-            "integrity": "sha512-BDxlaFzObRDXUiCCBQUNQcI+f1/aX2mgoNtXGjV6PG64POcHoDUoX+LgMWw+Q4609QhxwkcSnS65YFs42RA6qQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
+            "integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
             "dev": true,
             "dependencies": {
                 "css-declaration-sorter": "^6.3.1",
                 "cssnano-utils": "^4.0.0",
-                "postcss-calc": "^8.2.3",
+                "postcss-calc": "^9.0.0",
                 "postcss-colormin": "^6.0.0",
                 "postcss-convert-values": "^6.0.0",
                 "postcss-discard-comments": "^6.0.0",
@@ -489,7 +497,7 @@
                 "postcss-discard-empty": "^6.0.0",
                 "postcss-discard-overridden": "^6.0.0",
                 "postcss-merge-longhand": "^6.0.0",
-                "postcss-merge-rules": "^6.0.0",
+                "postcss-merge-rules": "^6.0.1",
                 "postcss-minify-font-values": "^6.0.0",
                 "postcss-minify-gradients": "^6.0.0",
                 "postcss-minify-params": "^6.0.0",
@@ -603,23 +611,23 @@
             }
         },
         "node_modules/domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dev": true,
             "dependencies": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
+                "domhandler": "^5.0.3"
             },
             "funding": {
                 "url": "https://github.com/fb55/domutils?sponsor=1"
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.284",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "version": "1.4.574",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
+            "integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -667,16 +675,16 @@
             "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
         },
         "node_modules/fraction.js": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
             "dev": true,
             "engines": {
                 "node": "*"
             },
             "funding": {
                 "type": "patreon",
-                "url": "https://www.patreon.com/infusion"
+                "url": "https://github.com/sponsors/rawify"
             }
         },
         "node_modules/fsevents": {
@@ -715,9 +723,9 @@
             }
         },
         "node_modules/iframe-resizer": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
-            "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.7.tgz",
+            "integrity": "sha512-a3EGVScU9NtUpj6lWvGhVw3EfOw5AopRs5xGsQU385kWdgQt++OsD6PCnTV+8YkgBu/g28rLIh0EztFg9UQr1Q==",
             "engines": {
                 "node": ">=0.8.0"
             },
@@ -727,9 +735,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-            "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
             "dev": true
         },
         "node_modules/is-binary-path": {
@@ -784,9 +792,9 @@
             }
         },
         "node_modules/jquery": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
-            "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
         },
         "node_modules/jquery-ui-dist": {
             "version": "1.13.2",
@@ -818,9 +826,9 @@
             "dev": true
         },
         "node_modules/luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg==",
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
             "engines": {
                 "node": ">=12"
             }
@@ -855,9 +863,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -937,13 +945,16 @@
             }
         },
         "node_modules/postcss-calc": {
-            "version": "8.2.4",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-            "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+            "integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.0.9",
+                "postcss-selector-parser": "^6.0.11",
                 "postcss-value-parser": "^4.2.0"
+            },
+            "engines": {
+                "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
                 "postcss": "^8.2.2"
@@ -1048,9 +1059,9 @@
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.0.tgz",
-            "integrity": "sha512-rCXkklftzEkniyv3f4mRCQzxD6oE4Quyh61uyWTUbCJ26Pv2hoz+fivJSsSBWxDBeScR4fKCfF3HHTcD7Ybqnw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
+            "integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.21.4",
@@ -1310,9 +1321,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "version": "6.0.13",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -1381,14 +1392,14 @@
             }
         },
         "node_modules/rtlcss": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.0.0.tgz",
-            "integrity": "sha512-j6oypPP+mgFwDXL1JkLCtm6U/DQntMUqlv5SOhpgHhdIE+PmBcjrtAHIpXfbIup47kD5Sgja9JDsDF1NNOsBwQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.1.1.tgz",
+            "integrity": "sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==",
             "dev": true,
             "dependencies": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.6",
+                "postcss": "^8.4.21",
                 "strip-json-comments": "^3.1.1"
             },
             "bin": {
@@ -1399,9 +1410,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.57.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
-            "integrity": "sha512-O2+LwLS79op7GI0xZ8fqzF7X2m/m8WFfI02dHOdsK5R2ECeS5F62zrwg/relM1rjSLy7Vd/DiMNIvPrQGsA0jw==",
+            "version": "1.69.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -1412,7 +1423,7 @@
                 "sass": "sass.js"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=14.0.0"
             }
         },
         "node_modules/shortcut-buttons-flatpickr": {
@@ -1532,13 +1543,13 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.16.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+            "version": "5.24.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+            "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/source-map": "^0.3.2",
-                "acorn": "^8.5.0",
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -1568,9 +1579,9 @@
             }
         },
         "node_modules/update-browserslist-db": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-            "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "dev": true,
             "funding": [
                 {
@@ -1580,6 +1591,10 @@
                 {
                     "type": "tidelift",
                     "url": "https://tidelift.com/funding/github/npm/browserslist"
+                },
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/ai"
                 }
             ],
             "dependencies": {
@@ -1587,7 +1602,7 @@
                 "picocolors": "^1.0.0"
             },
             "bin": {
-                "browserslist-lint": "cli.js"
+                "update-browserslist-db": "cli.js"
             },
             "peerDependencies": {
                 "browserslist": ">= 4.21.0"
@@ -1626,9 +1641,9 @@
             }
         },
         "node_modules/yargs": {
-            "version": "17.6.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -1655,14 +1670,14 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.2.1.tgz",
-            "integrity": "sha512-viouXhegu/TjkvYQoiRZK3aax69dGXxgEjpvZW81wIJdxm5Fnvp3VVIP4VHKqX4SvFw6qpmkILkD4RJWAdrt7A=="
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
+            "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg=="
         },
         "@jridgewell/gen-mapping": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.2.tgz",
-            "integrity": "sha512-mh65xKQAzI6iBcFzwv28KVWSmCkdRBWoOh+bYQGW3+6OZvbbN3TqMGo5hqYxQniRcH9F2VZIoJCm4pa3BPDK/A==",
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/set-array": "^1.0.1",
@@ -1671,9 +1686,9 @@
             }
         },
         "@jridgewell/resolve-uri": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-            "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
             "dev": true
         },
         "@jridgewell/set-array": {
@@ -1683,9 +1698,9 @@
             "dev": true
         },
         "@jridgewell/source-map": {
-            "version": "0.3.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.2.tgz",
-            "integrity": "sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/gen-mapping": "^0.3.0",
@@ -1693,25 +1708,25 @@
             }
         },
         "@jridgewell/sourcemap-codec": {
-            "version": "1.4.14",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-            "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
+            "version": "1.4.15",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.17",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.17.tgz",
-            "integrity": "sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==",
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
             "dev": true,
             "requires": {
-                "@jridgewell/resolve-uri": "3.1.0",
-                "@jridgewell/sourcemap-codec": "1.4.14"
+                "@jridgewell/resolve-uri": "^3.1.0",
+                "@jridgewell/sourcemap-codec": "^1.4.14"
             }
         },
         "@popperjs/core": {
-            "version": "2.11.6",
-            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.6.tgz",
-            "integrity": "sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==",
+            "version": "2.11.8",
+            "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+            "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
             "peer": true
         },
         "@trysound/sax": {
@@ -1721,9 +1736,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.8.1",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-            "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
             "dev": true
         },
         "ansi-regex": {
@@ -1752,14 +1767,14 @@
             }
         },
         "autoprefixer": {
-            "version": "10.4.13",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
-            "integrity": "sha512-49vKpMqcZYsJjwotvt4+h/BCjJVnhGwcLpDt5xkcaOG3eLrG/HUYLagrihYsQ+qrIBgIzX1Rw7a6L8I/ZA1Atg==",
+            "version": "10.4.16",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
+            "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
-                "caniuse-lite": "^1.0.30001426",
-                "fraction.js": "^4.2.0",
+                "browserslist": "^4.21.10",
+                "caniuse-lite": "^1.0.30001538",
+                "fraction.js": "^4.3.6",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -1778,9 +1793,9 @@
             "dev": true
         },
         "bootstrap": {
-            "version": "5.2.3",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.2.3.tgz",
-            "integrity": "sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
             "requires": {}
         },
         "braces": {
@@ -1793,15 +1808,15 @@
             }
         },
         "browserslist": {
-            "version": "4.21.4",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.4.tgz",
-            "integrity": "sha512-CBHJJdDmgjl3daYjN5Cp5kbTf1mUhZoS+beLklHIvkOWscs83YAhLlF3Wsh/lciQYAcbBJgTOD44VtG31ZM4Hw==",
+            "version": "4.22.1",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
+            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001400",
-                "electron-to-chromium": "^1.4.251",
-                "node-releases": "^2.0.6",
-                "update-browserslist-db": "^1.0.9"
+                "caniuse-lite": "^1.0.30001541",
+                "electron-to-chromium": "^1.4.535",
+                "node-releases": "^2.0.13",
+                "update-browserslist-db": "^1.0.13"
             }
         },
         "buffer-from": {
@@ -1823,9 +1838,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001547",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-            "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
+            "version": "1.0.30001565",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
+            "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
             "dev": true
         },
         "chokidar": {
@@ -1856,9 +1871,9 @@
             }
         },
         "codemirror": {
-            "version": "5.65.11",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.11.tgz",
-            "integrity": "sha512-Gp62g2eKSCHYt10axmGhKq3WoJSvVpvhXmowNq7pZdRVowwtvBR/hi2LSP5srtctKkRT33T6/n8Kv1UGp7JW4A=="
+            "version": "5.65.15",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
+            "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -1888,9 +1903,9 @@
             "dev": true
         },
         "css-declaration-sorter": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.0.tgz",
-            "integrity": "sha512-jDfsatwWMWN0MODAFuHszfjphEXfNw9JUAhmY4pLu3TyTU+ohUpsbVtbU+1MZn4a47D9kqh03i4eyOm+74+zew==",
+            "version": "6.4.1",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
+            "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
             "dev": true,
             "requires": {}
         },
@@ -1930,24 +1945,24 @@
             "dev": true
         },
         "cssnano": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.0.tgz",
-            "integrity": "sha512-RGlcbzGhzEBCHuQe3k+Udyj5M00z0pm9S+VurHXFEOXxH+y0sVrJH2sMzoyz2d8N1EScazg+DVvmgyx0lurwwA==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
+            "integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
             "dev": true,
             "requires": {
-                "cssnano-preset-default": "^6.0.0",
+                "cssnano-preset-default": "^6.0.1",
                 "lilconfig": "^2.1.0"
             }
         },
         "cssnano-preset-default": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.0.tgz",
-            "integrity": "sha512-BDxlaFzObRDXUiCCBQUNQcI+f1/aX2mgoNtXGjV6PG64POcHoDUoX+LgMWw+Q4609QhxwkcSnS65YFs42RA6qQ==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
+            "integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
             "dev": true,
             "requires": {
                 "css-declaration-sorter": "^6.3.1",
                 "cssnano-utils": "^4.0.0",
-                "postcss-calc": "^8.2.3",
+                "postcss-calc": "^9.0.0",
                 "postcss-colormin": "^6.0.0",
                 "postcss-convert-values": "^6.0.0",
                 "postcss-discard-comments": "^6.0.0",
@@ -1955,7 +1970,7 @@
                 "postcss-discard-empty": "^6.0.0",
                 "postcss-discard-overridden": "^6.0.0",
                 "postcss-merge-longhand": "^6.0.0",
-                "postcss-merge-rules": "^6.0.0",
+                "postcss-merge-rules": "^6.0.1",
                 "postcss-minify-font-values": "^6.0.0",
                 "postcss-minify-gradients": "^6.0.0",
                 "postcss-minify-params": "^6.0.0",
@@ -2037,20 +2052,20 @@
             }
         },
         "domutils": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.0.1.tgz",
-            "integrity": "sha512-z08c1l761iKhDFtfXO04C7kTdPBLi41zwOZl00WS8b5eiaebNpY00HKbztwBq+e3vyqWNwWF3mP9YLUeqIrF+Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
+            "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
             "dev": true,
             "requires": {
                 "dom-serializer": "^2.0.0",
                 "domelementtype": "^2.3.0",
-                "domhandler": "^5.0.1"
+                "domhandler": "^5.0.3"
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.284",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.284.tgz",
-            "integrity": "sha512-M8WEXFuKXMYMVr45fo8mq0wUrrJHheiKZf6BArTKk9ZBYCKJEOU5H8cdWgDT+qCVZf7Na4lVUaZsA+h6uA9+PA==",
+            "version": "1.4.574",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
+            "integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
             "dev": true
         },
         "emoji-regex": {
@@ -2086,9 +2101,9 @@
             "integrity": "sha512-97PMG/aywoYpB4IvbvUJi0RQi8vearvU0oov1WW3k0WZPBMrTQVqekSX5CjSG/M4Q3i6A/0FKXC7RyAoAUUSPw=="
         },
         "fraction.js": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.2.0.tgz",
-            "integrity": "sha512-MhLuK+2gUcnZe8ZHlaaINnQLl0xRIGRfcGk2yl8xoQAfHrSsL3rYu6FCmBdkdbhc9EPlwyGHewaRsvwRMJtAlA==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
             "dev": true
         },
         "fsevents": {
@@ -2114,14 +2129,14 @@
             }
         },
         "iframe-resizer": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.2.tgz",
-            "integrity": "sha512-gOWo2hmdPjMQsQ+zTKbses08mDfDEMh4NneGQNP4qwePYujY1lguqP6gnbeJkf154gojWlBhIltlgnMfYjGHWA=="
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.7.tgz",
+            "integrity": "sha512-a3EGVScU9NtUpj6lWvGhVw3EfOw5AopRs5xGsQU385kWdgQt++OsD6PCnTV+8YkgBu/g28rLIh0EztFg9UQr1Q=="
         },
         "immutable": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.2.2.tgz",
-            "integrity": "sha512-fTMKDwtbvO5tldky9QZ2fMX7slR0mYpY5nbnFWYp0fOzDhHqhgIw9KoYgxLWsoNTS9ZHGauHj18DTyEw6BK3Og==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
+            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
             "dev": true
         },
         "is-binary-path": {
@@ -2161,9 +2176,9 @@
             "dev": true
         },
         "jquery": {
-            "version": "3.6.3",
-            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
-            "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.1.tgz",
+            "integrity": "sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg=="
         },
         "jquery-ui-dist": {
             "version": "1.13.2",
@@ -2192,9 +2207,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "3.2.1",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.2.1.tgz",
-            "integrity": "sha512-QrwPArQCNLAKGO/C+ZIilgIuDnEnKx5QYODdDtbFaxzsbZcc/a7WFq7MhsVYgRlwawLtvOUESTlfJ+hc/USqPg=="
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
+            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg=="
         },
         "mathjax": {
             "version": "3.2.2",
@@ -2214,9 +2229,9 @@
             "dev": true
         },
         "node-releases": {
-            "version": "2.0.8",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.8.tgz",
-            "integrity": "sha512-dFSmB8fFHEH/s81Xi+Y/15DQY6VHW81nXRj86EMSL3lmuTmK1e+aT4wrFCkTbm+gSwkw4KpX+rT/pMM2c1mF+A==",
+            "version": "2.0.13",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
+            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
             "dev": true
         },
         "normalize-path": {
@@ -2264,12 +2279,12 @@
             }
         },
         "postcss-calc": {
-            "version": "8.2.4",
-            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-8.2.4.tgz",
-            "integrity": "sha512-SmWMSJmB8MRnnULldx0lQIyhSNvuDl9HfrZkaqqE/WHAhToYsAvDq+yAsA/kIyINDszOp3Rh0GFoNuH5Ypsm3Q==",
+            "version": "9.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-calc/-/postcss-calc-9.0.1.tgz",
+            "integrity": "sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==",
             "dev": true,
             "requires": {
-                "postcss-selector-parser": "^6.0.9",
+                "postcss-selector-parser": "^6.0.11",
                 "postcss-value-parser": "^4.2.0"
             }
         },
@@ -2334,9 +2349,9 @@
             }
         },
         "postcss-merge-rules": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.0.tgz",
-            "integrity": "sha512-rCXkklftzEkniyv3f4mRCQzxD6oE4Quyh61uyWTUbCJ26Pv2hoz+fivJSsSBWxDBeScR4fKCfF3HHTcD7Ybqnw==",
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
+            "integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
             "dev": true,
             "requires": {
                 "browserslist": "^4.21.4",
@@ -2495,9 +2510,9 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.11",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
-            "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
+            "version": "6.0.13",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
+            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -2545,21 +2560,21 @@
             "dev": true
         },
         "rtlcss": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.0.0.tgz",
-            "integrity": "sha512-j6oypPP+mgFwDXL1JkLCtm6U/DQntMUqlv5SOhpgHhdIE+PmBcjrtAHIpXfbIup47kD5Sgja9JDsDF1NNOsBwQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/rtlcss/-/rtlcss-4.1.1.tgz",
+            "integrity": "sha512-/oVHgBtnPNcggP2aVXQjSy6N1mMAfHg4GSag0QtZBlD5bdDgAHwr4pydqJGd+SUCu9260+Pjqbjwtvu7EMH1KQ==",
             "dev": true,
             "requires": {
                 "escalade": "^3.1.1",
                 "picocolors": "^1.0.0",
-                "postcss": "^8.4.6",
+                "postcss": "^8.4.21",
                 "strip-json-comments": "^3.1.1"
             }
         },
         "sass": {
-            "version": "1.57.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.57.1.tgz",
-            "integrity": "sha512-O2+LwLS79op7GI0xZ8fqzF7X2m/m8WFfI02dHOdsK5R2ECeS5F62zrwg/relM1rjSLy7Vd/DiMNIvPrQGsA0jw==",
+            "version": "1.69.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -2650,13 +2665,13 @@
             }
         },
         "terser": {
-            "version": "5.16.1",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.16.1.tgz",
-            "integrity": "sha512-xvQfyfA1ayT0qdK47zskQgRZeWLoOQ8JQ6mIgRGVNwZKdQMU+5FkCBjmv4QjcrTzyZquRw2FVtlJSRUmMKQslw==",
+            "version": "5.24.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+            "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
             "dev": true,
             "requires": {
-                "@jridgewell/source-map": "^0.3.2",
-                "acorn": "^8.5.0",
+                "@jridgewell/source-map": "^0.3.3",
+                "acorn": "^8.8.2",
                 "commander": "^2.20.0",
                 "source-map-support": "~0.5.20"
             },
@@ -2679,9 +2694,9 @@
             }
         },
         "update-browserslist-db": {
-            "version": "1.0.10",
-            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.10.tgz",
-            "integrity": "sha512-OztqDenkfFkbSG+tRxBeAnCVPckDBcvibKd35yDONx6OU8N7sqgwc7rCbkJ/WcYtVRZ4ba68d6byhC21GFh7sQ==",
+            "version": "1.0.13",
+            "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.13.tgz",
+            "integrity": "sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==",
             "dev": true,
             "requires": {
                 "escalade": "^3.1.1",
@@ -2712,9 +2727,9 @@
             "dev": true
         },
         "yargs": {
-            "version": "17.6.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+            "version": "17.7.2",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+            "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
             "dev": true,
             "requires": {
                 "cliui": "^8.0.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -11,27 +11,27 @@
         "url": "https://github.com/openwebwork/webwork2"
     },
     "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.2.1",
-        "bootstrap": "~5.2.3",
-        "codemirror": "^5.65.11",
+        "@fortawesome/fontawesome-free": "^6.4.2",
+        "bootstrap": "~5.3.2",
+        "codemirror": "^5.65.15",
         "flatpickr": "^4.6.13",
-        "iframe-resizer": "^4.3.2",
-        "jquery": "^3.6.3",
+        "iframe-resizer": "^4.3.7",
+        "jquery": "^3.7.1",
         "jquery-ui-dist": "^1.13.2",
-        "luxon": "^3.2.1",
+        "luxon": "^3.4.3",
         "mathjax": "^3.2.2",
         "shortcut-buttons-flatpickr": "^0.4.0",
         "sortablejs": "^1.15.0"
     },
     "devDependencies": {
-        "autoprefixer": "^10.4.13",
+        "autoprefixer": "^10.4.16",
         "chokidar": "^3.5.3",
-        "cssnano": "^6.0.0",
+        "cssnano": "^6.0.1",
         "postcss": "^8.4.31",
-        "rtlcss": "^4.0.0",
-        "sass": "^1.57.1",
-        "terser": "^5.16.1",
-        "yargs": "^17.6.2"
+        "rtlcss": "^4.1.1",
+        "sass": "^1.69.5",
+        "terser": "^5.24.0",
+        "yargs": "^17.7.2"
     },
     "browserslist": [
         "last 10 Chrome versions",

--- a/htdocs/themes/math4/bootstrap.scss
+++ b/htdocs/themes/math4/bootstrap.scss
@@ -39,6 +39,7 @@ $breadcrumb-active-color: #495057;
 
 // Include the remainder of bootstrap's scss configuration
 @import "../../node_modules/bootstrap/scss/variables";
+@import "../../node_modules/bootstrap/scss/variables-dark";
 @import "../../node_modules/bootstrap/scss/maps";
 @import "../../node_modules/bootstrap/scss/mixins";
 @import "../../node_modules/bootstrap/scss/utilities";

--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -820,6 +820,10 @@ input.changed[type=text] { /* orange */
 			padding: 0 0 0 0.5rem;
 		}
 	}
+
+	.table {
+		--bs-table-bg: #f5f5f5;
+	}
 }
 
 .pdr_placeholder {


### PR DESCRIPTION
The following dependencies were updated.

* @fortawesome/fontawesome-free from 6.2.1 to 6.4.2
* bootstrap from 5.2.3 to 5.3.2
* codemirror from 5.65.11 to 5.65.13
* iframe-resizer from 4.3.2 to 4.3.7
* jquery from 3.6.3 to 3.7.1
* luxon from 3.2.1 to 3.4.3
* autoprefixer from 10.4.13 to 10.4.16
* cssnano from 6.0.0 to 6.0.1
* rtlcss from 4.0.0 to 4.1.1
* sass from 1.57.1 to 1.69.5
* terser from 5.16.1 to 5.24.0
* yargs from 17.6.2 to 17.7.2

These versions of these libraries are all compatible with webwork's current usage and require no changes to the code except bootstrap. That requires a few minor changes.

All of the dependencies are now at their newest versions except for codemirror which will need some work to update.

Note that the new version of bootstrap brings lots of improvements that could be beneficial.  In particular it has color modes.  It will take some work to implement (particularly with addressing accessibility concerns), but a dark mode could now be added.