### PR TITLE
Fix filtering the user list by permission level or status for other languages.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -287,10 +287,12 @@ sub filter_handler ($c) {
 		for my $userID (@{ $c->{allUserIDs} }) {
 			if ($field eq 'permission') {
 				push @matchingUserIDs, $userID
-					if ($permissionLabels{ $allUsers{$userID}{permission} } =~ /^$regex/i);
+					if $permissionLabels{ $allUsers{$userID}{permission} } =~ /^$regex/i
+					|| $c->maketext($permissionLabels{ $allUsers{$userID}{permission} }) =~ /^$regex/i;
 			} elsif ($field eq 'status') {
 				push @matchingUserIDs, $userID
-					if ($ce->status_abbrev_to_name($allUsers{$userID}{status}) =~ /^$regex/i);
+					if $ce->status_abbrev_to_name($allUsers{$userID}{status}) =~ /^$regex/i
+					|| $c->maketext($ce->status_abbrev_to_name($allUsers{$userID}{status})) =~ /^$regex/i;
 			} else {
 				push @matchingUserIDs, $userID if $allUsers{$userID}{$field} =~ /^$regex/i;
 			}

--- a/lib/WeBWorK/Localize.pm
+++ b/lib/WeBWorK/Localize.pm
@@ -68,7 +68,7 @@ our %Lexicon = (
 		x('ta'),    x('professor'), x('admin'),         x('nobody')
 	],
 
-	'_STATUS' => [ x('Enrolled'), x('Audit'), x('Drop'), x('Proctor') ],
+	'_STATUS' => [ x('Enrolled'), x('Audit'), x('Drop'), x('Proctor'), x('Observer') ],
 );
 
 1;


### PR DESCRIPTION
Currently when filtering by permission level or status the text entered in the "Filter by what text?" field is matched against the untranslated permission level name or status name.  As a result other languages must enter the English names for these to match what is displayed translated which is probably very confusing.  This just matches against the translated names.

This fixes issue #1093.