### PR TITLE
button to randomize individual seeds on set detail page for one user

### DIFF
--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -416,8 +416,25 @@
 	});
 
 	// Set up seed randomization buttons.
-	for (const btn of document.querySelectorAll('.randomize-seed-btn')) {
+	const randomize_seeds_button = document.getElementById('randomize_seeds');
+	const randomize_seed_buttons = document.querySelectorAll('.randomize-seed-btn');
+	if (randomize_seeds_button) {
+		randomize_seeds_button.addEventListener('click',
+			() => (randomize_seed_buttons.forEach((btn) => {
+				const exclude_correct = document.getElementById('excludeCorrect').checked;
+				const input = document.getElementById(btn.dataset.seedInput);
+				const stat  = document.getElementById(btn.dataset.statusInput).value || 0;
+				if (input) {
+					if (!exclude_correct || (exclude_correct && stat < 1)) {
+						input.value = Math.floor(Math.random() * 10000);
+					}
+				}
+			}))
+		)
+	}
+	for (const btn of randomize_seed_buttons) {
 		const input = document.getElementById(btn.dataset.seedInput);
 		if (input) btn.addEventListener('click', () => (input.value = Math.floor(Math.random() * 10000)));
 	}
+
 })();

--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -414,4 +414,10 @@
 		comboBoxSelect.addEventListener('change',
 			() => comboBoxText.value = comboBoxSelect.options[comboBoxSelect.selectedIndex].value);
 	});
+
+	// Set up seed randomization buttons.
+	for (const btn of document.querySelectorAll('.randomize-seed-btn')) {
+		const input = document.getElementById(btn.dataset.seedInput);
+		if (input) btn.addEventListener('click', () => (input.value = Math.floor(Math.random() * 10000)));
+	}
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -947,22 +947,22 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 			);
 			if ($field eq 'problem_seed') {
 				# Insert a randomization button
-				$inputType = Mojo::ByteStream->new($c->tag(
+				$inputType = $c->tag(
 					'div',
 					class => 'input-group input-group-sm',
 					style => 'min-width: 7rem',
-					$c->number_field(@field_args, min => 0)->to_string
-						. $c->tag(
+					$c->c(
+						$c->number_field(@field_args, min => 0),
+						$c->tag(
 							'button',
-							type    => 'button',
-							class   => 'btn btn-sm btn-secondary',
-							title   => 'randomize',
-							onclick =>
-							"(function() {document.getElementById('$recordType.$recordID.${field}_id').value = Math.floor(Math.random() * 10000);})();",
+							type  => 'button',
+							class => 'randomize-seed-btn btn btn-sm btn-secondary',
+							title => 'randomize',
+							data  => { seed_input => "$recordType.$recordID.${field}_id" },
 							$c->tag('i', class => 'fa-solid fa-shuffle')
 						)
-				))->html_unescape;
-				warn(ref($inputType));
+					)->join('')
+				);
 			} else {
 				$inputType = $c->text_field(@field_args);
 			}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -958,7 +958,10 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 							type  => 'button',
 							class => 'randomize-seed-btn btn btn-sm btn-secondary',
 							title => 'randomize',
-							data  => { seed_input => "$recordType.$recordID.${field}_id" },
+							data  => {
+								seed_input   => "$recordType.$recordID.problem_seed_id",
+								status_input => "$recordType.$recordID.status_id"
+							},
 							$c->tag('i', class => 'fa-solid fa-shuffle')
 						)
 					)->join('')

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -937,7 +937,7 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 			my $value = $forUsers ? $userValue : $globalValue;
 			$value = format_set_name_display($value =~ s/\s*,\s*/,/gr) if $field eq 'restricted_release';
 
-			$inputType = $c->text_field(
+			my @field_args = (
 				"$recordType.$recordID.$field", $value,
 				id    => "$recordType.$recordID.${field}_id",
 				data  => { override => "$recordType.$recordID.$field.override_id" },
@@ -945,6 +945,27 @@ sub fieldHTML ($c, $userID, $setID, $problemID, $globalRecord, $userRecord, $fie
 				$forUsers && $check ? (aria_labelledby => "$recordType.$recordID.$field.label") : (),
 				$field eq 'restricted_release' || $field eq 'source_file' ? (dir => 'ltr')      : ()
 			);
+			if ($field eq 'problem_seed') {
+				# Insert a randomization button
+				$inputType = Mojo::ByteStream->new($c->tag(
+					'div',
+					class => 'input-group input-group-sm',
+					style => 'min-width: 7rem',
+					$c->number_field(@field_args, min => 0)->to_string
+						. $c->tag(
+							'button',
+							type    => 'button',
+							class   => 'btn btn-sm btn-secondary',
+							title   => 'randomize',
+							onclick =>
+							"(function() {document.getElementById('$recordType.$recordID.${field}_id').value = Math.floor(Math.random() * 10000);})();",
+							$c->tag('i', class => 'fa-solid fa-shuffle')
+						)
+				))->html_unescape;
+				warn(ref($inputType));
+			} else {
+				$inputType = $c->text_field(@field_args);
+			}
 		}
 	} elsif ($choose) {
 		# If $field matches /:/, then multiple fields are used.

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -348,6 +348,17 @@
 						<%= maketext('Hide All') =%>
 					</button>
 				</div>
+			% } else {
+				<div class="input-group d-inline-flex flex-nowrap w-auto py-1 me-3">
+					<button id="randomize_seeds" type="button" class="btn btn-secondary">
+						<%= maketext('Randomize Seeds') =%>
+					</button>
+					<label class="form-check-label input-group-text ps-0">
+						<%= check_box excludeCorrect => 0,
+							id => 'excludeCorrect', class => 'form-check-input mx-2' =%>
+						<%= maketext('if status less than 1') =%>
+					</label>
+				</div>
 			% }
 			% if (!@editForUser) {
 				<div class="btn-group w-auto me-3 py-1">


### PR DESCRIPTION
This is a first stab at making it easier to randomize seeds, as discussed in #1151.

In a Set Detail page for one user:
* The seed field is changed to `type='number'` to give a quick way to shift a seed by 1 at a time, which I find helpful if there might be a need to revert to some previous seed.
* This (inelegantly in the code) puts a button next to the seed input field that you can use to re-randomize the seed.

After any changes, the Save button still needs to be used to submit the form.

<img width="641" alt="Screenshot 2023-12-05 at 10 28 55 AM" src="https://github.com/openwebwork/webwork2/assets/4732672/6d7798b0-04c6-43e3-a8bf-70d53629559f">

If this is on the right track, I will add a button somewhere at the top to randomize all of the seeds at once. If it is not too much clutter, there will be an option to only randomize those seeds with status less than 1.

A future PR will have a button on the "Set Detail page for multiple users" that randomizes seeds for all users and goes ahead with the action, reloading the page. And this PR will add a tool to Instructor Tools for doing the same thing, possible with multiple sets too.