### PR TITLE
Add problem seed to past answers.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1091,6 +1091,7 @@ async sub pre_header_initialize ($c) {
 				$pastAnswer->scores($scores);
 				$pastAnswer->answer_string($past_answers_string);
 				$pastAnswer->source_file($problem->source_file);
+				$pastAnswer->problem_seed($problem->problem_seed);
 				$db->addPastAnswer($pastAnswer);
 			}
 		}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -173,18 +173,12 @@ async sub initialize ($c) {
 				}
 
 				for my $pastAnswer (@pastAnswers) {
-					my $answerID = $pastAnswer->answer_id;
-					my $answers  = $pastAnswer->answer_string;
-					my $scores   = $pastAnswer->scores;
-					my $time     = $pastAnswer->timestamp;
-					my @scores   = split(//,   $scores);
-					my @answers  = split(/\t/, $answers);
-
-					$records{$studentUser}{$setName}{$problemNumber}{$answerID} = {
-						time        => $time,
-						answers     => [@answers],
+					$records{$studentUser}{$setName}{$problemNumber}{ $pastAnswer->answer_id } = {
+						time        => $pastAnswer->timestamp,
+						seed        => $pastAnswer->problem_seed,
+						answers     => [ split(/\t/, $pastAnswer->answer_string) ],
 						answerTypes => \@answerTypes,
-						scores      => [@scores],
+						scores      => [ split(//, $pastAnswer->scores) ],
 						comment     => $pastAnswer->comment_string // ''
 					};
 				}

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -27,7 +27,6 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-
 		answer_id      => { type => "INT AUTO_INCREMENT",    key => 1 },
 		user_id        => { type => "VARCHAR(100) NOT NULL", key => 1 },
 		set_id         => { type => "VARCHAR(100) NOT NULL", key => 1 },
@@ -37,7 +36,7 @@ BEGIN {
 		scores         => { type => "TINYTEXT" },
 		answer_string  => { type => "VARCHAR(5012)" },
 		comment_string => { type => "VARCHAR(5012)" },
-
+		problem_seed   => { type => "INT" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/PermissionLevel.pm
+++ b/lib/WeBWorK/DB/Record/PermissionLevel.pm
@@ -30,7 +30,6 @@ BEGIN {
 	__PACKAGE__->_fields(
 		user_id    => { type => "VARCHAR(100) NOT NULL", key => 1 },
 		permission => { type => "INT" },
-
 	);
 }
 

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -122,6 +122,7 @@ async sub process_and_log_answer ($c) {
 			$pastAnswer->scores($scores2);
 			$pastAnswer->answer_string($past_answers_string);
 			$pastAnswer->source_file($problem->source_file);
+			$pastAnswer->problem_seed($problem->problem_seed);
 			$db->addPastAnswer($pastAnswer);
 		}
 	}

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -109,7 +109,11 @@ sub putPastAnswer {
 
 	$pastAnswer->{user_id} = $params->{user_id} if $params->{user_id};
 
-	for ('set_id', 'problem_id', 'source_file', 'timestamp', 'scores', 'answer_string', 'comment_string') {
+	for (
+		'set_id', 'problem_id',    'source_file',    'timestamp',
+		'scores', 'answer_string', 'comment_string', 'problem_seed'
+		)
+	{
 		$pastAnswer->{$_} = $params->{$_} if defined($params->{$_});
 	}
 

--- a/templates/ContentGenerator/Instructor/ShowAnswers/past-answers-table.html.ep
+++ b/templates/ContentGenerator/Instructor/ShowAnswers/past-answers-table.html.ep
@@ -8,11 +8,11 @@
 		% for my $problemNumber (sort { $a <=> $b } keys %{ $records->{$studentUser}{$setName} }) {
 			% my @pastAnswerIDs = sort { $a <=> $b } keys %{ $records->{$studentUser}{$setName}{$problemNumber} };
 			% my $prettyProblemNumber = stash->{prettyProblemNumbers}{$setName}{$problemNumber};
-			<h3>
+			<h2 class="fs-3">
 				<%== maketext('Past Answers for [_1], set [_2], problem [_3]',
 					$studentUser, tag('span', dir => 'ltr', format_set_name_display($setName)), $prettyProblemNumber
 				) =%>
-			</h3>
+			</h2>
 			<div class="table-responsive">
 				<table class="past-answer-table table table-striped" dir="ltr">
 					% my $previousTime = -1;
@@ -27,8 +27,20 @@
 						%
 						<tr <%== $record{time} - $previousTime > $ce->{sessionKeyTimeout}
 							? 'class="table-rule"' : '' %>>
+							% # Show the problem seed for instructors.
+							% if ($isInstructor) {
+								<td class="px-3">
+									<small>
+										<%= maketext(
+											'Seed: [_1]',
+											defined $record{seed} && $record{seed} ne ''
+												?  $record{seed} : maketext('unknown')
+										) %>
+									</small>
+								</td>
+							% }
 							<td class="px-3"><small><%= $c->formatDateTime($record{time}) %></small></td>
-							% for (my $i = 0; $i <= $upper_limit; $i++) {
+							% for (my $i = 0; $i <= $upper_limit; ++$i) {
 								% my $answer     = $answers[$i]             // '';
 								% my $answerType = $record{answerTypes}[$i] // '';
 								% my $score      = shift(@scores);


### PR DESCRIPTION
Add a `problem_seed` column to the `past_answer` database table.  This is displayed in the first column of the table shown on the "Answer Log" page.  Since that table is not a fully qualified data table and is missing headers, it is displayed in the table as "Seed: 123".  If a problem does not have a seed (because it is from a past answer before this pull request like an archived course), then "Seed: unknown" is shown.