### PR TITLE
Remove the checkboxes for showing correct answers and solutions.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -205,6 +205,14 @@ $pg{options}{periodicRandomizationPeriod} = 5;
 # and before a new version is requested.
 $pg{options}{showCorrectOnRandomize} = 0;
 
+###############################################################################
+# automaticAnswerFeedback
+################################################################################
+# If set, then answer feedback is automatically shown after answers are
+# available for the assignment. This is present in problems when a student opens
+# the problem without the student needing to click the "Check Answers" button.
+$pg{options}{automaticAnswerFeedback} = 1;
+
 ################################################################################
 # Single Problem Grader
 ################################################################################
@@ -2076,6 +2084,17 @@ $ConfigValues = [
 			),
 			type => 'popuplist',
 			values => ['preview', 'submit', 'conservative']
+		},
+		{
+			var  => 'pg{options}{automaticAnswerFeedback}',
+			doc  => x('Show automatic answer feedback when answers are available.'),
+			doc2 => x(
+				'Answer feedback will be available in problems after answers are available. Students will not even '
+					. 'need to click "Submit Answers" to make this feedback appear. Furthermore, the '
+					. '$showPartialCorrectAnswers variable set in some problems that prevents showing which of the '
+					. 'answers are correct is ignored.'
+			),
+			type => 'boolean'
 		}
 	],
 	[

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -208,9 +208,10 @@ $pg{options}{showCorrectOnRandomize} = 0;
 ###############################################################################
 # automaticAnswerFeedback
 ################################################################################
-# If set, then answer feedback is automatically shown after answers are
-# available for the assignment. This is present in problems when a student opens
-# the problem without the student needing to click the "Check Answers" button.
+# If set to 1, then answer feedback is automatically shown when returning to an
+# answered problem or after answers are available for the assignment. This is
+# present in problems when a student opens the problem without the student
+# needing to click the "Check Answers" button.
 $pg{options}{automaticAnswerFeedback} = 1;
 
 ################################################################################
@@ -2087,15 +2088,15 @@ $ConfigValues = [
 		},
 		{
 			var  => 'pg{options}{automaticAnswerFeedback}',
-			doc  => x('Show automatic answer feedback when answers are available.'),
+			doc  => x('Show automatic answer feedback'),
 			doc2 => x(
-				'Answer feedback will be available in problems after answers are available. Students will not even '
-					. 'need to click "Submit Answers" to make this feedback appear. Furthermore, the '
-					. '$showPartialCorrectAnswers variable set in some problems that prevents showing which of the '
-					. 'answers are correct is ignored.'
+				'Answer feedback will be available in problems when returning to a previously worked problem and '
+					. 'after answers are available. Students will not need to click "Submit Answers" to make this '
+					. 'feedback appear. Furthermore, the $showPartialCorrectAnswers variable set in some problems '
+					. 'that prevents showing which of the answers are correct is ignored after the answer date.'
 			),
 			type => 'boolean'
-		}
+		},
 	],
 	[
 		x('E-Mail'),

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -206,13 +206,18 @@ $pg{options}{periodicRandomizationPeriod} = 5;
 $pg{options}{showCorrectOnRandomize} = 0;
 
 ###############################################################################
-# automaticAnswerFeedback
+# answer feedback options
 ################################################################################
+
 # If set to 1, then answer feedback is automatically shown when returning to an
 # answered problem or after answers are available for the assignment. This is
 # present in problems when a student opens the problem without the student
 # needing to click the "Check Answers" button.
 $pg{options}{automaticAnswerFeedback} = 1;
+
+# If set to 1, then a "Reveal" button must be clicked to reveal correct answers
+# even after the answer date.
+$pg{options}{correctRevealBtnAlways} = 0;
 
 ################################################################################
 # Single Problem Grader
@@ -2097,6 +2102,16 @@ $ConfigValues = [
 			),
 			type => 'boolean'
 		},
+		{
+			var  => 'pg{options}{correctRevealBtnAlways}',
+			doc  => x('Show correct answer "Reveal" button always'),
+			doc2 => x(
+				'A "Reveal" button must be clicked to make a correct answer visible any time that correct answers for '
+					. ' a problem are shown. Note that this is always the case for instructors before answers are '
+					. ' available to students, and in "Show Me Another" problems.'
+			),
+			type => 'boolean'
+		}
 	],
 	[
 		x('E-Mail'),

--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -294,8 +294,6 @@
 	}, { passive: true });
 
 	// Send a request to the webwork webservice and render a problem.
-	const basicWebserviceURL = `${webworkConfig?.webwork_url ?? '/webwork2'}/render_rpc`;
-
 	const render = (id) => new Promise((resolve) => {
 		const renderArea = document.getElementById(`psr_render_area_${id}`);
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1446,6 +1446,13 @@ sub warningMessage ($c) {
 # hash of parameters from the input form that need to be passed to the translator, and $mergedProblem
 # is what we'd expect.
 async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem) {
+	my $showReturningFeedback =
+		!($c->{submitAnswers} || $c->{previewAnswers} || $c->{checkAnswers})
+		&& $c->{will}{showOldAnswers}
+		&& $c->ce->{pg}{options}{automaticAnswerFeedback}
+		&& $c->{can}{showProblemScores}
+		&& $mergedProblem->num_correct + $mergedProblem->num_incorrect > 0;
+
 	my $pg = await renderPG(
 		$c,
 		$effectiveUser,
@@ -1454,17 +1461,20 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 		$set->psvn,
 		$formFields,
 		{
-			displayMode             => $c->{displayMode},
-			showHints               => $c->{will}{showHints},
-			showSolutions           => $c->{will}{showSolutions},
-			refreshMath2img         => $c->{will}{showHints} || $c->{will}{showSolutions},
-			processAnswers          => 1,
-			QUIZ_PREFIX             => 'Q' . sprintf('%04d', $mergedProblem->problem_id) . '_',
-			useMathQuill            => $c->{will}{useMathQuill},
-			useMathView             => $c->{will}{useMathView},
-			forceScaffoldsOpen      => 1,
-			isInstructor            => $c->authz->hasPermissions($c->{userID}, 'view_answers'),
-			showFeedback            => $c->{submitAnswers} || $c->{previewAnswers} || $c->{will}{checkAnswers},
+			displayMode        => $c->{displayMode},
+			showHints          => $c->{will}{showHints},
+			showSolutions      => $c->{will}{showSolutions},
+			refreshMath2img    => $c->{will}{showHints} || $c->{will}{showSolutions},
+			processAnswers     => 1,
+			QUIZ_PREFIX        => 'Q' . sprintf('%04d', $mergedProblem->problem_id) . '_',
+			useMathQuill       => $c->{will}{useMathQuill},
+			useMathView        => $c->{will}{useMathView},
+			forceScaffoldsOpen => 1,
+			isInstructor       => $c->authz->hasPermissions($c->{userID}, 'view_answers'),
+			showFeedback       => $c->{submitAnswers}
+				|| $c->{previewAnswers}
+				|| $c->{will}{checkAnswers}
+				|| $showReturningFeedback,
 			showAttemptAnswers      => $c->ce->{pg}{options}{showEvaluatedAnswers},
 			showAttemptPreviews     => 1,
 			showAttemptResults      => !$c->{previewAnswers} && $c->{can}{showProblemScores},

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1487,7 +1487,7 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 				$c->{will}{showProblemGrader} ? 2
 				: !$c->{previewAnswers} && $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet})
 				? ($c->ce->{pg}{options}{correctRevealBtnAlways} ? 1 : 2)
-				: ($c->{submitAnswers} || $c->{will}{checkAnswers}) && $c->{will}{showCorrectAnswers} ? 1
+				: !$c->{previewAnswers} && $c->{will}{showCorrectAnswers} ? 1
 				: 0
 			),
 			debuggingOptions => getTranslatorDebuggingOptions($c->authz, $c->{userID})

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -692,10 +692,8 @@ async sub pre_header_initialize ($c) {
 		showProblemGrader => $c->param('showProblemGrader')
 			|| 0,
 		# Hints are not yet implemented in gateway quzzes.
-		showHints => 0,
-		# showProblemGrader implies showSolutions.  Another convenience for grading.
-		showSolutions => $c->param('showProblemGrader')
-			|| ($c->param('showSolutions') && ($c->{submitAnswers} || $c->{checkAnswers})),
+		showHints     => 0,
+		showSolutions => 1,
 		recordAnswers => $c->{submitAnswers} && !$authz->hasPermissions($userID, 'avoid_recording_answers'),
 		# we also want to check answers if we were checking answers and are switching between pages
 		checkAnswers => $c->{checkAnswers},

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -74,23 +74,41 @@ sub can_showCorrectAnswers ($c, $user, $permissionLevel, $effectiveUser, $set, $
 	my $attemptsPerVersion = $set->attempts_per_version || 0;
 	my $attemptsUsed       = $problem->num_correct + $problem->num_incorrect + ($c->{submitAnswers} ? 1 : 0);
 
-	# This is complicated by trying to address hiding scores by problem.  That is, if $set->hide_score_by_problem and
-	# $set->hide_score are both set, then we should allow scores to be shown, but not show the score on any individual
-	# problem.  To deal with this, we make can_showCorrectAnswers give the least restrictive view of hiding, and then
-	# filter scores for the problems themselves later.
 	return (
 		(
-			(
-				after($set->answer_date, $c->submitTime) || ($attemptsUsed >= $attemptsPerVersion
-					&& $attemptsPerVersion != 0
-					&& $set->due_date == $set->answer_date)
-			)
-				|| $authz->hasPermissions($user->user_id, 'show_correct_answers_before_answer_date')
+			$authz->hasPermissions($user->user_id, 'show_correct_answers_before_answer_date')
+				|| (
+					after($set->answer_date, $c->submitTime)
+					|| ($attemptsUsed >= $attemptsPerVersion
+						&& $attemptsPerVersion != 0
+						&& $set->due_date == $set->answer_date)
+				)
+		)
+			&& $c->can_showProblemScores($user, $permissionLevel, $effectiveUser, $set, $problem, $tmplSet)
+	);
+}
+
+# This version is the same as the above version except that it ignores elevated permisions. So it will be true if this
+# set is in the state that anyone can show correct answers regardless of if they have the
+# show_correct_answers_before_answer_date or view_hidden_work permissions.  In this case, feedback is shown even without
+# a form submission, and correct answers are shown in the feedback, if the $pg{options}{automaticAnswerFeedback} option
+# is set in the course configuration.
+sub can_showCorrectAnswersForAll ($c, $set, $problem, $tmplSet) {
+	my $attemptsPerVersion = $set->attempts_per_version || 0;
+	my $attemptsUsed       = $problem->num_correct + $problem->num_incorrect + ($c->{submitAnswers} ? 1 : 0);
+
+	return (
+		(
+			after($set->answer_date, $c->submitTime) || ($attemptsUsed >= $attemptsPerVersion
+				&& $attemptsPerVersion != 0
+				&& $set->due_date == $set->answer_date)
 		)
 			&& (
-				$authz->hasPermissions($user->user_id, 'view_hidden_work')
-				|| $set->hide_score_by_problem eq 'N' && ($set->hide_score eq 'N'
-					|| ($set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date, $c->submitTime)))
+				(
+					$set->hide_score eq 'N'
+					|| ($set->hide_score eq 'BeforeAnswerDate' && after($tmplSet->answer_date, $c->submitTime))
+				)
+				&& $set->hide_score_by_problem eq 'N'
 			)
 	);
 }
@@ -108,10 +126,7 @@ sub can_showHints ($c) { return 1; }
 
 sub can_showSolutions ($c, $user, $permissionLevel, $effectiveUser, $set, $problem, $tmplSet) {
 	my $authz = $c->authz;
-
 	return 1 if $authz->hasPermissions($user->user_id, 'always_show_solution');
-
-	# This is the same as can_showCorrectAnswers.
 	return $c->can_showCorrectAnswers($user, $permissionLevel, $effectiveUser, $set, $problem, $tmplSet);
 }
 
@@ -684,34 +699,15 @@ async sub pre_header_initialize ($c) {
 
 	# What does the user want to do?
 	my %want = (
-		showOldAnswers => $user->showOldAnswers ne '' ? $user->showOldAnswers : $ce->{pg}{options}{showOldAnswers},
-		# showProblemGrader implies showCorrectAnswers.  This is a convenience for grading.
-		showCorrectAnswers => ($c->param('showProblemGrader') || 0)
-			|| ($c->param('showCorrectAnswers') && ($c->{submitAnswers} || $c->{checkAnswers}))
-			|| 0,
-		showProblemGrader => $c->param('showProblemGrader')
-			|| 0,
-		# Hints are not yet implemented in gateway quzzes.
-		showHints     => 0,
-		showSolutions => 1,
-		recordAnswers => $c->{submitAnswers} && !$authz->hasPermissions($userID, 'avoid_recording_answers'),
-		# we also want to check answers if we were checking answers and are switching between pages
-		checkAnswers => $c->{checkAnswers},
-		useMathView  => $user->useMathView ne ''  ? $user->useMathView  : $ce->{pg}{options}{useMathView},
-		useMathQuill => $user->useMathQuill ne '' ? $user->useMathQuill : $ce->{pg}{options}{useMathQuill},
-	);
-
-	# Are certain options enforced?
-	my %must = (
-		showOldAnswers     => 0,
-		showCorrectAnswers => 0,
-		showProblemGrader  => 0,
-		showHints          => 0,
-		showSolutions      => 0,
-		recordAnswers      => 0,
-		checkAnswers       => 0,
-		useMathView        => 0,
-		useMathQuill       => 0,
+		showOldAnswers     => $user->showOldAnswers ne '' ? $user->showOldAnswers : $ce->{pg}{options}{showOldAnswers},
+		showCorrectAnswers => 1,
+		showProblemGrader  => $c->param('showProblemGrader') || 0,
+		showHints          => 0,    # Hints are not yet implemented in gateway quzzes.
+		showSolutions      => 1,
+		recordAnswers      => $c->{submitAnswers} && !$authz->hasPermissions($userID, 'avoid_recording_answers'),
+		checkAnswers       => $c->{checkAnswers},
+		useMathView        => $user->useMathView ne ''  ? $user->useMathView  : $ce->{pg}{options}{useMathView},
+		useMathQuill       => $user->useMathQuill ne '' ? $user->useMathQuill : $ce->{pg}{options}{useMathQuill},
 	);
 
 	# Does the user have permission to use certain options?
@@ -734,10 +730,9 @@ async sub pre_header_initialize ($c) {
 	);
 
 	# Final values for options
-	my %will = map { $_ => $can{$_} && ($must{$_} || $want{$_}) } keys %must;
+	my %will = map { $_ => $can{$_} && $want{$_} } keys %can;
 
 	$c->{want} = \%want;
-	$c->{must} = \%must;
 	$c->{can}  = \%can;
 	$c->{will} = \%will;
 
@@ -1473,11 +1468,18 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 			showAttemptAnswers      => $c->ce->{pg}{options}{showEvaluatedAnswers},
 			showAttemptPreviews     => 1,
 			showAttemptResults      => !$c->{previewAnswers} && $c->{can}{showProblemScores},
-			forceShowAttemptResults => $c->{will}{showProblemGrader},
-			showMessages            => 1,
-			showCorrectAnswers => ($c->{submitAnswers} || $c->{will}{checkAnswers} || $c->{will}{showProblemGrader})
-			? $c->{will}{showCorrectAnswers}
-			: 0,
+			forceShowAttemptResults => $c->{will}{showProblemGrader}
+				|| ($c->ce->{pg}{options}{automaticAnswerFeedback}
+					&& !$c->{previewAnswers}
+					&& $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet})),
+			showMessages       => 1,
+			showCorrectAnswers => (
+				$c->{will}{showProblemGrader}
+					|| (!$c->{previewAnswers} && $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet}))
+				? 2
+				: ($c->{submitAnswers} || $c->{will}{checkAnswers}) && $c->{will}{showCorrectAnswers} ? 1
+				: 0
+			),
 			debuggingOptions => getTranslatorDebuggingOptions($c->authz, $c->{userID})
 		},
 	);

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1484,9 +1484,9 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 					&& $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet})),
 			showMessages       => 1,
 			showCorrectAnswers => (
-				$c->{will}{showProblemGrader}
-					|| (!$c->{previewAnswers} && $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet}))
-				? 2
+				$c->{will}{showProblemGrader} ? 2
+				: !$c->{previewAnswers} && $c->can_showCorrectAnswersForAll($set, $c->{problem}, $c->{tmplSet})
+				? ($c->ce->{pg}{options}{correctRevealBtnAlways} ? 1 : 2)
 				: ($c->{submitAnswers} || $c->{will}{checkAnswers}) && $c->{will}{showCorrectAnswers} ? 1
 				: 0
 			),

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -600,7 +600,7 @@ async sub pre_header_initialize ($c) {
 				$will{showProblemGrader} || ($c->{submitAnswers} && $c->{showCorrectOnRandomize}) ? 2
 				: !$c->{previewAnswers} && after($c->{set}->answer_date, $c->submitTime)
 				? ($ce->{pg}{options}{correctRevealBtnAlways} ? 1 : 2)
-				: (($c->{submitAnswers} || $will{checkAnswers}) && $will{showCorrectAnswers}) ? 1
+				: !$c->{previewAnswers} && $will{showCorrectAnswers} ? 1
 				: 0
 			),
 			debuggingOptions => getTranslatorDebuggingOptions($authz, $userID)

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -597,9 +597,9 @@ async sub pre_header_initialize ($c) {
 					&& after($c->{set}->answer_date, $c->submitTime)),
 			showMessages       => 1,
 			showCorrectAnswers => (
-				$will{showProblemGrader}
-					|| (!$c->{previewAnswers} && after($c->{set}->answer_date, $c->submitTime))
-					|| ($c->{submitAnswers}   && $c->{showCorrectOnRandomize}) ? 2
+				$will{showProblemGrader} || ($c->{submitAnswers} && $c->{showCorrectOnRandomize}) ? 2
+				: !$c->{previewAnswers} && after($c->{set}->answer_date, $c->submitTime)
+				? ($ce->{pg}{options}{correctRevealBtnAlways} ? 1 : 2)
 				: (($c->{submitAnswers} || $will{checkAnswers}) && $will{showCorrectAnswers}) ? 1
 				: 0
 			),

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -235,7 +235,7 @@ async sub renderProblem {
 		showAttemptResults      => $rh->{showAttemptResults} // ($rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		forceShowAttemptResults => $rh->{forceShowAttemptResults},
 		showMessages       => $rh->{showMessages}       // ($rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
-		showCorrectAnswers => $rh->{showCorrectAnswers} // $rh->{WWcorrectAns},
+		showCorrectAnswers => $rh->{showCorrectAnswers} // ($rh->{WWcorrectAns} ? 2 : 0),
 		debuggingOptions   => {
 			show_resource_info          => $rh->{show_resource_info}          // 0,
 			view_problem_debugging_info => $rh->{view_problem_debugging_info} // 0,

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -564,6 +564,17 @@
 						<div class="mb-2"><b><%== maketext('Note: [_1]', tag('i', $pg->{result}{msg})) %></b></div>
 					% }
 					%
+					% if ($pg->{flags}{solutionExists} && $authz->hasPermissions($userID, 'always_show_solution')) {
+						<p>
+							<b><%= maketext('Note') %>:</b>
+							<i>
+								<%= maketext('The solution shown is an instructor preview and '
+									. 'will only be shown to students when answers are available.'
+								) =%>
+							</i>
+						</p>
+					% }
+					%
 					<div class="text-end mb-2">
 						<%= link_to maketext('preview answers') => '#',
 							class => 'gateway-preview-btn btn btn-secondary',
@@ -613,15 +624,6 @@
 						<input name="showCorrectAnswers" type="checkbox" class="form-check-input"
 							<%= $c->{want}{showCorrectAnswers} || $c->{want}{showProblemGrader} ? 'checked' : '' %>>
 						<%= maketext('Show correct answers') %>
-					</label>
-				</div>
-			% }
-			% if ($c->{can}{showSolutions}) {
-				<div class="form-check">
-					<label class="form-check-label">
-						<input name="showSolutions" type="checkbox" class="form-check-input"
-							<%= $c->{will}{showSolutions} || $c->{want}{showProblemGrader} ? 'checked' : '' %>>
-						<%= maketext('Show Solutions') %>
 					</label>
 				</div>
 			% }

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -345,7 +345,7 @@
 		<div class="row">
 			<div class="col-md-10 mb-1">
 				<div class="alert alert-info p-1 mb-0">
-					<%= maketext('The test (which is version [_1]) may  no longer be submitted for a grade.',
+					<%= maketext('The test (which is version [_1]) may no longer be submitted for a grade.',
 							$setVersionID)
 						. ($c->{can}{showScore} ? (' ' . maketext('You may still check your answers.')) : '') %>
 				</div>
@@ -618,15 +618,6 @@
 		<div class="gwDivider"></div>
 		%
 		<div class="checkboxes-container col-12 my-2">
-			% if ($c->{can}{showCorrectAnswers}) {
-				<div class="form-check">
-					<label class="form-check-label">
-						<input name="showCorrectAnswers" type="checkbox" class="form-check-input"
-							<%= $c->{want}{showCorrectAnswers} || $c->{want}{showProblemGrader} ? 'checked' : '' %>>
-						<%= maketext('Show correct answers') %>
-					</label>
-				</div>
-			% }
 			% if ($c->{can}{showProblemGrader}) {
 				<div class="form-check">
 					<label class="form-check-label">

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -575,6 +575,23 @@
 						</p>
 					% }
 					%
+					% if (
+						% (
+							% $authz->hasPermissions($userID, 'show_correct_answers_before_answer_date')
+							% || $authz->hasPermissions($userID, 'view_hidden_work')
+						% )
+						% && !$c->can_showCorrectAnswersForAll($c->{set}, $c->{problem}, $c->{tmplSet})
+						% )
+					% {
+						<p>
+							<b><%= maketext('Note') %>:</b>
+							<i>
+								<%= maketext('The correct answers shown in feedback are instructor previews and '
+									. 'will only be shown to students when answers are available.') =%>
+							</i>
+						</p>
+					% }
+					%
 					<div class="text-end mb-2">
 						<%= link_to maketext('preview answers') => '#',
 							class => 'gateway-preview-btn btn btn-secondary',

--- a/templates/ContentGenerator/Problem/checkboxes.html.ep
+++ b/templates/ContentGenerator/Problem/checkboxes.html.ep
@@ -1,24 +1,13 @@
 % my %can  = %{ $c->{can} };
 % my %will = %{ $c->{will} };
 %
-% if ($can{showCorrectAnswers}
-	% || $can{showProblemGrader}
+% if ($can{showProblemGrader}
 	% || $can{showAnsGroupInfo}
 	% || $can{showAnsHashInfo}
 	% || $can{showPGInfo}
 	% || $can{showResourceInfo})
 % {
 	<span class="me-2"><%= maketext('Show:') %></span>
-% }
-%
-% if ($can{showCorrectAnswers}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showCorrectAnswers => 1, id => 'showCorrectAnswers_id', class => 'form-check-input',
-				$will{showCorrectAnswers} ? (checked => undef) : () =%>
-			<%= maketext('Correct Answers') =%>
-		</label>
-	</div>
 % }
 %
 % if ($can{showProblemGrader} && !$will{showMeAnother}) {

--- a/templates/ContentGenerator/Problem/messages.html.ep
+++ b/templates/ContentGenerator/Problem/messages.html.ep
@@ -43,8 +43,18 @@
 		<b><%= maketext('Note') %>:</b>
 		<i>
 			<%= maketext('The solution shown is an instructor preview and '
-				. 'will only be shown to students after the due date.'
+				. 'will only be shown to students after the answer date.'
 			) =%>
+		</i>
+	</p>
+% }
+%
+% if ($authz->hasPermissions($c->{userID}, 'show_correct_answers_before_answer_date')) {
+	<p>
+		<b><%= maketext('Note') %>:</b>
+		<i>
+			<%= maketext('The correct answers shown in feedback are instructor previews and '
+				. 'will only be shown to students after the answer date.') =%>
 		</i>
 	</p>
 % }

--- a/templates/ContentGenerator/ShowMeAnother/messages.html.ep
+++ b/templates/ContentGenerator/ShowMeAnother/messages.html.ep
@@ -5,8 +5,8 @@
 % }
 %
 % if ($c->{pg}{flags}{hintExists}
-	% && $authz->hasPermissions($c->{userName}, 'always_show_hint')
-	% && !$c->{options}{showHints}) {
+	% && $authz->hasPermissions($c->{userID}, 'always_show_hint')
+	% && !$c->{showMeAnother}{options}{showHints}) {
 	% my $showHintsAfter =
 		% $c->{set}->hide_hint                 ? -1
 		% : $c->{problem}->showHintsAfter > -2 ? $c->{problem}->showHintsAfter
@@ -25,14 +25,25 @@
 % }
 %
 % if ($c->{pg}{flags}{solutionExists}
-	% && $authz->hasPermissions($c->{userName}, 'always_show_solution')
-	% && !$c->{options}{showSolutions}) {
+	% && $authz->hasPermissions($c->{userID}, 'always_show_solution')
+	% && !$c->{showMeAnother}{options}{showSolutions}) {
 	<p>
 		<b><%= maketext('Note') %>:</b>
 		<i>
 			<%= maketext('The solution shown is an instructor preview and '
-				. 'will only be shown to students after the due date.'
+				. 'will only be shown to students after the answer date.'
 			) =%>
+		</i>
+	</p>
+% }
+%
+% if ($authz->hasPermissions($c->{userID}, 'show_correct_answers_before_answer_date')
+	% && !$c->{showMeAnother}{options}{showCorrect}) {
+	<p>
+		<b><%= maketext('Note') %>:</b>
+		<i>
+			<%= maketext('The correct answers shown in feedback are instructor previews and '
+				. 'will only be shown to students after the answer date.') =%>
 		</i>
 	</p>
 % }


### PR DESCRIPTION
Remove the "Show solutions" checkbox for tests (a.k.a. gateway quizzes) Solutions are just shown when they can be.  This is the same as this is for homework problems.  There is just no reason for the checkbox in tests either.

The show correct answers checkbox is also removed for both homework and tests.  Correct answers are just shown when they "can" be.  However, there are two cases in which I don't think that it is appropriate to show the correct answers without any user interaction.  This is where the corresponding PG pull request (https://github.com/openwebwork/pg/pull/982) that adds a "Reveal" button for correct answers comes in.
    
The first case is in "Show Me Another" problems when the course configuration is set to allow correct answers to be shown for these problems.  Students should be able to see feedback messages and such without seeing the correct answer.  The point of these problems is for students to obtain practice working problems without simply looking at the correct answers, so an additional step should be needed to see the correct answer.
    
The second case is for instructors viewing problems before answers are available for students.  The instructor may be viewing the problem with students present (for example, when working problems in class) and may want to be able to show messages and such without showing the correct answer.
    
There is a new course configuration option in "Problem Display/Answer Checking".  If this option is true, then answer feedback is immediately available in problems after answers are available. Students do not even need to click "Submit Answers" to make this feedback appear. Furthermore, the $showPartialCorrectAnswers variable set in some problems that prevents showing which of the answers are correct is ignored if this option is true. This option is true by default, but if it is believed that the majority won't want this, then it can be switched to false.  This option was actually added as an afterthought.  It was initially implemented with automatic feedback after answers are available with no option to disable that behavior. I would also be happy reverting to that if we feel that this is something everyone will want.
    
This automatic feedback is particularly useful for tests that have multiple pages. Currently you need to change the page, click the show correct answers checkbox, then click check test, and that has to be repeated for each page.  That is a real pain if each problem is on its own page. The check box is gone, but you still have to click check test after changing pages.  With this option the feedback is there with each page change (the same as it was before when the problem grader is enabled).
    
Also the %must hash has been removed.  It was not used at all except in Problem.pm for one permission, and that usage was incorrect.  It resulted in recordAnswers always being forced to be true with the default setting of avoid_recording_answers set to "nobody".  The %must hash can not force an option to be disabled. It can only force it to be enabled.  This permission was done correctly in the GatewayQuiz.pm module, so that approach is now used in Problem.pm also.

Edit: This now takes the automatic feedback option a bit further (as requested by @dlglin).  Now the automatic feedback is shown anytime that a student returns to a problem that has been previously answered.

Also there is another new option added.  If the `$pg{options}{correctRevealBtnAlways}` option is true, then the "Reveal" button will be shown instead of the correct answer being immediately visible anytime that correct answers are available in the feedback (except when the problem grader is active and the last time that a student sees a problem before needing to request a new problem version when problem randomization and show correct on randomize are enabled).  This option is false by default.  This was also requested by @dlglin.