### PR TITLE
Switch to using Github links for bug reporting.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -324,8 +324,9 @@ $webworkDirs{localize} = "$webworkDirs{root}/lib/WeBWorK/Localize";
 # URL of general WeBWorK documentation.
 $webworkURLs{docs}          = "https://webwork.maa.org";
 
-# URL of WeBWorK Bugzilla database.
-$webworkURLs{bugReporter}   = "https://bugs.webwork.maa.org/enter_bug.cgi";
+# URLs for new issues in Github.
+$webworkURLs{webwork2BugReporter} = "https://github.com/openwebwork/webwork2/issues/new";
+$webworkURLs{OPLBugReporter}      = "https://github.com/openwebwork/webwork-open-problem-library/issues/new";
 
 # URL of WeBWorK on GitHub
 $webworkURLs{GitHub}        = "https://github.com/openwebwork";

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -39,7 +39,9 @@
 			</li>
 		% }
 		<li class="list-group-item nav-item"><%= $makelink->('instructor_user_list') %></li>
-		<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+		% if ($authz->hasPermissions($userID, 'send_mail')) {
+			<li class="list-group-item nav-item"><%= $makelink->('instructor_mail_merge') %></li>
+		% }
 		<li class="list-group-item nav-item">
 			<%= $makelink->(
 				'instructor_file_manager',
@@ -49,8 +51,11 @@
 		<li class="list-group-item nav-item">
 			<%= $c->helpMacro('admin_links', { label => maketext('Help'), class => 'nav-link' }) =%>
 		</li>
-		<li class="list-group-item nav-item">
-			<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
-		</li>
+		% if ($ce->{webworkURLs}{webwork2BugReporter} && $authz->hasPermissions($userID, 'report_bugs')) {
+			<li class="list-group-item nav-item">
+				<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{webwork2BugReporter},
+					target => 'bug_report', class => 'nav-link' =%>
+			</li>
+		% }
 	% }
 </ul>

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -2,8 +2,9 @@
 %
 % if ($ce->{courseName} eq 'admin') {
 	<%= include 'ContentGenerator/Base/admin_links' =%>
-	% next;
+	% last;
 % }
+%
 <ul class="nav flex-column">
 	% if (defined $courseID && $authen->was_verified) {
 		% # Assignments or Course Administration
@@ -366,12 +367,10 @@
 			</li>
 		% }
 		%
-		% if (exists $ce->{webworkURLs}{bugReporter}
-			% && $ce->{webworkURLs}{bugReporter} ne ''
-			% && $authz->hasPermissions($userID, 'report_bugs'))
-		% {
+		% if ($ce->{webworkURLs}{webwork2BugReporter} && $authz->hasPermissions($userID, 'report_bugs')) {
 			<li class="list-group-item nav-item">
-				<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{bugReporter}, class => 'nav-link' =%>
+				<%= link_to maketext('Report bugs') => $ce->{webworkURLs}{webwork2BugReporter},
+					target => 'bug_report', class => 'nav-link' =%>
 			</li>
 		% }
 	% }

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -1,3 +1,5 @@
+% use Mojo::URL;
+%
 % use WeBWorK::Utils qw(not_blank x format_set_name_display getAssetURL);
 % use WeBWorK::HTML::CodeMirrorEditor
 	% qw(generate_codemirror_html generate_codemirror_controls_html output_codemirror_static_files);
@@ -136,11 +138,16 @@
 				class  => 'reference-link btn btn-sm btn-info',
 				data   => { bs_toggle => 'tooltip', bs_placement => 'top' } =%>
 			% # Only show the report bugs in problem button if editing an OPL or Contrib problem.
-			% if ($c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/|
-				% && ($1 eq 'Library' || $1 eq 'Contrib')) {
+			% if ($ce->{webworkURLs}{OPLBugReporter}
+				% && $c->{editFilePath} =~ m|^$ce->{courseDirs}{templates}/([^/]*)/|
+				% && ($1 eq 'Library' || $1 eq 'Contrib'))
+			% {
 				<%= link_to maketext('Report Bugs in this Problem') =>
-						"$ce->{webworkURLs}{bugReporter}?product=Problem%20libraries"
-						. "&component=$1&bug_file_loc=$c->{editFilePath}_with_problemSeed=$c->{problemSeed}",
+						Mojo::URL->new($ce->{webworkURLs}{OPLBugReporter})
+							->query(
+								title => $c->getRelativeSourceFilePath($c->{editFilePath}),
+								body  => "Problem Seed: " . (param('action.view.seed') // $c->{problemSeed})
+							),
 					target => 'bug_report',
 					title  => maketext(
 						'Report bugs in a WeBWorK question/problem using this link. '


### PR DESCRIPTION
The site nav bug link now links to https://github.com/openwebwork/webwork2/issues/new.  This link does not add a title or body for the issue.

The PG problem editor bug link now links to
https://github.com/openwebwork/webwork-open-problem-library/issues/new. This link sets the issue title to the problem file path (relative to the templates directory of the course), and adds the current problem seed to the issue body.