### PR TITLE
offer to upgrade course after unarchiving it

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1291,26 +1291,42 @@ sub do_unarchive_course ($c) {
 			),
 			$c->tag(
 				'div',
-				class => 'text-center',
-				$c->link_to(
-					$c->maketext('Log into [_1]', $new_courseID) => 'set_list' => { courseID => $new_courseID }
-				),
-			),
-			$c->form_for(
-				$c->current_route,
-				method => 'POST',
+				class => 'row',
 				$c->c(
-					$c->hidden_authen_fields,
-					$c->hidden_fields('subDisplay'),
-					$c->hidden_field(unarchive_courseID => $unarchive_courseID),
-					$c->tag(
-						'div',
-						class => 'd-flex justify-content-center mt-2',
-						$c->submit_button(
-							$c->maketext('Unarchive Next Course'),
-							name  => 'decline_unarchive_course',
-							class => 'btn btn-primary'
-						)
+					$c->form_for(
+						$c->current_route,
+						method => 'POST',
+						class  => 'col-4',
+						$c->c(
+							$c->hidden_authen_fields,
+							$c->hidden_field(subDisplay        => 'upgrade_course'),
+							$c->hidden_field(upgrade_course    => 1),
+							$c->hidden_field(upgrade_courseIDs => $new_courseID),
+							$c->submit_button(
+								$c->maketext('Upgrade Course'),
+								name  => 'upgrade_course_confirm',
+								class => 'btn btn-primary'
+							)
+						)->join('')
+					),
+					$c->link_to(
+						$c->maketext('Log into Course') => 'set_list' => { courseID => $new_courseID },
+						class                           => 'btn btn-primary col-4'
+					),
+					$c->form_for(
+						$c->current_route,
+						method => 'POST',
+						class  => 'col-4 text-end',
+						$c->c(
+							$c->hidden_authen_fields,
+							$c->hidden_fields('subDisplay'),
+							$c->hidden_field(unarchive_courseID => $unarchive_courseID),
+							$c->submit_button(
+								$c->maketext('Unarchive More'),
+								name  => 'unarchive_more',
+								class => 'btn btn-primary'
+							)
+						)->join('')
 					)
 				)->join('')
 			)

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1291,14 +1291,13 @@ sub do_unarchive_course ($c) {
 			),
 			$c->tag(
 				'div',
-				class => 'row',
+				class => 'd-flex justify-content-between',
 				$c->c(
 					$c->form_for(
 						$c->current_route,
 						method => 'POST',
-						class  => 'col-4',
 						$c->c(
-							$c->hidden_authen_fields,
+							$c->hidden_authen_fields('upgrade_course_'),
 							$c->hidden_field(subDisplay        => 'upgrade_course'),
 							$c->hidden_field(upgrade_course    => 1),
 							$c->hidden_field(upgrade_courseIDs => $new_courseID),
@@ -1311,14 +1310,13 @@ sub do_unarchive_course ($c) {
 					),
 					$c->link_to(
 						$c->maketext('Log into Course') => 'set_list' => { courseID => $new_courseID },
-						class                           => 'btn btn-primary col-4'
+						class                           => 'btn btn-primary'
 					),
 					$c->form_for(
 						$c->current_route,
 						method => 'POST',
-						class  => 'col-4 text-end',
 						$c->c(
-							$c->hidden_authen_fields,
+							$c->hidden_authen_fields('unarchive_more_'),
 							$c->hidden_fields('subDisplay'),
 							$c->hidden_field(unarchive_courseID => $unarchive_courseID),
 							$c->submit_button(


### PR DESCRIPTION
This makes it so when you unarchive a course, you have an option to immediately go and upgrade it. Without this, after unarchiving a course, if it needs to be upgraded you must go to the Upgrade Courses page and wait while all courses are assessed for upgrade needs. But this lets you bypass that page and go straight to the confirmation page for only the one newly unarchived course.

Since now there are three things you can do (upgrade the new course, log in to the new course, and move on to unarchive something else) I changed the layout to look like three buttons in a row.