### PR TITLE
be able to copy more things from a course when adding a new course

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -693,13 +693,17 @@ $courseFiles{logs}{activity_log} = '';
 # Site defaults (Usually overridden in localOverrides.conf)
 ################################################################################
 
-# The default_templates_course is used by default to create a new course.
-# The contents of the templates directory are copied from this course
-# to the new course being created.
-$siteDefaults{default_templates_course} ="modelCourse";
+# The default_copy_from_course is used by default when creating a new course.
+# Its templates folder, html folder, course.conf file, and simple.conf file
+# might be copied into a new course. This course might not be a true course;
+# it might only have a directory structure and no presense in the database.
+# If it is a real course, then also its title, institution, non-student users,
+# achievements, and sets can be copied.
+$siteDefaults{default_copy_from_course} ="modelCourse";
 
 # Provide a list of model courses which are not real courses, but from which
-# the templates for a new course can be copied.
+# the templates for a new course can be copied. This list helps exclude such
+# non-real courses when that is appopriate.
 $modelCoursesForCopy = [ "modelCourse" ];
 
 ################################################################################

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -294,21 +294,29 @@ sub do_add_course ($c) {
 	my $db    = $c->db;
 	my $authz = $c->authz;
 
-	my $add_courseID          = trim_spaces($c->param('new_courseID'))          || '';
-	my $add_courseTitle       = trim_spaces($c->param('add_courseTitle'))       || '';
-	my $add_courseInstitution = trim_spaces($c->param('add_courseInstitution')) || '';
+	my $add_courseID          = trim_spaces($c->param('new_courseID'))          // '';
+	my $add_courseTitle       = trim_spaces($c->param('add_courseTitle'))       // '';
+	my $add_courseInstitution = trim_spaces($c->param('add_courseInstitution')) // '';
 
-	my $add_admin_users = trim_spaces($c->param('add_admin_users')) || '';
+	my $add_admin_users = $c->param('add_admin_users') || '';
 
-	my $add_initial_userID          = trim_spaces($c->param('add_initial_userID'))          || '';
-	my $add_initial_password        = trim_spaces($c->param('add_initial_password'))        || '';
-	my $add_initial_confirmPassword = trim_spaces($c->param('add_initial_confirmPassword')) || '';
-	my $add_initial_firstName       = trim_spaces($c->param('add_initial_firstName'))       || '';
-	my $add_initial_lastName        = trim_spaces($c->param('add_initial_lastName'))        || '';
-	my $add_initial_email           = trim_spaces($c->param('add_initial_email'))           || '';
+	my $add_initial_userID          = trim_spaces($c->param('add_initial_userID'))          // '';
+	my $add_initial_password        = trim_spaces($c->param('add_initial_password'))        // '';
+	my $add_initial_confirmPassword = trim_spaces($c->param('add_initial_confirmPassword')) // '';
+	my $add_initial_firstName       = trim_spaces($c->param('add_initial_firstName'))       // '';
+	my $add_initial_lastName        = trim_spaces($c->param('add_initial_lastName'))        // '';
+	my $add_initial_email           = trim_spaces($c->param('add_initial_email'))           // '';
 
-	my $add_templates_course = trim_spaces($c->param('add_templates_course')) || '';
-	my $add_config_file      = trim_spaces($c->param('add_config_file'))      || '';
+	my $copy_from_course = trim_spaces($c->param('copy_from_course')) // '';
+
+	my $copy_templates_html     = $c->param('copy_templates_html')     || '';
+	my $copy_simple_config_file = $c->param('copy_simple_config_file') || '';
+	my $copy_config_file        = $c->param('copy_config_file')        || '';
+	my $copy_non_students       = $c->param('copy_non_students')       || '';
+	my $copy_sets               = $c->param('copy_sets')               || '';
+	my $copy_achievements       = $c->param('copy_achievements')       || '';
+	my $copy_title              = $c->param('copy_title')              || '';
+	my $copy_institution        = $c->param('copy_institution')        || '';
 
 	my $add_dbLayout = trim_spaces($c->param('add_dbLayout')) || '';
 
@@ -365,11 +373,16 @@ sub do_add_course ($c) {
 
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
-	if ($add_templates_course ne '') {
-		$optional_arguments{templatesFrom} = $add_templates_course;
-	}
-	if ($add_config_file ne '') {
-		$optional_arguments{copySimpleConfig} = $add_config_file;
+	if ($copy_from_course ne '') {
+		$optional_arguments{copyFrom}          = $copy_from_course;
+		$optional_arguments{copyTemplatesHtml} = $copy_templates_html;
+		$optional_arguments{copySimpleConfig}  = $copy_simple_config_file;
+		$optional_arguments{copyConfig}        = $copy_config_file;
+		$optional_arguments{copyNonStudents}   = $copy_non_students;
+		$optional_arguments{copySets}          = $copy_sets;
+		$optional_arguments{copyAchievements}  = $copy_achievements;
+		$optional_arguments{copyTitle}         = $copy_title;
+		$optional_arguments{copyInstitution}   = $copy_institution;
 	}
 	if ($add_courseTitle ne '') {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -363,8 +363,9 @@ sub do_add_course ($c) {
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
 	if ($copy_from_course ne '') {
-		%optional_arguments = map { $_ => 1 } $c->param('copy_component');
-		$optional_arguments{copyFrom} = $copy_from_course;
+		%optional_arguments             = map { $_ => 1 } $c->param('copy_component');
+		$optional_arguments{copyFrom}   = $copy_from_course;
+		$optional_arguments{copyConfig} = $c->param('copy_config_file');
 	}
 	if ($add_courseTitle ne '') {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -309,15 +309,6 @@ sub do_add_course ($c) {
 
 	my $copy_from_course = trim_spaces($c->param('copy_from_course')) // '';
 
-	my $copy_templates_html     = $c->param('copy_templates_html')     || '';
-	my $copy_simple_config_file = $c->param('copy_simple_config_file') || '';
-	my $copy_config_file        = $c->param('copy_config_file')        || '';
-	my $copy_non_students       = $c->param('copy_non_students')       || '';
-	my $copy_sets               = $c->param('copy_sets')               || '';
-	my $copy_achievements       = $c->param('copy_achievements')       || '';
-	my $copy_title              = $c->param('copy_title')              || '';
-	my $copy_institution        = $c->param('copy_institution')        || '';
-
 	my $add_dbLayout = trim_spaces($c->param('add_dbLayout')) || '';
 
 	my $ce2 = WeBWorK::CourseEnvironment->new({ courseName => $add_courseID });
@@ -374,15 +365,9 @@ sub do_add_course ($c) {
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
 	if ($copy_from_course ne '') {
-		$optional_arguments{copyFrom}          = $copy_from_course;
-		$optional_arguments{copyTemplatesHtml} = $copy_templates_html;
-		$optional_arguments{copySimpleConfig}  = $copy_simple_config_file;
-		$optional_arguments{copyConfig}        = $copy_config_file;
-		$optional_arguments{copyNonStudents}   = $copy_non_students;
-		$optional_arguments{copySets}          = $copy_sets;
-		$optional_arguments{copyAchievements}  = $copy_achievements;
-		$optional_arguments{copyTitle}         = $copy_title;
-		$optional_arguments{copyInstitution}   = $copy_institution;
+		%optional_arguments             = map { $_ => 1 } ($c->param('copy_component'));
+		$optional_arguments{copyFrom}   = $copy_from_course;
+		$optional_arguments{copyConfig} = $c->param('copy_config_file') || '';
 	}
 	if ($add_courseTitle ne '') {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -298,8 +298,6 @@ sub do_add_course ($c) {
 	my $add_courseTitle       = trim_spaces($c->param('add_courseTitle'))       // '';
 	my $add_courseInstitution = trim_spaces($c->param('add_courseInstitution')) // '';
 
-	my $add_admin_users = $c->param('add_admin_users') || '';
-
 	my $add_initial_userID          = trim_spaces($c->param('add_initial_userID'))          // '';
 	my $add_initial_password        = trim_spaces($c->param('add_initial_password'))        // '';
 	my $add_initial_confirmPassword = trim_spaces($c->param('add_initial_confirmPassword')) // '';
@@ -318,7 +316,7 @@ sub do_add_course ($c) {
 	my @users;
 
 	# copy users from current (admin) course if desired
-	if ($add_admin_users ne '') {
+	if ($c->param('add_admin_users')) {
 		for my $userID ($db->listUsers) {
 			if ($userID eq $add_initial_userID) {
 				$c->addbadmessage($c->maketext(
@@ -365,9 +363,8 @@ sub do_add_course ($c) {
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
 	if ($copy_from_course ne '') {
-		%optional_arguments             = map { $_ => 1 } ($c->param('copy_component'));
-		$optional_arguments{copyFrom}   = $copy_from_course;
-		$optional_arguments{copyConfig} = $c->param('copy_config_file') || '';
+		%optional_arguments = map { $_ => 1 } $c->param('copy_component');
+		$optional_arguments{copyFrom} = $copy_from_course;
 	}
 	if ($add_courseTitle ne '') {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -301,7 +301,7 @@ sub addCourse {
 		}
 
 		# try to create it
-		eval { Mojo::File($courseDir)->make_path };
+		eval { Mojo::File->new($courseDir)->make_path };
 		warn "Failed to create $courseDirName directory '$courseDir': $@. "
 			. "You will have to create this directory manually."
 			if $@;
@@ -479,7 +479,7 @@ sub addCourse {
 		if ($options{copySimpleConfig}) {
 			my $sourceFile = $sourceCE->{courseFiles}{simpleConfig};
 			if (-e $sourceFile) {
-				eval { Mojo::File->new($sourceFile)->copy_to($ce->{courseFiles}) };
+				eval { Mojo::File->new($sourceFile)->copy_to($ce->{courseDirs}{root}) };
 				warn "Failed to copy simple.conf from course '$sourceCourse': $@" if $@;
 			}
 		}
@@ -488,7 +488,7 @@ sub addCourse {
 		if ($options{copyConfig}) {
 			my $sourceFile = $sourceCE->{courseFiles}{environment};
 			if (-e $sourceFile) {
-				eval { Mojo::File->new($sourceFile)->copy_to($ce->{courseFiles}) };
+				eval { Mojo::File->new($sourceFile)->copy_to($ce->{courseDirs}{root}) };
 				warn "Failed to copy course.conf from course '$sourceCourse': $@" if $@;
 			}
 		}

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -488,17 +488,8 @@ sub addCourse {
 		if ($options{copyConfig}) {
 			my $sourceFile = $sourceCE->{courseFiles}{environment};
 			if (-e $sourceFile) {
-				my $destFile = $ce->{courseFiles}{environment};
-				my $cp_cmd =
-					join(" ", ("2>&1", $ce->{externalPrograms}{cp}, shell_quote($sourceFile), shell_quote($destFile)));
-				my $cp_out = readpipe $cp_cmd;
-				if ($?) {
-					my $exit   = $? >> 8;
-					my $signal = $? & 127;
-					my $core   = $? & 128;
-					warn "Failed to copy course.conf from course '$sourceCourse' "
-						. "with command '$cp_cmd' (exit=$exit signal=$signal core=$core): $cp_out\n";
-				}
+				eval { Mojo::File->new($sourceFile)->copy_to($ce->{courseFiles}) };
+				warn "Failed to copy course.conf from course '$sourceCourse': $@" if $@;
 			}
 		}
 	}

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -15,16 +15,10 @@
 				% 'add_course',
 				% maketext('Add Courses'),
 				% {
-					% add_admin_users      => 1,
-					% copy_from_course     => $ce->{siteDefaults}{default_copy_from_course} || '',
-					% copy_templates_html     => 1,
-					% copy_simple_config_file => 1,
-					% copy_non_students       => 1,
-					% copy_sets               => 1,
-					% copy_achievements       => 1,
-					% copy_title              => 1,
-					% copy_institution        => 1,
-					% add_dbLayout         => 'sql_single',
+					% add_admin_users  => 1,
+					% copy_from_course => $ce->{siteDefaults}{default_copy_from_course} || '',
+					% copy_component   => 'copyTemplatesHtml',
+					% add_dbLayout     => 'sql_single'
 				% }
 			% ],
 			% [ 'rename_course',        maketext('Rename Courses') ],

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -16,9 +16,15 @@
 				% maketext('Add Courses'),
 				% {
 					% add_admin_users      => 1,
-					% add_config_file      => 1,
+					% copy_from_course     => $ce->{siteDefaults}{default_copy_from_course} || '',
+					% copy_templates_html     => 1,
+					% copy_simple_config_file => 1,
+					% copy_non_students       => 1,
+					% copy_sets               => 1,
+					% copy_achievements       => 1,
+					% copy_title              => 1,
+					% copy_institution        => 1,
 					% add_dbLayout         => 'sql_single',
-					% add_templates_course => $ce->{siteDefaults}{default_templates_course} || ''
 				% }
 			% ],
 			% [ 'rename_course',        maketext('Rename Courses') ],

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -103,27 +103,72 @@
 		</div>
 	</div>
 	<div class="mb-1">
-		<%= maketext('To copy the templates and html folders from an existing course, select the course below.') =%>
+		<%= maketext('To copy components from an existing course, select the course and check which components to copy.') =%>
 	</div>
 	<div class="row mb-3">
 		% my @existingCourses = sort { lc($a) cmp lc($b) } listCourses($ce);
 		% unshift(@existingCourses, sort { lc($a) cmp lc($b) } @{ $ce->{modelCoursesForCopy} });
 		%
-		<%= label_for add_templates_course => maketext('Copy from:'),
+		<%= label_for copy_from_course => maketext('Copy Components From:'),
 			class => 'col-auto col-form-label fw-bold' =%>
 		<div class="col-auto">
-			<%= select_field add_templates_course => [
+			<%= select_field copy_from_course => [
 					[ maketext('No Course') => '' ],
 					map { [ $_ => $_] } @existingCourses
 				],
-				id      => 'add_templates_course',
+				id      => 'copy_from_course',
 				class   => 'form-select' =%>
 		</div>
 		<div class="mb-3">
+			<div class="col-form-label fw-bold">
+				Copy These Components:
+			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'add_config_file' => 1, class => 'form-check-input' =%>
-					<%= maketext('Also copy simple configuration file') =%>
+					<%= check_box 'copy_templates_html' => 1, class => 'form-check-input' =%>
+					<%= maketext('[_1] and [_2] folders', 'templates', 'html') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_simple_config_file' => 1, class => 'form-check-input' =%>
+					<%= maketext('simple configuration file') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_config_file' => 1, class => 'form-check-input' =%>
+					<%= maketext('course configuration file') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_non_students' => 1, class => 'form-check-input' =%>
+					<%= maketext('non-student users') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_sets' => 1, class => 'form-check-input' =%>
+					<%= maketext('assignments/sets') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_achievements' => 1, class => 'form-check-input' =%>
+					<%= maketext('achievements') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_title' => 1, class => 'form-check-input' =%>
+					<%= maketext('course title (will override "Course Title" input above)') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box 'copy_institution' => 1, class => 'form-check-input' =%>
+					<%= maketext('course institution (will override "Institution" input above)') =%>
 				</label>
 			</div>
 		</div>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -144,12 +144,6 @@
 		</div>
 		<div class="form-check">
 			<label class="form-check-label">
-				<%= check_box copy_component => 'copyConfig', class => 'form-check-input' =%>
-				<%= maketext('course configuration file') =%>
-			</label>
-		</div>
-		<div class="form-check">
-			<label class="form-check-label">
 				<%= check_box copy_component => 'copyNonStudents', class => 'form-check-input' =%>
 				<%= maketext('non-student users') =%>
 			</label>
@@ -176,6 +170,22 @@
 			<label class="form-check-label">
 				<%= check_box copy_component => 'copyInstitution', class => 'form-check-input' =%>
 				<%= maketext('course institution (will override "Institution" input above)') =%>
+			</label>
+		</div>
+		<div class="form-check mt-3 mb-2">
+			<label class="form-check-label">
+				<%= check_box copy_config_file => 1, class => 'form-check-input' =%>
+				<%= maketext('course configuration file') =%>
+				<a class="help-popup" role="button" tabindex="0" data-bs-placement="top" data-bs-toggle="popover"
+					 data-bs-content="<%= maketext('Copying the course configuration file may copy configuration '
+						. 'settings that are specific to the original course instructor. If this is a new course '
+						. 'for a new instructor, use the fields above to add the new instructor and do not copy '
+						. 'the course configuration file. Then if there is something in the course configuration '
+						. 'file that should be carried into the new course, the administrator can copy that manually. '
+						. 'Alternatively, do copy the course configuration file, but then the administrator should '
+						. 'inspect the new course configuration file and make adjustments for the new instructor.') =%>">
+					<i class="icon fas fa-question-circle" data="<%= maketext('Help Icon') =%>" aria-hidden="true"></i>
+				</a>
 			</label>
 		</div>
 	</fieldset>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -125,49 +125,56 @@
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_templates_html' => 1, class => 'form-check-input' =%>
+					<%= check_box select_all => 1, class => 'select-all form-check-input',
+						'data-select-group' => 'copy_component'=%>
+					<%= maketext('select all', 'templates', 'html') =%>
+				</label>
+			</div>
+			<div class="form-check">
+				<label class="form-check-label">
+					<%= check_box copy_component => 'copyTemplatesHtml', class => 'form-check-input' =%>
 					<%= maketext('[_1] and [_2] folders', 'templates', 'html') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_simple_config_file' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copySimpleConfig', class => 'form-check-input' =%>
 					<%= maketext('simple configuration file') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_config_file' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_config_file => 1, class => 'form-check-input' =%>
 					<%= maketext('course configuration file') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_non_students' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copyNonStudents', class => 'form-check-input' =%>
 					<%= maketext('non-student users') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_sets' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copySets', class => 'form-check-input' =%>
 					<%= maketext('assignments/sets') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_achievements' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copyAchievements', class => 'form-check-input' =%>
 					<%= maketext('achievements') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_title' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copyTitle', class => 'form-check-input' =%>
 					<%= maketext('course title (will override "Course Title" input above)') =%>
 				</label>
 			</div>
 			<div class="form-check">
 				<label class="form-check-label">
-					<%= check_box 'copy_institution' => 1, class => 'form-check-input' =%>
+					<%= check_box copy_component => 'copyInstitution', class => 'form-check-input' =%>
 					<%= maketext('course institution (will override "Institution" input above)') =%>
 				</label>
 			</div>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -6,12 +6,12 @@
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields('subDisplay') =%>
 	%
-	<p><%= maketext(
+	<div class="mb-2"><%= maketext(
 		'Specify an ID, title, and institution for the new course. The course ID may contain only letters, '
 			. 'numbers, hyphens, and underscores, and may have at most [_1] characters.',
 		$ce->{maxCourseIdLength}) %>
-	</p>
-	<div class="row mb-2">
+	</div>
+	<div class="row mb-3">
 		<div class="col-lg-8 col-md-10">
 			<div class="form-floating mb-1">
 				<%= text_field new_courseID => '',
@@ -27,7 +27,7 @@
 					class       => 'form-control' =%>
 				<%= label_for add_courseTitle => maketext('Course Title') =%>
 			</div>
-			<div class="form-floating mb-1">
+			<div class="form-floating">
 				<%= text_field add_courseInstitution => '',
 					id          => 'add_courseInstitution',
 					placeholder => '',
@@ -41,7 +41,7 @@
 			<%= maketext(
 				'To add the WeBWorK administrators to the new course (as administrators) check the box below.') =%>
 		</div>
-		<div class="form-check mb-2">
+		<div class="form-check">
 			<label class="form-check-label">
 				<%= check_box 'add_admin_users' => 1, class => 'form-check-input' =%>
 				<%= maketext('Add WeBWorK administrators to new course') =%>
@@ -54,7 +54,7 @@
 				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.'
 		) =%>
 	</div>
-	<div class="row mb-2">
+	<div class="row mb-3">
 		<div class="col-lg-4 col-md-5 col-sm-6">
 			<div class="form-floating mb-1">
 				<%= text_field add_initial_userID => '',
@@ -103,10 +103,11 @@
 		</div>
 	</div>
 	<div class="mb-1">
-		<%= maketext('To copy components from an existing course, select the course and check which components to copy.') =%>
+		<%= maketext('To copy components from an existing course, '
+			. 'select the course and check which components to copy.') =%>
 	</div>
-	<div class="row mb-3">
-		% my @existingCourses = sort { lc($a) cmp lc($b) } listCourses($ce);
+	<div class="row mb-1">
+		% my @existingCourses = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
 		% unshift(@existingCourses, sort { lc($a) cmp lc($b) } @{ $ce->{modelCoursesForCopy} });
 		%
 		<%= label_for copy_from_course => maketext('Copy Components From:'),
@@ -119,67 +120,65 @@
 				id      => 'copy_from_course',
 				class   => 'form-select' =%>
 		</div>
-		<div class="mb-3">
-			<div class="col-form-label fw-bold">
-				Copy These Components:
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box select_all => 1, class => 'select-all form-check-input',
-						'data-select-group' => 'copy_component'=%>
-					<%= maketext('select all', 'templates', 'html') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copyTemplatesHtml', class => 'form-check-input' =%>
-					<%= maketext('[_1] and [_2] folders', 'templates', 'html') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copySimpleConfig', class => 'form-check-input' =%>
-					<%= maketext('simple configuration file') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_config_file => 1, class => 'form-check-input' =%>
-					<%= maketext('course configuration file') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copyNonStudents', class => 'form-check-input' =%>
-					<%= maketext('non-student users') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copySets', class => 'form-check-input' =%>
-					<%= maketext('assignments/sets') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copyAchievements', class => 'form-check-input' =%>
-					<%= maketext('achievements') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copyTitle', class => 'form-check-input' =%>
-					<%= maketext('course title (will override "Course Title" input above)') =%>
-				</label>
-			</div>
-			<div class="form-check">
-				<label class="form-check-label">
-					<%= check_box copy_component => 'copyInstitution', class => 'form-check-input' =%>
-					<%= maketext('course institution (will override "Institution" input above)') =%>
-				</label>
-			</div>
-		</div>
 	</div>
+	<fieldset class="mb-3">
+		<legend class="fw-bold fs-6">Copy These Components:</legend>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box select_all => 1, class => 'select-all form-check-input',
+					data => { select_group => 'copy_component' } =%>
+				<%= maketext('select all', 'templates', 'html') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyTemplatesHtml', class => 'form-check-input' =%>
+				<%= maketext('[_1] and [_2] folders', 'templates', 'html') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copySimpleConfig', class => 'form-check-input' =%>
+				<%= maketext('simple configuration file') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyConfig', class => 'form-check-input' =%>
+				<%= maketext('course configuration file') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyNonStudents', class => 'form-check-input' =%>
+				<%= maketext('non-student users') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copySets', class => 'form-check-input' =%>
+				<%= maketext('assignments/sets') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyAchievements', class => 'form-check-input' =%>
+				<%= maketext('achievements') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyTitle', class => 'form-check-input' =%>
+				<%= maketext('course title (will override "Course Title" input above)') =%>
+			</label>
+		</div>
+		<div class="form-check">
+			<label class="form-check-label">
+				<%= check_box copy_component => 'copyInstitution', class => 'form-check-input' =%>
+				<%= maketext('course institution (will override "Institution" input above)') =%>
+			</label>
+		</div>
+	</fieldset>
 	<%= hidden_field add_dbLayout => 'sql_single' =%>
 	<%= submit_button maketext('Add Course'), name => 'add_course', class => 'btn btn-primary' =%>
 <% end =%>

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -26,12 +26,14 @@
 		. 'Unchecking this option will make it so WeBWorK administrators cannot directly login to the course.') =%>
 </p>
 <p>
-	<%= maketext('The simple configuration file is the name of the configuration file created when using the "Course '
-		. 'Configuration" page to configure course options.  This option sets if this configuration file is copied '
-		. 'from the old course or not and instead use the server defaults.') =%>
-</p>
-<p class="mb-0">
 	<%= maketext('Enter the details of the course instructor to be added when the course is created.  This user '
 		. 'will also be added to the admin course with the username "userID_courseID" so you can manage and '
 		. 'email the instructors of the courses on the server.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '
+		. 'If the course is not a true course (like the modelCourse) then only the templates and html folders, '
+		. 'and the simple and course config files can be copied. The "simple config" file contains the settings '
+		. 'made in the "Course Config" page. The "course config" file should only be copied if you know what you '
+		. 'are doing.') =%>
 </p>


### PR DESCRIPTION
This changes the "Add Course" sub page of Course Admin, so that when you make a new course, there is more you can copy from some target course (currently, you can copy the `templates` folder, `html` folder, and `simple.conf` file).

Now you can also copy the `course.conf file`, although this is discouraged in the help file and not selected by default.

Addiitionally you can copy certain data from the database. Namely:
* non-student users
* sets (aka assignments). This includes the problems associated with the sets from the problem table, and includes any locations associated with those sets.
* achievements
* the course title and/or course institution, which (if selected) override whatever you typed into the input fields above

For these database-flavored components, I made them all selected for copying when the page loads. I realize it's a change in behavior, and at first I had them all unchecked for that reason. But the more I thought about it, the fewer use cases I could come up with where you would want any of these unchecked. But it's up for discussion.

One thing I did not do: if users and sets are copied, this does not keep users assigned to whichever sets they were assigned to in the older course. Same with achievements. That could be done if desired, but I would only want it to reflect the assignments, not any progress the user made on the sets or the achievements.
