### PR TITLE
option to 'clean' a course just after unarchiving it

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -27,7 +27,6 @@ use File::Path 'remove_tree';
 use Mojo::File;
 use File::stat;
 use Time::localtime;
-use String::ShellQuote;
 
 use WeBWorK::CourseEnvironment;
 use WeBWorK::Debug;
@@ -1290,7 +1289,7 @@ sub do_unarchive_course ($c) {
 			my $ce_new = WeBWorK::CourseEnvironment->new({ courseName => $new_courseID });
 			my $db_new = WeBWorK::DB->new($ce_new->{dbLayout});
 
-			for my $student_id ($db_new->listPermissionLevelsWhere({ permission => 0 })) {
+			for my $student_id ($db_new->listPermissionLevelsWhere({ permission => $ce->{userRoles}{student} })) {
 				$db_new->deleteUser($student_id->[0]);
 			}
 

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
@@ -6,15 +6,14 @@
 		<div class="col-auto">
 			<input type="text" name="new_courseID" id="new_courseID" value="<%= $courseID %>" class="form-control">
 		</div>
-		<div class="row mb-2">
-			<div class="col-12">
-				<div class="form-check">
-					<label class="form-check-label" id="clean_up_course">
-						<%= maketext('Clean course after unarchiving '
-							. '(remove student users, scoring files, log files)') %>
-						<%= check_box clean_up_course => 1, class => 'form-check-input' %>
-					</label>
-				</div>
+	</div>
+	<div class="row mb-2">
+		<div class="col-12">
+			<div class="form-check">
+				<label class="form-check-label" id="clean_up_course">
+					<%= maketext('Clean course after unarchiving (remove student users, scoring files, log files)') =%>
+					<%= check_box clean_up_course => 1, class => 'form-check-input' =%>
+				</label>
 			</div>
 		</div>
 	</div>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
@@ -6,6 +6,17 @@
 		<div class="col-auto">
 			<input type="text" name="new_courseID" id="new_courseID" value="<%= $courseID %>" class="form-control">
 		</div>
+		<div class="row mb-2">
+			<div class="col-12">
+				<div class="form-check">
+					<label class="form-check-label" id="clean_up_course">
+						<%= maketext('Clean course after unarchiving '
+							. '(remove student users, scoring files, log files)') %>
+						<%= check_box clean_up_course => 1, class => 'form-check-input' %>
+					</label>
+				</div>
+			</div>
+		</div>
 	</div>
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields(qw(subDisplay unarchive_courseID create_newCourseID)) =%>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -24,14 +24,8 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-sm-4">
-					<div class="form-check">
-						<label class="form-check-label" id="create_newCourseID_label">
-							<%= maketext('New Name:') %>
-							<%= check_box create_newCourseID => 1, class => 'form-check-input' %>
-						</label>
-					</div>
-				</div>
+				<%= label_for 'new_courseID' => maketext('New Name:'), class => 'col-sm-4 col-form-label',
+					id => 'create_newCourseID_label' =%>
 				<div class="col-sm-8">
 					<%= text_field new_courseID => '',
 						size              => 25,
@@ -39,6 +33,17 @@
 						class             => 'form-control',
 						'aria-labelledby' => 'create_newCourseID_label'
 					=%>
+				</div>
+			</div>
+			<div class="row mb-2">
+				<div class="col-12">
+					<div class="form-check">
+						<label class="form-check-label" id="clean_up_course">
+							<%= maketext('Clean course after unarchiving '
+								. '(remove student users, scoring files, log files)') %>
+							<%= check_box clean_up_course => 1, class => 'form-check-input' %>
+						</label>
+					</div>
 				</div>
 			</div>
 		</div>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -24,24 +24,23 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<%= label_for 'new_courseID' => maketext('New Name:'), class => 'col-sm-4 col-form-label',
-					id => 'create_newCourseID_label' =%>
+				<%= label_for new_courseID => maketext('New Name:'), class => 'col-sm-4 col-form-label' =%>
 				<div class="col-sm-8">
 					<%= text_field new_courseID => '',
-						size              => 25,
-						maxlength         => $ce->{maxCourseIdLength},
-						class             => 'form-control',
-						'aria-labelledby' => 'create_newCourseID_label'
+						id        => 'new_courseID',
+						size      => 25,
+						maxlength => $ce->{maxCourseIdLength},
+						class     => 'col-sm-8 form-control'
 					=%>
 				</div>
 			</div>
 			<div class="row mb-2">
 				<div class="col-12">
 					<div class="form-check">
-						<label class="form-check-label" id="clean_up_course">
+						<%= check_box clean_up_course => 1, class => 'form-check-input', id => 'clean_up_course' %>
+						<label for="clean_up_course" class="form-check-label" id="clean_up_course">
 							<%= maketext('Clean course after unarchiving '
 								. '(remove student users, scoring files, log files)') %>
-							<%= check_box clean_up_course => 1, class => 'form-check-input' %>
 						</label>
 					</div>
 				</div>

--- a/templates/HelpFiles/AdminUnarchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminUnarchiveCourse.html.ep
@@ -22,7 +22,12 @@
 		. 'restoring a course with a new name, the name is used as the course ID, and must contain only '
 		. 'letters, numbers, hyphens, and underscores, and may have at most 40 characters.') =%>
 </p>
-<p class="mb-0">
+<p>
 	<%= maketext('Archived courses are located inside the "archives" directory of the "admin" course.  Use '
 		. 'the "File Manager" to upload additional .tar.gz files to be unarchived.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('You may check the box to "clean" the unarchived course. This will remove student users '
+		. 'and their associated data from the database after the course is unarchived. It will also remove '
+		. 'the log files and and any files in the scoring folder.') =%>
 </p>


### PR DESCRIPTION
This adds a checkbox to the unarchive course page, and if checked, then when the course is unarchived it will be "cleaned". Cleaning means:
* remove all student users and associated data from the database
* delete the log files
* delete any scoring files

Another small thing is that this removes the checkbox for giving a new course name. If you've entered something into the field for the new course name, that is enough, and the checkbox is redundant.