### PR TITLE
do not allow LTI access to admin course

### DIFF
--- a/conf/authen_CAS.conf.dist
+++ b/conf/authen_CAS.conf.dist
@@ -12,6 +12,24 @@ $authen{user_module} = {
   "*" => "WeBWorK::Authen::CAS",
 };
 
+# List of authentication modules that may be used to enter the admin course.
+# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# Since the admin course provides overall power to add/delete courses, access
+# to this course should be protected by the best possible authentication you
+# have available to you.  The current default is
+# WeBWorK::Authen::Basic_TheLastOption which is simple password based
+# authentication for a password locally stored in your WeBWorK server's
+# database.  On one hand, this is necessary as the initial setting, as it is the
+# only option available when a new server is being installed.  However, since
+# this option does not make use of multi-factor authentication or provide any
+# capabilities to prevent dictionary attacks, etc.  At the very least you should
+# use a very strong password.  If you have the option to use a more secure
+# authentication approach to the admin course (one which you are confident
+# cannot be spoofed) that is preferable.
+$authen{admin_module} = [
+	'WeBWorK::Authen::CAS'
+];
+
 $authen{cas_options} = {
 	# Options to pass to the AuthCAS module.
 	# Note that this is (plain) AuthCAS, not Apache::AuthCAS

--- a/conf/authen_CAS.conf.dist
+++ b/conf/authen_CAS.conf.dist
@@ -16,16 +16,7 @@ $authen{user_module} = {
 # This should be a non-empty sublist of whatever is in $authen{user_module}.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
-# have available to you.  The current default is
-# WeBWorK::Authen::Basic_TheLastOption which is simple password based
-# authentication for a password locally stored in your WeBWorK server's
-# database.  On one hand, this is necessary as the initial setting, as it is the
-# only option available when a new server is being installed.  However, since
-# this option does not make use of multi-factor authentication or provide any
-# capabilities to prevent dictionary attacks, etc.  At the very least you should
-# use a very strong password.  If you have the option to use a more secure
-# authentication approach to the admin course (one which you are confident
-# cannot be spoofed) that is preferable.
+# have available to you.
 $authen{admin_module} = [
 	'WeBWorK::Authen::CAS'
 ];

--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -45,6 +45,26 @@ $authen{user_module} = [
 	{ '*' => 'WeBWorK::Authen::Basic_TheLastOption' }    # fallback authorization method
 ];
 
+# List of authentication modules that may be used to enter the admin course.
+# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# Since the admin course provides overall power to add/delete courses, access
+# to this course should be protected by the best possible authentication you
+# have available to you.  The current default is
+# WeBWorK::Authen::Basic_TheLastOption which is simple password based
+# authentication for a password locally stored in your WeBWorK server's
+# database.  On one hand, this is necessary as the initial setting, as it is the
+# only option available when a new server is being installed.  However, since
+# this option does not make use of multi-factor authentication or provide any
+# capabilities to prevent dictionary attacks, etc.  At the very least you should
+# use a very strong password.  If you have the option to use a more secure
+# authentication approach to the admin course (one which you are confident
+# cannot be spoofed) that is preferable.
+$authen{admin_module} = [
+	'WeBWorK::Authen::LTIAdvantage',
+	'WeBWorK::Authen::LTIAdvanced',
+	'WeBWorK::Authen::Basic_TheLastOption'
+];
+
 # Include configurations.  You must uncomment at least one of the following. You may uncomment
 # both if the site may be using both LTI 1.1 and 1.3 in different courses. After uncommenting
 # the LTI_1_x line, you must copy the file authen_LTI_1_x.conf.dist to authen_LTI_1_x.conf and

--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -60,8 +60,8 @@ $authen{user_module} = [
 # authentication approach to the admin course (one which you are confident
 # cannot be spoofed) that is preferable.
 $authen{admin_module} = [
-	'WeBWorK::Authen::LTIAdvantage',
-	'WeBWorK::Authen::LTIAdvanced',
+	#'WeBWorK::Authen::LTIAdvantage',
+	#'WeBWorK::Authen::LTIAdvanced',
 	'WeBWorK::Authen::Basic_TheLastOption'
 ];
 

--- a/conf/authen_ldap.conf.dist
+++ b/conf/authen_ldap.conf.dist
@@ -12,6 +12,24 @@ $authen{user_module} = {
 	"*" => "WeBWorK::Authen::LDAP",
 };
 
+# List of authentication modules that may be used to enter the admin course.
+# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# Since the admin course provides overall power to add/delete courses, access
+# to this course should be protected by the best possible authentication you
+# have available to you.  The current default is
+# WeBWorK::Authen::Basic_TheLastOption which is simple password based
+# authentication for a password locally stored in your WeBWorK server's
+# database.  On one hand, this is necessary as the initial setting, as it is the
+# only option available when a new server is being installed.  However, since
+# this option does not make use of multi-factor authentication or provide any
+# capabilities to prevent dictionary attacks, etc.  At the very least you should
+# use a very strong password.  If you have the option to use a more secure
+# authentication approach to the admin course (one which you are confident
+# cannot be spoofed) that is preferable.
+$authen{admin_module} = [
+	'WeBWorK::Authen::LDAP'
+];
+
 $authen{ldap_options} = {
 	# hosts to attempt to connect to, in order. For example:
 	#   auth.myschool.edu             -- uses LDAP scheme and port 389

--- a/conf/authen_ldap.conf.dist
+++ b/conf/authen_ldap.conf.dist
@@ -16,16 +16,7 @@ $authen{user_module} = {
 # This should be a non-empty sublist of whatever is in $authen{user_module}.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
-# have available to you.  The current default is
-# WeBWorK::Authen::Basic_TheLastOption which is simple password based
-# authentication for a password locally stored in your WeBWorK server's
-# database.  On one hand, this is necessary as the initial setting, as it is the
-# only option available when a new server is being installed.  However, since
-# this option does not make use of multi-factor authentication or provide any
-# capabilities to prevent dictionary attacks, etc.  At the very least you should
-# use a very strong password.  If you have the option to use a more secure
-# authentication approach to the admin course (one which you are confident
-# cannot be spoofed) that is preferable.
+# have available to you.
 $authen{admin_module} = [
 	'WeBWorK::Authen::LDAP'
 ];

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -716,27 +716,28 @@ $modelCoursesForCopy = [ "modelCourse" ];
 # Select the authentication module to use for normal logins.
 #
 # If this value is a string, the given authentication module will be used
-# regardless of the database layout. If it is a hash, the database layout name
-# will be looked up in the hash and the resulting value will be used as the
-# authentication module. The special hash key "*" is used if no entry for the
-# current database layout is found.
-# If this value is a sequence of strings or hashes, then each
-# string or hash in the sequence will be successively tested to see if it
-# provides a module that can handle
-# the authentication request (by calling the module's
-#   sub  request_has_data_for_this_verification_module ).
-# The first module that responds affirmatively will be used.
+# regardless of the database layout.
 #
+# If it is a hash, the database layout name will be looked up in the hash and
+# the resulting value will be used as the authentication module.  The special
+# hash key "*" is used if no entry for the current database layout is found.
 #
-$authen{user_module} = {
-	# sql_moodle => "WeBWorK::Authen::Moodle",
-	# sql_ldap   => "WeBWorK::Authen::LDAP",
-	"*" => "WeBWorK::Authen::Basic_TheLastOption",
-};
+# If this value is a sequence of strings or hashes, then each string or hash in
+# the sequence will be successively tested to see if it provides a module that
+# can handle the authentication request by calling the module's sub
+# request_has_data_for_this_verification_module().  The first module that
+# responds affirmatively will be used.
+
+$authen{user_module} = {"*" => "WeBWorK::Authen::Basic_TheLastOption"};
 
 # Select the authentication module to use for proctor logins.
 # A string or a hash is accepted, as above.
 $authen{proctor_module} = "WeBWorK::Authen::Proctor";
+
+# List of authentication modules that may be used to enter the admin course.
+# This should always be an array reference with a subset of the modules named
+# in $authen{user_module}.
+$authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 
 ################################################################################
 # Authorization system (Make local overrides in localOverrides.conf )

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -482,6 +482,10 @@ $mail{feedbackRecipients}    = [
 # use a very strong password.  If you have the option to use a more secure
 # authentication approach to the admin course (one which you are confident
 # cannot be spoofed) that is preferable.
+#
+# Note that if you include authentication module config files further down,
+# those may override the setting of $authen{admin_module} here.
+
 #$authen{admin_module} = [
 #	'WeBWorK::Authen::Moodle',
 #	'WeBWorK::Authen::LDAP',

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -437,11 +437,56 @@ $mail{feedbackRecipients}    = [
 # END_PREAMBLE
 
 ################################################################################
-# Authentication Methods
+# Authentication
 ################################################################################
 
 # Extra modules have been created to allow WeBWorK to use certain external
 # methods of authentication.
+
+# Select the authentication module to use for normal logins.
+#
+# If this value is a string, the given authentication module will be used
+# regardless of the database layout.
+#
+# If it is a hash, the database layout name will be looked up in the hash and
+# the resulting value will be used as the authentication module.  The special
+# hash key "*" is used if no entry for the current database layout is found.
+#
+# If this value is a sequence of strings or hashes, then each string or hash in
+# the sequence will be successively tested to see if it provides a module that
+# can handle the authentication request by calling the module's sub
+# request_has_data_for_this_verification_module().  The first module that
+# responds affirmatively will be used.
+
+#$authen{user_module} = {
+#	sql_moodle => "WeBWorK::Authen::Moodle",
+#	sql_ldap   => "WeBWorK::Authen::LDAP"
+#	"*"        => "WeBWorK::Authen::Basic_TheLastOption"
+#};
+
+# Select the authentication module to use for proctor logins.
+# A string or a hash is accepted, as above.
+#$authen{proctor_module} = "WeBWorK::Authen::Proctor";
+
+# List of authentication modules that may be used to enter the admin course.
+# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# Since the admin course provides overall power to add/delete courses, access
+# to this course should be protected by the best possible authentication you
+# have available to you.  The current default is
+# WeBWorK::Authen::Basic_TheLastOption which is simple password based
+# authentication for a password locally stored in your WeBWorK server's
+# database.  On one hand, this is necessary as the initial setting, as it is the
+# only option available when a new server is being installed.  However, since
+# this option does not make use of multi-factor authentication or provide any
+# capabilities to prevent dictionary attacks, etc.  At the very least you should
+# use a very strong password.  If you have the option to use a more secure
+# authentication approach to the admin course (one which you are confident
+# cannot be spoofed) that is preferable.
+#$authen{admin_module} = [
+#	'WeBWorK::Authen::Moodle',
+#	'WeBWorK::Authen::LDAP',
+#	'WeBWorK::Authen::Basic_TheLastOption'
+#];
 
 ################################################################################
 # IMS LTI Authentication

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -152,6 +152,18 @@ sub verify {
 	debug('BEGIN VERIFY');
 
 	return $self->call_next_authen_method if !$self->request_has_data_for_this_verification_module;
+	my $authen_ref = ref($self);
+	if ($c->ce->{courseName} eq $c->ce->{admin_course_id}
+		&& !(grep {/^$authen_ref$/} @{ $c->ce->{authen}{admin_module} }))
+	{
+		$self->write_log_entry("Cannot authenticate into admin course using $authen_ref.");
+		$c->stash(
+			authen_error => $c->maketext(
+				'There was an error during the login process.  Please speak to your instructor or system administrator.'
+			)
+		);
+		return $self->call_next_authen_method();
+	}
 
 	$self->{was_verified} = $self->do_verify;
 


### PR DESCRIPTION
If the authentication module is an LTI authentication module and the course is the admin course, this moves on to the next authentication module.

This is to kill any potential for an LMS user to spoof their LTI data and enter the admin course as one of its admin users.