### PR TITLE
change add course input name to match unarchive course input name

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -229,7 +229,7 @@ sub add_course_form ($c) {
 sub add_course_validate ($c) {
 	my $ce = $c->ce;
 
-	my $add_courseID                = trim_spaces($c->param('add_courseID'))                || '';
+	my $add_courseID                = trim_spaces($c->param('new_courseID'))                || '';
 	my $add_initial_userID          = trim_spaces($c->param('add_initial_userID'))          || '';
 	my $add_initial_password        = trim_spaces($c->param('add_initial_password'))        || '';
 	my $add_initial_confirmPassword = trim_spaces($c->param('add_initial_confirmPassword')) || '';
@@ -293,7 +293,7 @@ sub do_add_course ($c) {
 	my $db    = $c->db;
 	my $authz = $c->authz;
 
-	my $add_courseID          = trim_spaces($c->param('add_courseID'))          || '';
+	my $add_courseID          = trim_spaces($c->param('new_courseID'))          || '';
 	my $add_courseTitle       = trim_spaces($c->param('add_courseTitle'))       || '';
 	my $add_courseInstitution = trim_spaces($c->param('add_courseInstitution')) || '';
 

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -14,11 +14,11 @@
 	<div class="row mb-2">
 		<div class="col-lg-8 col-md-10">
 			<div class="form-floating mb-1">
-				<%= text_field add_courseID => '',
-					id          => 'add_courseID',
+				<%= text_field new_courseID => '',
+					id          => 'new_courseID',
 					placeholder => '',
 					class       => 'form-control' =%>
-				<%= label_for add_courseID => maketext('Course ID') =%>
+				<%= label_for new_courseID => maketext('Course ID') =%>
 			</div>
 			<div class="form-floating mb-1">
 				<%= text_field add_courseTitle => '',


### PR DESCRIPTION
This changes one of the input names in the admin "add course" page from `add_courseID` to `new_courseID`. The reason for the change is to make the name match the input name in the "unarchive course" page. This lets the web browser remember and suggest course names in one page that you previously submitted in the other. For example if I once created a new course `math111-jordan-spring2024`, and later archived it, then in the "unarchive course" page `math111-jordan-spring2024` will be a suggested autocompletion which I can edit to `math111-jordan-spring2025` or whatever.

