### PR TITLE
Remove action scope and add action form validation.

### DIFF
--- a/htdocs/js/AchievementList/achievementlist.js
+++ b/htdocs/js/AchievementList/achievementlist.js
@@ -1,0 +1,76 @@
+(() => {
+	// Action form validation.
+	const is_achievement_selected = () => {
+		for (const achievement of document.getElementsByName('selected_achievements')) {
+			if (achievement.checked) return true;
+		}
+		document.getElementById('select_achievement_err_msg')?.classList.remove('d-none');
+		document.getElementById('achievement-table')?.addEventListener('change', e => {
+			document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+		}, { once : true });
+		return false;
+	};
+
+	document.getElementById('achievement-list')?.addEventListener('submit', e => {
+		const action = document.getElementById('current_action')?.value || '';
+		if (['edit', 'assign', 'export', 'score'].includes(action)) {
+			if (!is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+		} else if (action === 'import') {
+			const import_file = document.getElementById('import_file_select');
+			if (!import_file.value.endsWith('.axp')) {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('import_file_err_msg')?.classList.remove('d-none');
+				import_file.classList.add('is-invalid');
+				import_file.addEventListener(
+					'change',
+					() => {
+						document.getElementById('import_file_err_msg')?.classList.add('d-none');
+						document.getElementById('import_file_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'create') {
+			const create_text = document.getElementById('create_text');
+			if (create_text.value === '') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('create_file_err_msg')?.classList.remove('d-none');
+				create_text.classList.add('is-invalid');
+				create_text.addEventListener('change', e => {
+					document.getElementById('create_file_err_msg')?.classList.add('d-none');
+					document.getElementById('create_text')?.classList.remove('is-invalid');
+				}, { once : true });
+			} else if (document.getElementById('create_select')?.selectedIndex == 1 && !is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+		} else if (action === 'delete') {
+			const delete_confirm = document.getElementById('delete_select');
+			if (!is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (delete_confirm.value != 'yes') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
+				delete_confirm.classList.add('is-invalid');
+				delete_confirm.addEventListener('change', e => {
+					document.getElementById('delete_select')?.classList.remove('is-invalid');
+					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
+		}
+	});
+
+	// Remove select error message when changing tabs.
+	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
+		tab.addEventListener('shown.bs.tab', e => {
+			document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+		}, { once : true });
+	}
+})();

--- a/htdocs/js/AchievementList/achievementlist.js
+++ b/htdocs/js/AchievementList/achievementlist.js
@@ -5,13 +5,17 @@
 			if (achievement.checked) return true;
 		}
 		document.getElementById('select_achievement_err_msg')?.classList.remove('d-none');
-		document.getElementById('achievement-table')?.addEventListener('change', e => {
-			document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
-		}, { once : true });
+		document.getElementById('achievement-table')?.addEventListener(
+			'change',
+			() => {
+				document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+			},
+			{ once: true }
+		);
 		return false;
 	};
 
-	document.getElementById('achievement-list')?.addEventListener('submit', e => {
+	document.getElementById('achievement-list')?.addEventListener('submit', (e) => {
 		const action = document.getElementById('current_action')?.value || '';
 		if (['edit', 'assign', 'export', 'score'].includes(action)) {
 			if (!is_achievement_selected()) {
@@ -41,10 +45,14 @@
 				e.stopPropagation();
 				document.getElementById('create_file_err_msg')?.classList.remove('d-none');
 				create_text.classList.add('is-invalid');
-				create_text.addEventListener('change', e => {
-					document.getElementById('create_file_err_msg')?.classList.add('d-none');
-					document.getElementById('create_text')?.classList.remove('is-invalid');
-				}, { once : true });
+				create_text.addEventListener(
+					'change',
+					() => {
+						document.getElementById('create_file_err_msg')?.classList.add('d-none');
+						document.getElementById('create_text')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			} else if (document.getElementById('create_select')?.selectedIndex == 1 && !is_achievement_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
@@ -59,18 +67,26 @@
 				e.stopPropagation();
 				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
 				delete_confirm.classList.add('is-invalid');
-				delete_confirm.addEventListener('change', e => {
-					document.getElementById('delete_select')?.classList.remove('is-invalid');
-					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				delete_confirm.addEventListener(
+					'change',
+					() => {
+						document.getElementById('delete_select')?.classList.remove('is-invalid');
+						document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		}
 	});
 
 	// Remove select error message when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
-		tab.addEventListener('shown.bs.tab', e => {
-			document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
-		}, { once : true });
+		tab.addEventListener(
+			'shown.bs.tab',
+			() => {
+				document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+			},
+			{ once: true }
+		);
 	}
 })();

--- a/htdocs/js/AchievementList/achievementlist.js
+++ b/htdocs/js/AchievementList/achievementlist.js
@@ -79,14 +79,16 @@
 		}
 	});
 
-	// Remove select error message when changing tabs.
+	// Remove all error messages when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
-		tab.addEventListener(
-			'shown.bs.tab',
-			() => {
-				document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
-			},
-			{ once: true }
-		);
+		tab.addEventListener('shown.bs.tab', () => {
+			const actionForm = document.getElementById('achievement-list');
+			for (const err_msg of actionForm.querySelectorAll('div[id$=_err_msg]')) {
+				err_msg.classList.add('d-none');
+			}
+			for (const invalid of actionForm.querySelectorAll('.is-invalid')) {
+				invalid.classList.remove('is-invalid');
+			}
+		});
 	}
 })();

--- a/htdocs/js/AchievementList/achievementlist.js
+++ b/htdocs/js/AchievementList/achievementlist.js
@@ -9,6 +9,9 @@
 			'change',
 			() => {
 				document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+				for (const id of ['edit_select', 'assign_select', 'export_select', 'score_select']) {
+					document.getElementById(id)?.classList.remove('is-invalid');
+				}
 			},
 			{ once: true }
 		);
@@ -17,10 +20,35 @@
 
 	document.getElementById('achievement-list')?.addEventListener('submit', (e) => {
 		const action = document.getElementById('current_action')?.value || '';
-		if (['edit', 'assign', 'export', 'score'].includes(action)) {
-			if (!is_achievement_selected()) {
+		if (action === 'edit') {
+			const edit_select = document.getElementById('edit_select');
+			if (edit_select.value === 'selected' && !is_achievement_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				edit_select.classList.add('is-invalid');
+				edit_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+						document.getElementById('edit_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'assign') {
+			const assign_select = document.getElementById('assign_select');
+			if (assign_select.value === 'selected' && !is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				assign_select.classList.add('is-invalid');
+				assign_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+						document.getElementById('assign_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action === 'import') {
 			const import_file = document.getElementById('import_file_select');
@@ -34,6 +62,36 @@
 					() => {
 						document.getElementById('import_file_err_msg')?.classList.add('d-none');
 						document.getElementById('import_file_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'export') {
+			const export_select = document.getElementById('export_select');
+			if (export_select.value === 'selected' && !is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				export_select.classList.add('is-invalid');
+				export_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+						document.getElementById('export_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'score') {
+			const score_select = document.getElementById('score_select');
+			if (export_select.value === 'selected' && !is_achievement_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				score_select.classList.add('is-invalid');
+				score_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_achievement_err_msg')?.classList.add('d-none');
+						document.getElementById('score_select')?.classList.remove('is-invalid');
 					},
 					{ once: true }
 				);

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -5,13 +5,17 @@
 			if (set.checked) return true;
 		}
 		document.getElementById('select_set_err_msg')?.classList.remove('d-none');
-		document.getElementById('set_table_id')?.addEventListener('change', e => {
-			document.getElementById('select_set_err_msg')?.classList.add('d-none');
-		}, { once : true });
+		document.getElementById('set_table_id')?.addEventListener(
+			'change',
+			() => {
+				document.getElementById('select_set_err_msg')?.classList.add('d-none');
+			},
+			{ once: true }
+		);
 		return false;
 	};
 
-	document.getElementById('problemsetlist')?.addEventListener('submit', e => {
+	document.getElementById('problemsetlist')?.addEventListener('submit', (e) => {
 		const action = document.getElementById('current_action')?.value || '';
 		if (action === 'filter') {
 			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
@@ -24,10 +28,14 @@
 				e.stopPropagation();
 				document.getElementById('filter_err_msg')?.classList.remove('d-none');
 				filter_text.classList.add('is-invalid');
-				filter_text.addEventListener('change', e => {
-					document.getElementById('filter_err_msg')?.classList.add('d-none');
-					document.getElementById('filter_text')?.classList.remove('is-invalid');
-				}, { once : true });
+				filter_text.addEventListener(
+					'change',
+					() => {
+						document.getElementById('filter_err_msg')?.classList.add('d-none');
+						document.getElementById('filter_text')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			}
 		} else if (['edit', 'publish', 'export', 'save_export', 'score'].includes(action)) {
 			if (!is_set_selected()) {
@@ -41,10 +49,14 @@
 				e.stopPropagation();
 				document.getElementById('import_file_err_msg')?.classList.remove('d-none');
 				import_select.classList.add('is-invalid');
-				import_select.addEventListener('change', e => {
-					document.getElementById('import_source_select')?.classList.remove('is-invalid');
-					document.getElementById('import_file_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				import_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('import_source_select')?.classList.remove('is-invalid');
+						document.getElementById('import_file_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action === 'create') {
 			const create_text = document.getElementById('create_text');
@@ -53,10 +65,14 @@
 				e.stopPropagation();
 				document.getElementById('create_file_err_msg')?.classList.remove('d-none');
 				create_text.classList.add('is-invalid');
-				create_text.addEventListener('change', e => {
-					document.getElementById('create_file_err_msg')?.classList.add('d-none');
-					document.getElementById('create_text')?.classList.remove('is-invalid');
-				}, { once : true });
+				create_text.addEventListener(
+					'change',
+					() => {
+						document.getElementById('create_file_err_msg')?.classList.add('d-none');
+						document.getElementById('create_text')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			} else if (document.getElementById('create_select')?.selectedIndex == 1 && !is_set_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
@@ -71,17 +87,21 @@
 				e.stopPropagation();
 				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
 				delete_confirm.classList.add('is-invalid');
-				delete_confirm.addEventListener('change', e => {
-					document.getElementById('delete_select')?.classList.remove('is-invalid');
-					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				delete_confirm.addEventListener(
+					'change',
+					() => {
+						document.getElementById('delete_select')?.classList.remove('is-invalid');
+						document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		}
 	});
 
 	// Remove select error message when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
-		tab.addEventListener('shown.bs.tab', e => {
+		tab.addEventListener('shown.bs.tab', () => {
 			document.getElementById('select_set_err_msg')?.classList.add('d-none');
 		});
 	}
@@ -135,17 +155,16 @@
 	// Initialize the date/time picker for the import form.
 	const importDateShift = document.getElementById('import_date_shift');
 	if (importDateShift) {
-
 		luxon.Settings.defaultLocale = importDateShift.dataset.locale ?? 'en';
 
 		// Compute the time difference between the current browser timezone and the course timezone.
 		// flatpickr gives the time in the browser's timezone, and this is used to adjust to the course timezone.
 		// Note that this is in seconds.
-		const timezoneAdjustment = (
-			(new Date((new Date).toLocaleString('en-US'))).getTime() -
-			(new Date((new Date).toLocaleString('en-US',
-				{ timeZone: importDateShift.dataset.timezone ?? 'America/New_York' }))).getTime()
-		);
+		const timezoneAdjustment =
+			new Date(new Date().toLocaleString('en-US')).getTime() -
+			new Date(
+				new Date().toLocaleString('en-US', { timeZone: importDateShift.dataset.timezone ?? 'America/New_York' })
+			).getTime();
 
 		const fp = flatpickr(importDateShift.parentNode, {
 			allowInput: true,

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -9,6 +9,15 @@
 			'change',
 			() => {
 				document.getElementById('select_set_err_msg')?.classList.add('d-none');
+				for (const id of [
+					'filter_select',
+					'edit_select',
+					'publish_filter_select',
+					'export_select',
+					'score_select'
+				]) {
+					document.getElementById(id)?.classList.remove('is-invalid');
+				}
 			},
 			{ once: true }
 		);
@@ -23,6 +32,13 @@
 			if (filter === 1 && !is_set_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				document.getElementById('filter_select')?.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_set_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			} else if (filter === 2 && filter_text.value === '') {
 				e.preventDefault();
 				e.stopPropagation();
@@ -37,10 +53,70 @@
 					{ once: true }
 				);
 			}
-		} else if (['edit', 'publish', 'export', 'save_export', 'score'].includes(action)) {
+		} else if (action === 'edit') {
+			const edit_select = document.getElementById('edit_select');
+			if (edit_select.value === 'selected' && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				edit_select.classList.add('is-invalid');
+				edit_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_set_err_msg')?.classList.add('d-none');
+						document.getElementById('edit_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'publish') {
+			const publish_select = document.getElementById('publish_filter_select');
+			if (publish_select.value === 'selected' && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				publish_select.classList.add('is-invalid');
+				publish_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_set_err_msg')?.classList.add('d-none');
+						document.getElementById('publish_filter_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'export') {
+			const export_select = document.getElementById('export_select');
+			if (export_select.value === 'selected' && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				export_select.classList.add('is-invalid');
+				export_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_set_err_msg')?.classList.add('d-none');
+						document.getElementById('export_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'save_export') {
 			if (!is_set_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+			}
+		} else if (action === 'score') {
+			const score_select = document.getElementById('score_select');
+			if (score_select.value === 'selected' && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				score_select.classList.add('is-invalid');
+				score_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_set_err_msg')?.classList.add('d-none');
+						document.getElementById('score_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action === 'import') {
 			const import_select = document.getElementById('import_source_select');

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -99,10 +99,16 @@
 		}
 	});
 
-	// Remove select error message when changing tabs.
+	// Remove all error messages when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
 		tab.addEventListener('shown.bs.tab', () => {
-			document.getElementById('select_set_err_msg')?.classList.add('d-none');
+			const actionForm = document.getElementById('problemsetlist');
+			for (const err_msg of actionForm.querySelectorAll('div[id$=_err_msg]')) {
+				err_msg.classList.add('d-none');
+			}
+			for (const invalid of actionForm.querySelectorAll('.is-invalid')) {
+				invalid.classList.remove('is-invalid');
+			}
 		});
 	}
 

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -20,10 +20,10 @@
 		if (action === 'filter') {
 			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
 			const filter_text = document.getElementById('filter_text');
-			if (filter === 2 && !is_set_selected()) {
+			if (filter === 1 && !is_set_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
-			} else if (filter === 3 && filter_text.value === '') {
+			} else if (filter === 2 && filter_text.value === '') {
 				e.preventDefault();
 				e.stopPropagation();
 				document.getElementById('filter_err_msg')?.classList.remove('d-none');
@@ -116,7 +116,7 @@
 	const filter_select = document.getElementById('filter_select');
 	const filter_elements = document.getElementById('filter_elements');
 	const filterElementToggle = () => {
-		if (filter_select?.selectedIndex == 3) filter_elements.style.display = 'flex';
+		if (filter_select?.selectedIndex == 2) filter_elements.style.display = 'flex';
 		else filter_elements.style.display = 'none';
 	};
 

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -1,20 +1,90 @@
 (() => {
-	// Show the filter error message if the 'Filter' button is clicked when matching set IDs without having entered
-	// a text to filter on.
-	document.getElementById('take_action')?.addEventListener('click',
-		(e) => {
-			const filter_err_msg = document.getElementById('filter_err_msg');
+	// Action form validation.
+	const is_set_selected = () => {
+		for (const set of document.getElementsByName('selected_sets')) {
+			if (set.checked) return true;
+		}
+		document.getElementById('select_set_err_msg')?.classList.remove('d-none');
+		document.getElementById('set_table_id')?.addEventListener('change', e => {
+			document.getElementById('select_set_err_msg')?.classList.add('d-none');
+		}, { once : true });
+		return false;
+	};
 
-			if (filter_err_msg &&
-				document.getElementById('current_action')?.value === 'filter' &&
-				document.getElementById('filter_select')?.selectedIndex === 3 &&
-				document.getElementById('filter_text')?.value === '') {
-				filter_err_msg.classList.remove('d-none');
+	document.getElementById('problemsetlist')?.addEventListener('submit', e => {
+		const action = document.getElementById('current_action')?.value || '';
+		if (action === 'filter') {
+			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
+			const filter_text = document.getElementById('filter_text');
+			if (filter === 2 && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (filter === 3 && filter_text.value === '') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('filter_err_msg')?.classList.remove('d-none');
+				filter_text.classList.add('is-invalid');
+				filter_text.addEventListener('change', e => {
+					document.getElementById('filter_err_msg')?.classList.add('d-none');
+					document.getElementById('filter_text')?.classList.remove('is-invalid');
+				}, { once : true });
+			}
+		} else if (['edit', 'publish', 'export', 'save_export', 'score'].includes(action)) {
+			if (!is_set_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
 			}
+		} else if (action === 'import') {
+			const import_select = document.getElementById('import_source_select');
+			if (!import_select.value.endsWith('.def')) {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('import_file_err_msg')?.classList.remove('d-none');
+				import_select.classList.add('is-invalid');
+				import_select.addEventListener('change', e => {
+					document.getElementById('import_source_select')?.classList.remove('is-invalid');
+					document.getElementById('import_file_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
+		} else if (action === 'create') {
+			const create_text = document.getElementById('create_text');
+			if (create_text.value === '') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('create_file_err_msg')?.classList.remove('d-none');
+				create_text.classList.add('is-invalid');
+				create_text.addEventListener('change', e => {
+					document.getElementById('create_file_err_msg')?.classList.add('d-none');
+					document.getElementById('create_text')?.classList.remove('is-invalid');
+				}, { once : true });
+			} else if (document.getElementById('create_select')?.selectedIndex == 1 && !is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+		} else if (action === 'delete') {
+			const delete_confirm = document.getElementById('delete_select');
+			if (!is_set_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (delete_confirm.value != 'yes') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
+				delete_confirm.classList.add('is-invalid');
+				delete_confirm.addEventListener('change', e => {
+					document.getElementById('delete_select')?.classList.remove('is-invalid');
+					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
 		}
-	);
+	});
+
+	// Remove select error message when changing tabs.
+	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
+		tab.addEventListener('shown.bs.tab', e => {
+			document.getElementById('select_set_err_msg')?.classList.add('d-none');
+		});
+	}
 
 	// Toggle the display of the filter elements as the filter select changes.
 	const filter_select = document.getElementById('filter_select');

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -63,16 +63,45 @@
 					{ once: true }
 				);
 			}
-		} else if (action === 'edit' || action === 'password') {
-			if (!is_user_selected()) {
+		} else if (action === 'edit') {
+			const edit_select = document.getElementById('edit_select');
+			if (edit_select.value === 'selected' && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				edit_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
+			}
+		} else if (action === 'password') {
+			const password_select = document.getElementById('password_select');
+			if (password_select.value === 'selected' && !is_user_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+				password_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action == 'export') {
 			const export_filename = document.getElementById('export_filename');
-			if (!is_user_selected()) {
+			const export_select = document.getElementById('export_select_scope');
+			if (export_select.value === 'selected' && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				export_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			} else if (
 				document.getElementById('export_select_target')?.value === 'new' &&
 				export_filename.value === ''

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -24,4 +24,80 @@
 		export_select_target.addEventListener('change', classlist_add_export_elements);
 		classlist_add_export_elements();
 	}
+
+	// Action form validation.
+	const is_user_selected = () => {
+		for (const user of document.getElementsByName('selected_users')) {
+			if (user.checked) return true;
+		}
+		document.getElementById('select_user_err_msg')?.classList.remove('d-none');
+		document.getElementById('classlist-table')?.addEventListener('change', e => {
+			document.getElementById('select_user_err_msg')?.classList.add('d-none');
+		}, { once : true });
+		return false;
+	};
+
+	document.getElementById('user-list-form')?.addEventListener('submit', e => {
+		const action = document.getElementById('current_action')?.value || '';
+		if (action === 'filter') {
+			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
+			const filter_text = document.getElementById('filter_text');
+			if (filter === 2 && !is_user_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (filter === 3 && filter_text.value === '') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('filter_err_msg')?.classList.remove('d-none');
+				filter_text.classList.add('is-invalid');
+				filter_text.addEventListener('change', e => {
+					document.getElementById('filter_text')?.classList.remove('is-invalid');
+					document.getElementById('filter_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
+		} else if (action === 'edit' || action === 'password') {
+			if (!is_user_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			}
+		} else if (action == 'export') {
+			const export_filename = document.getElementById('export_filename');
+			if (!is_user_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (document.getElementById('export_select_target')?.value === 'new' &&
+						export_filename.value === '') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('export_file_err_msg')?.classList.remove('d-none');
+				export_filename.classList.add('is-invalid');
+				export_filename.addEventListener('change', e => {
+					document.getElementById('export_filename')?.classList.remove('is-invalid');
+					document.getElementById('export_file_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
+		} else if (action === 'delete') {
+			const delete_confirm = document.getElementById('delete_select');
+			if (!is_user_selected()) {
+				e.preventDefault();
+				e.stopPropagation();
+			} else if (delete_confirm.value != 'yes') {
+				e.preventDefault();
+				e.stopPropagation();
+				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
+				delete_confirm.classList.add('is-invalid');
+				delete_confirm.addEventListener('change', e => {
+					document.getElementById('delete_select')?.classList.remove('is-invalid');
+					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+				}, { once : true });
+			}
+		}
+	});
+
+	// Remove select error message when changing tabs.
+	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
+		tab.addEventListener('shown.bs.tab', e => {
+			document.getElementById('select_user_err_msg')?.classList.add('d-none');
+		});
+	}
 })();

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -31,13 +31,17 @@
 			if (user.checked) return true;
 		}
 		document.getElementById('select_user_err_msg')?.classList.remove('d-none');
-		document.getElementById('classlist-table')?.addEventListener('change', e => {
-			document.getElementById('select_user_err_msg')?.classList.add('d-none');
-		}, { once : true });
+		document.getElementById('classlist-table')?.addEventListener(
+			'change',
+			() => {
+				document.getElementById('select_user_err_msg')?.classList.add('d-none');
+			},
+			{ once: true }
+		);
 		return false;
 	};
 
-	document.getElementById('user-list-form')?.addEventListener('submit', e => {
+	document.getElementById('user-list-form')?.addEventListener('submit', (e) => {
 		const action = document.getElementById('current_action')?.value || '';
 		if (action === 'filter') {
 			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
@@ -50,10 +54,14 @@
 				e.stopPropagation();
 				document.getElementById('filter_err_msg')?.classList.remove('d-none');
 				filter_text.classList.add('is-invalid');
-				filter_text.addEventListener('change', e => {
-					document.getElementById('filter_text')?.classList.remove('is-invalid');
-					document.getElementById('filter_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				filter_text.addEventListener(
+					'change',
+					() => {
+						document.getElementById('filter_text')?.classList.remove('is-invalid');
+						document.getElementById('filter_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action === 'edit' || action === 'password') {
 			if (!is_user_selected()) {
@@ -65,16 +73,22 @@
 			if (!is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
-			} else if (document.getElementById('export_select_target')?.value === 'new' &&
-						export_filename.value === '') {
+			} else if (
+				document.getElementById('export_select_target')?.value === 'new' &&
+				export_filename.value === ''
+			) {
 				e.preventDefault();
 				e.stopPropagation();
 				document.getElementById('export_file_err_msg')?.classList.remove('d-none');
 				export_filename.classList.add('is-invalid');
-				export_filename.addEventListener('change', e => {
-					document.getElementById('export_filename')?.classList.remove('is-invalid');
-					document.getElementById('export_file_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				export_filename.addEventListener(
+					'change',
+					() => {
+						document.getElementById('export_filename')?.classList.remove('is-invalid');
+						document.getElementById('export_file_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		} else if (action === 'delete') {
 			const delete_confirm = document.getElementById('delete_select');
@@ -86,17 +100,21 @@
 				e.stopPropagation();
 				document.getElementById('delete_confirm_err_msg')?.classList.remove('d-none');
 				delete_confirm.classList.add('is-invalid');
-				delete_confirm.addEventListener('change', e => {
-					document.getElementById('delete_select')?.classList.remove('is-invalid');
-					document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
-				}, { once : true });
+				delete_confirm.addEventListener(
+					'change',
+					() => {
+						document.getElementById('delete_select')?.classList.remove('is-invalid');
+						document.getElementById('delete_confirm_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
 			}
 		}
 	});
 
 	// Remove select error message when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
-		tab.addEventListener('shown.bs.tab', e => {
+		tab.addEventListener('shown.bs.tab', () => {
 			document.getElementById('select_user_err_msg')?.classList.add('d-none');
 		});
 	}

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -35,6 +35,9 @@
 			'change',
 			() => {
 				document.getElementById('select_user_err_msg')?.classList.add('d-none');
+				for (const id of ['filter_select', 'edit_select', 'password_select', 'export_select_scope']) {
+					document.getElementById(id)?.classList.remove('is-invalid');
+				}
 			},
 			{ once: true }
 		);
@@ -44,11 +47,21 @@
 	document.getElementById('user-list-form')?.addEventListener('submit', (e) => {
 		const action = document.getElementById('current_action')?.value || '';
 		if (action === 'filter') {
-			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
+			const filter_select = document.getElementById('filter_select');
+			const filter = filter_select?.selectedIndex || 0;
 			const filter_text = document.getElementById('filter_text');
 			if (filter === 1 && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				filter_select.classList.add('is-invalid');
+				filter_select.addEventListener(
+					'change',
+					() => {
+						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+						document.getElementById('filter_select')?.classList.remove('is-invalid');
+					},
+					{ once: true }
+				);
 			} else if (filter === 2 && filter_text.value === '') {
 				e.preventDefault();
 				e.stopPropagation();
@@ -68,10 +81,12 @@
 			if (edit_select.value === 'selected' && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				edit_select.classList.add('is-invalid');
 				edit_select.addEventListener(
 					'change',
 					() => {
 						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+						document.getElementById('edit_select')?.classList.remove('is-invalid');
 					},
 					{ once: true }
 				);
@@ -81,10 +96,12 @@
 			if (password_select.value === 'selected' && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				password_select.classList.add('is-invalid');
 				password_select.addEventListener(
 					'change',
 					() => {
 						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+						document.getElementById('password_select')?.classList.remove('is-invalid');
 					},
 					{ once: true }
 				);
@@ -95,10 +112,12 @@
 			if (export_select.value === 'selected' && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
+				export_select.classList.add('is-invalid');
 				export_select.addEventListener(
 					'change',
 					() => {
 						document.getElementById('select_user_err_msg')?.classList.add('d-none');
+						document.getElementById('export_select_scope')?.classList.remove('is-invalid');
 					},
 					{ once: true }
 				);
@@ -109,11 +128,22 @@
 				e.preventDefault();
 				e.stopPropagation();
 				document.getElementById('export_file_err_msg')?.classList.remove('d-none');
+				document.getElementById('export_select_target')?.classList.add('is-invalid');
 				export_filename.classList.add('is-invalid');
 				export_filename.addEventListener(
 					'change',
 					() => {
 						document.getElementById('export_filename')?.classList.remove('is-invalid');
+						document.getElementById('export_select_target')?.classList.remove('is-invalid');
+						document.getElementById('export_file_err_msg')?.classList.add('d-none');
+					},
+					{ once: true }
+				);
+				document.getElementById('export_select_target')?.addEventListener(
+					'change',
+					() => {
+						document.getElementById('export_filename')?.classList.remove('is-invalid');
+						document.getElementById('export_select_target')?.classList.remove('is-invalid');
 						document.getElementById('export_file_err_msg')?.classList.add('d-none');
 					},
 					{ once: true }

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -46,10 +46,10 @@
 		if (action === 'filter') {
 			const filter = document.getElementById('filter_select')?.selectedIndex || 0;
 			const filter_text = document.getElementById('filter_text');
-			if (filter === 2 && !is_user_selected()) {
+			if (filter === 1 && !is_user_selected()) {
 				e.preventDefault();
 				e.stopPropagation();
-			} else if (filter === 3 && filter_text.value === '') {
+			} else if (filter === 2 && filter_text.value === '') {
 				e.preventDefault();
 				e.stopPropagation();
 				document.getElementById('filter_err_msg')?.classList.remove('d-none');

--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -112,10 +112,16 @@
 		}
 	});
 
-	// Remove select error message when changing tabs.
+	// Remove all error messages when changing tabs.
 	for (const tab of document.querySelectorAll('a[data-bs-toggle="tab"]')) {
 		tab.addEventListener('shown.bs.tab', () => {
-			document.getElementById('select_user_err_msg')?.classList.add('d-none');
+			const actionForm = document.getElementById('user-list-form');
+			for (const err_msg of actionForm.querySelectorAll('div[id$=_err_msg]')) {
+				err_msg.classList.add('d-none');
+			}
+			for (const invalid of actionForm.querySelectorAll('.is-invalid')) {
+				invalid.classList.remove('is-invalid');
+			}
 		});
 	}
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -82,7 +82,7 @@ sub initialize ($c) {
 	$c->stash->{formsToShow}  = VIEW_FORMS();
 	$c->stash->{formTitles}   = FORM_TITLES();
 	$c->stash->{achievements} = [];
-	$c->stash->{axpList}      = [ $c->getAxpList ];
+	$c->stash->{axpList}      = [];
 
 	# Check permissions
 	return unless $authz->hasPermissions($user, 'edit_achievements');
@@ -132,6 +132,7 @@ sub initialize ($c) {
 	}
 
 	$c->stash->{formsToShow} = $c->{editMode} ? EDIT_FORMS() : $c->{exportMode} ? EXPORT_FORMS() : VIEW_FORMS();
+	$c->stash->{axpList}     = [ $c->getAxpList ] unless $c->{editMode} || $c->{exportMode};
 
 	# Get and sort achievements. Achievements are sorted by in the order they are evaluated.
 	$c->stash->{achievements} = [ sortAchievements($c->db->getAchievements(@{ $c->{allAchievementIDs} })) ];

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -15,6 +15,7 @@
 
 package WeBWorK::ContentGenerator::Instructor::ProblemSetList;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
+use WeBWorK::Utils::Instructor qw(getDefList);
 
 =head1 NAME
 
@@ -158,18 +159,7 @@ sub pre_header_initialize ($c) {
 	$c->{totalUsers} = $db->countUsers;
 
 	if (defined $c->param('action') && $c->param('action') eq 'score' && $authz->hasPermissions($user, 'score_sets')) {
-		my $scope = $c->param('action.score.scope');
-		my @setsToScore;
-
-		if ($scope eq 'none') {
-			return;
-		} elsif ($scope eq 'all') {
-			@setsToScore = @{ $c->{allSetIDs} };
-		} elsif ($scope eq 'visible') {
-			@setsToScore = @{ $c->param('visibleSetIDs') };
-		} elsif ($scope eq 'selected') {
-			@setsToScore = $c->param('selected_sets');
-		}
+		my @setsToScore = $c->param('selected_sets');
 
 		return unless @setsToScore;
 
@@ -198,6 +188,7 @@ sub initialize ($c) {
 	$c->stash->{fieldTypes}     = FIELD_TYPES();
 	$c->stash->{sortableFields} = SORTABLE_FIELDS();
 	$c->stash->{sets}           = [];
+	$c->stash->{setDefList}     = [ getDefList($ce) ];
 
 	# Determine if the user has permisson to do anything here.
 	return unless $authz->hasPermissions($user, 'access_instructor_tools');
@@ -373,62 +364,24 @@ sub sort_handler ($c) {
 }
 
 sub edit_handler ($c) {
-	my $result;
+	$c->{visibleSetIDs} = [ $c->param('selected_sets') ];
+	$c->{editMode}      = 1;
 
-	my $scope = $c->param('action.edit.scope');
-	if ($scope eq "all") {
-		$result = $c->maketext('Editing all sets.');
-		$c->{visibleSetIDs} = $c->{allSetIDs};
-	} elsif ($scope eq "visible") {
-		$result = $c->maketext('Editing listed sets.');
-		# leave visibleSetIDs alone
-	} elsif ($scope eq "selected") {
-		$result = $c->maketext('Editing selected sets.');
-		$c->{visibleSetIDs} = [ $c->param('selected_sets') ];
-	}
-	$c->{editMode} = 1;
-
-	return (1, $result);
+	return (1, $c->maketext('Editing selected sets.'));
 }
 
 sub publish_handler ($c) {
-	my $db = $c->db;
-
-	my @result;
-
-	my $scope = $c->param('action.publish.scope');
-	my $value = $c->param('action.publish.value');
-
-	my @setIDs;
-
-	if ($scope eq "none") {
-		@setIDs = ();
-		@result = (0, $c->maketext('No change made to any set.'));
-	} elsif ($scope eq "all") {
-		@setIDs = @{ $c->{allSetIDs} };
-		@result =
-			$value
-			? (1, $c->maketext('All sets made visible for all students.'))
-			: (1, $c->maketext('All sets hidden from all students.'));
-	} elsif ($scope eq "visible") {
-		@setIDs = @{ $c->{visibleSetIDs} };
-		@result =
-			$value
-			? (1, $c->maketext('All listed sets were made visible for all the students.'))
-			: (1, $c->maketext('All listed sets were hidden from all the students.'));
-	} elsif ($scope eq "selected") {
-		@setIDs = $c->param('selected_sets');
-		@result =
-			$value
-			? (1, $c->maketext('All selected sets made visible for all students.'))
-			: (1, $c->maketext('All selected sets hidden from all students.'));
-	}
+	my $db     = $c->db;
+	my $value  = $c->param('action.publish.value');
+	my @setIDs = $c->param('selected_sets');
 
 	# Can we use UPDATE here, instead of fetch/change/store?
 	my @sets = $db->getGlobalSets(@setIDs);
 	map { $_->visible($value); $db->putGlobalSet($_); } @sets;
 
-	return @result;
+	return $value
+		? (1, $c->maketext('All selected sets made visible for all students.'))
+		: (1, $c->maketext('All selected sets hidden from all students.'));
 }
 
 sub score_handler ($c) {
@@ -438,16 +391,12 @@ sub score_handler ($c) {
 }
 
 sub delete_handler ($c) {
-	my $db = $c->db;
+	my $db      = $c->db;
+	my $confirm = $c->param('action.delete.confirm');
 
-	my $scope = $c->param('action.delete.scope');
+	return (1, $c->maketext('Deleted [_1] sets.', 0)) unless ($confirm eq 'yes');
 
-	my @setIDsToDelete = ();
-
-	if ($scope eq "selected") {
-		@setIDsToDelete = @{ $c->{selectedSetIDs} };
-	}
-
+	my @setIDsToDelete = @{ $c->{selectedSetIDs} };
 	my %allSetIDs      = map { $_ => 1 } @{ $c->{allSetIDs} };
 	my %visibleSetIDs  = map { $_ => 1 } @{ $c->{visibleSetIDs} };
 	my %selectedSetIDs = map { $_ => 1 } @{ $c->{selectedSetIDs} };
@@ -463,8 +412,7 @@ sub delete_handler ($c) {
 	$c->{visibleSetIDs}  = [ keys %visibleSetIDs ];
 	$c->{selectedSetIDs} = [ keys %selectedSetIDs ];
 
-	my $num = @setIDsToDelete;
-	return (1, $c->maketext('Deleted [_1] sets.', $num));
+	return (1, $c->maketext('Deleted [_1] sets.', scalar @setIDsToDelete));
 }
 
 sub create_handler ($c) {
@@ -595,22 +543,10 @@ sub import_handler ($c) {
 
 # this does not actually export any files, rather it sends us to a new page in order to export the files
 sub export_handler ($c) {
-	my $result;
+	$c->{selectedSetIDs} = $c->{visibleSetIDs} = [ $c->param('selected_sets') ];
+	$c->{exportMode}     = 1;
 
-	my $scope = $c->param('action.export.scope');
-	if ($scope eq "all") {
-		$result = $c->maketext("All sets were selected for export.");
-		$c->{selectedSetIDs} = $c->{visibleSetIDs} = $c->{allSetIDs};
-	} elsif ($scope eq "visible") {
-		$result = $c->maketext("Visible sets were selected for export.");
-		$c->{selectedSetIDs} = $c->{visibleSetIDs};
-	} elsif ($scope eq "selected") {
-		$result = $c->maketext("Sets were selected for export.");
-		$c->{selectedSetIDs} = $c->{visibleSetIDs} = [ $c->param('selected_sets') ];
-	}
-	$c->{exportMode} = 1;
-
-	return (1, $result);
+	return (1, $c->maketext('Selected sets were exported.'));
 }
 
 sub cancel_export_handler ($c) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -31,7 +31,7 @@ What do we want to be able to do here?
 filter sort edit publish import create delete
 
 Filter what sets are shown:
-	- none, all, selected
+	- all, selected
 	- matching set_id, visible to students, hidden from students
 
 Sort sets by:
@@ -293,9 +293,6 @@ sub filter_handler ($c) {
 	if ($scope eq "all") {
 		$result = $c->maketext('Showing all sets.');
 		$c->{visibleSetIDs} = $c->{allSetIDs};
-	} elsif ($scope eq "none") {
-		$result = $c->maketext('Showing no sets.');
-		$c->{visibleSetIDs} = [];
 	} elsif ($scope eq "selected") {
 		$result = $c->maketext('Showing selected sets.');
 		$c->{visibleSetIDs} = [ $c->param('selected_sets') ];

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -189,7 +189,7 @@ sub initialize ($c) {
 	$c->stash->{fieldTypes}     = FIELD_TYPES();
 	$c->stash->{sortableFields} = SORTABLE_FIELDS();
 	$c->stash->{sets}           = [];
-	$c->stash->{setDefList}     = [ getDefList($ce) ];
+	$c->stash->{setDefList}     = [];
 
 	# Determine if the user has permisson to do anything here.
 	return unless $authz->hasPermissions($user, 'access_instructor_tools');
@@ -264,6 +264,7 @@ sub initialize ($c) {
 		&& ($c->{secondarySortOrder} eq 'ASC' || $c->{secondarySortOrder} eq 'DESC');
 
 	$c->stash->{formsToShow} = $c->{editMode} ? EDIT_FORMS() : $c->{exportMode} ? EXPORT_FORMS() : VIEW_FORMS();
+	$c->stash->{setDefList}  = [ getDefList($ce) ] unless $c->{editMode} || $c->{exportMode};
 	# Get requested sets in the requested order.
 	$c->stash->{sets} = [
 		@{ $c->{visibleSetIDs} }

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -28,7 +28,7 @@ data editing
 What do we want to be able to do here?
 
 Filter what users are shown:
-	- none, all, selected
+	- all, selected
 	- matching user_id, matching section, matching recitation
 Switch from view mode to edit mode:
 	- showing visible users
@@ -273,9 +273,6 @@ sub filter_handler ($c) {
 	if ($scope eq 'all') {
 		$result = $c->maketext('Showing all users.');
 		$c->{visibleUserIDs} = { map { $_ => 1 } @{ $c->{allUserIDs} } };
-	} elsif ($scope eq 'none') {
-		$result = $c->maketext('Showing no users.');
-		$c->{visibleUserIDs} = {};
 	} elsif ($scope eq 'selected') {
 		$result = $c->maketext('Showing selected users.');
 		$c->{visibleUserIDs} = $c->{selectedUserIDs};

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -347,19 +347,25 @@ sub sort_handler ($c) {
 }
 
 sub edit_handler ($c) {
-	my @usersToEdit = grep { $c->{userIsEditable}{$_} } (keys %{ $c->{selectedUserIDs} });
+	my $scope = $c->param('action.edit.scope');
+	my @usersToEdit =
+		grep { $c->{userIsEditable}{$_} } ($scope eq 'all' ? @{ $c->{allUserIDs} } : (keys %{ $c->{selectedUserIDs} }));
 	$c->{visibleUserIDs} = { map { $_ => 1 } @usersToEdit };
 	$c->{editMode}       = 1;
 
-	return $c->maketext('Editing selected users.');
+	return $scope eq 'all' ? $c->maketext('Editing all users.') : $c->maketext('Editing selected users.');
 }
 
 sub password_handler ($c) {
-	my @usersToEdit = grep { $c->{userIsEditable}{$_} } (keys %{ $c->{selectedUserIDs} });
+	my $scope = $c->param('action.password.scope');
+	my @usersToEdit =
+		grep { $c->{userIsEditable}{$_} } ($scope eq 'all' ? @{ $c->{allUserIDs} } : (keys %{ $c->{selectedUserIDs} }));
 	$c->{visibleUserIDs} = { map { $_ => 1 } @usersToEdit };
 	$c->{passwordMode}   = 1;
 
-	return $c->maketext('Giving new passwords to selected users.');
+	return $scope eq 'all'
+		? $c->maketext('Giving new passwords to all users.')
+		: $c->maketext('Giving new passwords to selected users.');
 }
 
 sub delete_handler ($c) {
@@ -451,6 +457,7 @@ sub export_handler ($c) {
 	my $ce  = $c->ce;
 	my $dir = $ce->{courseDirs}{templates};
 
+	my $scope  = $c->param('action.export.scope');
 	my $target = $c->param('action.export.target');
 	my $new    = $c->param('action.export.new');
 
@@ -466,7 +473,7 @@ sub export_handler ($c) {
 
 	$fileName .= '.lst' unless $fileName =~ m/\.lst$/;
 
-	my @userIDsToExport = keys %{ $c->{selectedUserIDs} };
+	my @userIDsToExport = $scope eq 'all' ? @{ $c->{allUserIDs} } : keys %{ $c->{selectedUserIDs} };
 	$c->exportUsersToCSV($fileName, @userIDsToExport);
 
 	return $c->maketext('[_1] users exported to file [_2]', scalar @userIDsToExport, "$dir/$fileName");

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -255,7 +255,7 @@ sub initialize ($c) {
 	$c->stash->{formPerms}       = FORM_PERMS();
 	$c->stash->{fields}          = FIELDS();
 	$c->stash->{fieldProperties} = FIELD_PROPERTIES();
-	$c->stash->{CSVList}         = [ getCSVList($c->ce) ];
+	$c->stash->{CSVList}         = $c->{editMode} || $c->{passwordMode} ? [] : [ getCSVList($c->ce) ];
 
 	return;
 }

--- a/templates/ContentGenerator/Instructor/AchievementList.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList.html.ep
@@ -1,8 +1,9 @@
 % use WeBWorK::Utils qw(getAssetURL);
 %
 % content_for js => begin
-	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'), defer => undef =%>
-	<%= javascript getAssetURL($ce, 'js/SelectAll/selectall.js'),   defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'),           defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/AchievementList/achievementlist.js'), defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/SelectAll/selectall.js'),             defer => undef =%>
 % end
 %
 % unless ($authz->hasPermissions(param('user'), 'edit_achievements')) {
@@ -26,7 +27,9 @@
 			% for my $actionID (@$formsToShow) {
 				<li class="nav-item" role="presentation">
 					<%= link_to maketext($formTitles->{$actionID}) => "#$actionID",
-						class           => 'nav-link action-link' . ($actionID eq $formsToShow->[0] ? ' active' : ''),
+						class           => 'nav-link action-link'
+							. ($actionID eq $formsToShow->[0] ? ' active' : '')
+							. ($actionID eq 'import' && !@$axpList ? ' disabled' : ''),
 						id              => "$actionID-tab",
 						data            => { action => $actionID, bs_toggle => 'tab', bs_target => "#$actionID" },
 						role            => 'tab',
@@ -44,8 +47,10 @@
 			% }
 		</div>
 	</div>
-	<%= submit_button maketext($formTitles->{ $formsToShow->[0] }),
-		id => 'take_action', class => 'btn btn-primary mb-3' =%>
+	<div>
+		<%= submit_button maketext($formTitles->{ $formsToShow->[0] }),
+			id => 'take_action', class => 'btn btn-primary mb-3' =%>
+	</div>
 	% if ($c->{exportMode}) {
 		<%= include 'ContentGenerator/Instructor/AchievementList/export_table' =%>
 	% } elsif ($c->{editMode}) {

--- a/templates/ContentGenerator/Instructor/AchievementList/assign_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/assign_form.html.ep
@@ -1,5 +1,16 @@
 <div>
-	<p><%= maketext('Select achievements to assign to all users.') =%></p>
+	<div class="row mb-2">
+		<%= label_for assign_select => maketext('Assign which achievements?'),
+			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.assign.scope' => [
+					[ maketext('all course achievements') => 'all' ],
+					[ maketext('selected achievements')   => 'selected', selected => undef ]
+				],
+				id    => 'assign_select',
+				class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
 	<div class="row mb-2">
 		<%= label_for 'assign_data_select' => maketext('Choose what to do with existing data:'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>

--- a/templates/ContentGenerator/Instructor/AchievementList/assign_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/assign_form.html.ep
@@ -1,16 +1,5 @@
 <div>
-	<div class="row mb-2">
-		<%= label_for assign_select => maketext('Assign which achievements?'),
-			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
-		<div class="col-auto">
-			<%= select_field 'action.assign.scope' => [
-					[ maketext('all achievements')      => 'all' ],
-					[ maketext('selected achievements') => 'selected', selected => undef ]
-				],
-				id    => 'assign_select',
-				class => 'form-select form-select-sm' =%>
-		</div>
-	</div>
+	<p><%= maketext('Select achievements to assign to all users.') =%></p>
 	<div class="row mb-2">
 		<%= label_for 'assign_data_select' => maketext('Choose what to do with existing data:'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>

--- a/templates/ContentGenerator/Instructor/AchievementList/create_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/create_form.html.ep
@@ -20,4 +20,7 @@
 				class => 'form-select form-select-sm d-inline w-auto' =%>
 		</div>
 	</div>
+	<div id="create_file_err_msg" class="alert alert-danger p-1 mb-0 mt-2 d-inline-flex d-none">
+		<%= maketext('Please enter in an ID for the new achievement.') %>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/default_table.html.ep
@@ -1,3 +1,6 @@
+<div id="select_achievement_err_msg" class="alert alert-danger p-1 mb-0 mt-2 d-inline-flex d-none">
+	<%= maketext('Please select at least one achievement.') %>
+</div>
 <div class="table-responsive">
 	<table class="table table-sm table-bordered font-sm caption-top" id="achievement-table">
 		<caption><%= maketext('Achievement List') %></caption>

--- a/templates/ContentGenerator/Instructor/AchievementList/delete_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/delete_form.html.ep
@@ -3,15 +3,18 @@
 		<em><%= maketext('Deletion destroys all achievement-related data and is not undoable!') =%></em>
 	</div>
 	<div class="row mb-2">
-		<%= label_for delete_select => maketext('Delete which achievements?'),
+		<%= label_for delete_select => maketext('Delete selected achievements?'),
 			class => 'col-form-label col-form-label-sm col-auto' =%>
 		<div class="col-auto">
-			<%= select_field 'action.delete.scope' => [
-					[ maketext('no achievements')       => 'none', selected => undef ],
-					[ maketext('selected achievements') => 'selected' ],
+			<%= select_field 'action.delete.confirm' => [
+					[ maketext('No')  => 'no', selected => undef ],
+					[ maketext('Yes') => 'yes' ],
 				],
 				id    => 'delete_select',
 				class => 'form-select form-select-sm d-inline w-auto me-3' =%>
 		</div>
+	</div>
+	<div id="delete_confirm_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
+		<%= maketext('Please confirm it is okay to delete selected achievements permanently.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/edit_form.html.ep
@@ -1,12 +1,3 @@
 <div class="row mb-2">
-	<%= label_for edit_select => maketext('Edit which achievements?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.edit.scope' => [
-				[ maketext('all achievements')      => 'all' ],
-				[ maketext('selected achievements') => 'selected', selected => undef ],
-			],
-			id    => 'edit_select',
-			class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select achievements to edit.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/edit_form.html.ep
@@ -1,3 +1,12 @@
 <div class="row mb-2">
-	<p><%= maketext('Select achievements to edit.') =%></p>
+<%= label_for edit_select => maketext('Edit which achievements?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.edit.scope' => [
+				[ maketext('all course achievements') => 'all' ],
+				[ maketext('selected achievements')   => 'selected', selected => undef ],
+			],
+			id    => 'edit_select',
+			class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/export_form.html.ep
@@ -1,3 +1,12 @@
 <div class="row mb-2">
-	<p><%= maketext('Select achievements to export.') =%></p>
+<%= label_for export_select => maketext('Export which achievements?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.export.scope' => [
+				[ maketext('all course achievements') => 'all' ],
+				[ maketext('selected achievements')   => 'selected', selected => undef ],
+			],
+			id    => 'export_select',
+			class => 'form-select form-select-sm d-inline w-auto' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/export_form.html.ep
@@ -1,12 +1,3 @@
 <div class="row mb-2">
-	<%= label_for export_select => maketext('Export which achievements?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.export.scope' => [
-				[ maketext('all achievements')      => 'all' ],
-				[ maketext('selected achievements') => 'selected', selected => undef ],
-			],
-			id    => 'export_select',
-			class => 'form-select form-select-sm d-inline w-auto' =%>
-	</div>
+	<p><%= maketext('Select achievements to export.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/import_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/import_form.html.ep
@@ -5,7 +5,7 @@
 		<div class="col-auto">
 			<%= select_field 'action.import.source' => [
 					[ maketext('Select import file') => '', selected => undef ],
-					$c->getAxpList
+					@$axpList
 				],
 				id    => 'import_file_select',
 				class => 'form-select form-select-sm d-inline w-auto' =%>
@@ -22,5 +22,8 @@
 				id    => 'import_users_select',
 				class => 'form-select form-select-sm d-inline w-auto' =%>
 		</div>
+	</div>
+	<div id="import_file_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
+		<%= maketext('Please select a file to import from.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/score_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/score_form.html.ep
@@ -1,3 +1,12 @@
 <div class="row mb-2">
-	<p><%= maketext('Select achievements to score.') =%></p>
+	<%= label_for score_select => maketext('Score which achievements?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.score.scope' => [
+				[ maketext('all course achievements') => 'all' ],
+				[ maketext('selected achievements')   => 'selected', selected => undef ],
+			],
+			id    => 'score_select',
+			class => 'form-select form-select-sm d-inline w-auto' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/AchievementList/score_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementList/score_form.html.ep
@@ -1,13 +1,3 @@
 <div class="row mb-2">
-	<%= label_for score_select => maketext('Score which achievements?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.score.scope' => [
-				[ maketext('no achievements')       => 'none', selected => undef ],
-				[ maketext('all achievements')      => 'all' ],
-				[ maketext('selected achievements') => 'selected' ],
-			],
-			id    => 'score_select',
-			class => 'form-select form-select-sm d-inline w-auto' =%>
-	</div>
+	<p><%= maketext('Select achievements to score.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -80,13 +80,14 @@
 		% # Check permissions
 		% next if $formPerms->{$actionID} && !$authz->hasPermissions(param('user'), $formPerms->{$actionID});
 		%
-		% my $active        = '';
+		% my $disabled = $actionID eq 'import' && !@$setDefList ? ' disabled' : '';
+		% my $active   = '';
 		% unless ($default_choice) { $active = ' active'; $default_choice = $actionID; }
 		%
 		% content_for 'tab-list' => begin
 			<li class="nav-item" role="presentation">
 				<%= link_to maketext($formTitles->{$actionID}) => "#$actionID",
-					class           => "nav-link action-link$active",
+					class           => "nav-link action-link$active$disabled",
 					id              => "$actionID-tab",
 					role            => 'tab',
 					data            => { action => $actionID, bs_toggle => 'tab', bs_target => "#$actionID" },

--- a/templates/ContentGenerator/Instructor/ProblemSetList/create_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/create_form.html.ep
@@ -19,4 +19,7 @@
 				id => 'create_select', class => 'form-select form-select-sm' =%>
 		</div>
 	</div>
+	<div id="create_file_err_msg" class="alert alert-danger p-1 mb-2 d-inline-flex d-none">
+		<%= maketext('Please enter a name for the new set.') %>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/delete_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/delete_form.html.ep
@@ -3,14 +3,17 @@
 		<em><%= maketext('Warning: Deletion destroys all set-related data and is not undoable!') =%></em>
 	</div>
 	<div class="row mb-2">
-		<%= label_for delete_select => maketext('Delete which sets?'),
+		<%= label_for delete_select => maketext('Delete selected sets?'),
 			class => 'col-form-label col-form-label-sm col-auto' =%>
 		<div class="col-auto">
-			<%= select_field 'action.delete.scope' => [
-					[ maketext('no sets')       => 'none', selected => undef ],
-					[ maketext('selected sets') => 'selected' ]
+			<%= select_field 'action.delete.confirm' => [
+					[ maketext('No')  => 'no', selected => undef ],
+					[ maketext('Yes') => 'yes' ]
 				],
 				id => 'delete_select', class => 'form-select form-select-sm' =%>
 		</div>
+	</div>
+	<div id="delete_confirm_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
+		<%= maketext('Please confirm it is okay to delete selected sets permanently.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
@@ -1,11 +1,3 @@
 <div class="row mb-2">
-	<%= label_for edit_select => maketext('Edit which sets?'), class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.edit.scope' => [
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('listed sets')   => 'visible' ],
-				[ maketext('selected sets') => 'selected', selected => undef ]
-			],
-			id => 'edit_select', class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select sets to edit.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
@@ -1,3 +1,10 @@
 <div class="row mb-2">
-	<p><%= maketext('Select sets to edit.') =%></p>
+	<%= label_for edit_select => maketext('Edit which sets?'), class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.edit.scope' => [
+				[ maketext('all sets')      => 'all' ],
+				[ maketext('selected sets') => 'selected', selected => undef ]
+			],
+			id => 'edit_select', class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/edit_form.html.ep
@@ -2,8 +2,8 @@
 	<%= label_for edit_select => maketext('Edit which sets?'), class => 'col-form-label col-form-label-sm col-auto' =%>
 	<div class="col-auto">
 		<%= select_field 'action.edit.scope' => [
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('selected sets') => 'selected', selected => undef ]
+				[ maketext('all course sets') => 'all' ],
+				[ maketext('selected sets')   => 'selected', selected => undef ]
 			],
 			id => 'edit_select', class => 'form-select form-select-sm' =%>
 	</div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
@@ -3,8 +3,8 @@
 		class => 'col-form-label col-form-label-sm col-auto' =%>
 	<div class="col-auto">
 		<%= select_field 'action.export.scope' => [
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('selected sets') => 'selected', selected => undef ],
+				[ maketext('all course sets') => 'all' ],
+				[ maketext('selected sets')   => 'selected', selected => undef ],
 			],
 			id => 'export_select', class => 'form-select form-select-sm' =%>
 	</div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
@@ -1,13 +1,3 @@
 <div class="row mb-2">
-	<%= label_for export_select => maketext('Prepare which sets for export?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.export.scope' => [
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('listed sets')   => 'visible', selected => undef ],
-				[ maketext('selected sets') => 'selected' ],
-
-			],
-			id => 'export_select', class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select sets to export.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/export_form.html.ep
@@ -1,3 +1,11 @@
 <div class="row mb-2">
-	<p><%= maketext('Select sets to export.') =%></p>
+	<%= label_for export_select => maketext('Prepare which sets for export?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.export.scope' => [
+				[ maketext('all sets')      => 'all' ],
+				[ maketext('selected sets') => 'selected', selected => undef ],
+			],
+			id => 'export_select', class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
@@ -25,6 +25,6 @@
 		</div>
 	</div>
 	<div id="filter_err_msg" class="alert alert-danger p-1 mb-2 d-inline-flex d-none">
-		<%= maketext('Please enter in a value to match in the filter field.') =%>
+		<%= maketext('Please enter a list of IDs to match.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
@@ -5,7 +5,6 @@
 		<div class="col-auto">
 			<%= select_field 'action.filter.scope' => [
 					[ maketext('all sets')                     => 'all' ],
-					[ maketext('no sets')                      => 'none' ],
 					[ maketext('selected sets')                => 'selected' ],
 					[ maketext('enter matching set IDs below') => 'match_ids', selected => undef ],
 					[ maketext('sets visible to students')     => 'visible' ],

--- a/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/filter_form.html.ep
@@ -4,7 +4,7 @@
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.filter.scope' => [
-					[ maketext('all sets')                     => 'all' ],
+					[ maketext('all course sets')              => 'all' ],
 					[ maketext('selected sets')                => 'selected' ],
 					[ maketext('enter matching set IDs below') => 'match_ids', selected => undef ],
 					[ maketext('sets visible to students')     => 'visible' ],

--- a/templates/ContentGenerator/Instructor/ProblemSetList/import_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/import_form.html.ep
@@ -1,5 +1,3 @@
-% use WeBWorK::Utils::Instructor qw(getDefList);
-%
 <div>
 	<div class="row mb-2">
 		<%= label_for import_amt_select => maketext('Import how many sets?'),
@@ -7,7 +5,7 @@
 		<div class="col-auto">
 			<%= select_field 'action.import.number' => [
 					[ maketext('a single set') => 1, selected => undef ],
-					[maketext('multiple sets') => 8 ]
+					[ maketext('multiple sets') => 8 ]
 				],
 				id => 'import_amt_select', class => 'form-select form-select-sm' =%>
 		</div>
@@ -18,7 +16,7 @@
 		<div class="col-auto">
 			<%= select_field 'action.import.source' => [
 					[ maketext('Enter filenames below') => '', selected => undef ],
-					getDefList($ce)
+					@$setDefList
 				],
 				id => 'import_source_select', class => 'form-select form-select-sm', dir => 'ltr',
 				size => param('action.import.number') || 1,
@@ -44,7 +42,7 @@
 					id => 'import_date_shift', size => '27', class => 'form-control',
 					data => {
 						input => undef,
-					   	done_text  => maketext('Done'),
+						done_text  => maketext('Done'),
 						today_text => maketext('Today'),
 						now_text   => maketext('Now'),
 						locale     => $ce->{language},
@@ -70,4 +68,7 @@
 			</div>
 		</div>
 	% }
+	<div id="import_file_err_msg" class="alert alert-danger p-1 mb-2 d-inline-flex d-none">
+		<%= maketext('Please select a set definition file to import.') %>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
@@ -1,6 +1,17 @@
 <div>
 	<div class="row mb-2">
-		<%= label_for publish_visibility_select => maketext('Choose visibility of the selected sets') . ':',
+		<%= label_for publish_filter_select => maketext('Choose which sets to be affected') . ':',
+			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.publish.scope' => [
+					[ maketext('all sets')      => 'all' ],
+					[ maketext('selected sets') => 'selected', selected => undef ]
+				],
+				id => 'publish_filter_select', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="row mb-2">
+		<%= label_for publish_visibility_select => maketext('Choose visibility of the sets to be affected') . ':',
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.publish.value' => [

--- a/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
@@ -1,19 +1,6 @@
 <div>
 	<div class="row mb-2">
-		<%= label_for publish_filter_select => maketext('Choose which sets to be affected') . ':',
-			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
-		<div class="col-auto">
-			<%= select_field 'action.publish.scope' => [
-					[ maketext('no sets')       => 'none' ],
-					[ maketext('all sets')      => 'all' ],
-					[ maketext('listed sets')   => 'visible' ],
-					[ maketext('selected sets') => 'selected', selected => undef ]
-				],
-				id => 'publish_filter_select', class => 'form-select form-select-sm' =%>
-		</div>
-	</div>
-	<div class="row mb-2">
-		<%= label_for publish_visibility_select => maketext('Choose visibility of the sets to be affected') . ':',
+		<%= label_for publish_visibility_select => maketext('Choose visibility of the selected sets') . ':',
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.publish.value' => [

--- a/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/publish_form.html.ep
@@ -4,8 +4,8 @@
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.publish.scope' => [
-					[ maketext('all sets')      => 'all' ],
-					[ maketext('selected sets') => 'selected', selected => undef ]
+					[ maketext('all course sets') => 'all' ],
+					[ maketext('selected sets')   => 'selected', selected => undef ]
 				],
 				id => 'publish_filter_select', class => 'form-select form-select-sm' =%>
 		</div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
@@ -1,3 +1,11 @@
 <div class="row mb-2">
-	<p><%= maketext('Select sets to score.') =%></p>
+	<%= label_for score_select => maketext('Score which sets?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.score.scope' => [
+				[ maketext('all sets')      => 'all' ],
+				[ maketext('selected sets') => 'selected', selected => undef ]
+			],
+			id => 'score_select', class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
@@ -3,8 +3,8 @@
 		class => 'col-form-label col-form-label-sm col-auto' =%>
 	<div class="col-auto">
 		<%= select_field 'action.score.scope' => [
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('selected sets') => 'selected', selected => undef ]
+				[ maketext('all course sets') => 'all' ],
+				[ maketext('selected sets')   => 'selected', selected => undef ]
 			],
 			id => 'score_select', class => 'form-select form-select-sm' =%>
 	</div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/score_form.html.ep
@@ -1,12 +1,3 @@
 <div class="row mb-2">
-	<%= label_for score_select => maketext('Score which sets?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.score.scope' => [
-				[ maketext('no sets')       => 'none', selected => undef ],
-				[ maketext('all sets')      => 'all' ],
-				[ maketext('selected sets') => 'selected' ]
-			],
-			id => 'score_select', class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select sets to score.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
@@ -10,6 +10,9 @@
 	% answer_date            => maketext('Answer Date')
 % );
 %
+<div id="select_set_err_msg" class="alert alert-danger p-1 mb-0 mt-2 d-inline-flex d-none">
+	<%= maketext('Please select at least one set.') %>
+</div>
 <div class="table-responsive">
 	<table id="set_table_id" class="set_table table table-sm table-bordered caption-top font-sm <%=
 		$c->{editMode} ? 'align-middle' : '' %>">

--- a/templates/ContentGenerator/Instructor/UserList.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList.html.ep
@@ -46,13 +46,14 @@
 	% for my $actionID (@$formsToShow) {
 		% next if $formPerms->{$actionID} && !$authz->hasPermissions(param('user'), $formPerms->{$actionID});
 		%
-		% my $active = '';
+		% my $disabled = $actionID eq 'import' && !@$CSVList ? ' disabled' : '';
+		% my $active   = '';
 		% unless ($default_choice) { $active = ' active'; $default_choice = $actionID; }
 		%
 		% content_for 'tab-list' => begin
 			<li class="nav-item" role="presentation">
 				<%= link_to maketext($formTitles->{$actionID}) => "#$actionID",
-					class            => "nav-link action-link$active",
+					class            => "nav-link action-link$active$disabled",
 					id               => "$actionID-tab",
 					data             => { action => $actionID, bs_toggle => 'tab', bs_target => "#$actionID" },
 					role             => 'tab',

--- a/templates/ContentGenerator/Instructor/UserList/delete_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/delete_form.html.ep
@@ -3,14 +3,17 @@
 		<em><%= maketext('Warning: Deletion destroys all user-related data and is not undoable!') =%></em>
 	</div>
 	<div class="row mb-2">
-		<%= label_for delete_select => maketext('Delete which users?'),
+		<%= label_for delete_select => maketext('Delete selected users?'),
 			class => 'col-form-label col-form-label-sm col-auto' =%>
 		<div class="col-auto">
-			<%= select_field 'action.delete.scope' => [
-					[ maketext('no users')       => 'none', selected => undef ],
-					[ maketext('selected users') => 'selected' ]
+			<%= select_field 'action.delete.confirm' => [
+					[ maketext('No')  => 'no', selected => undef ],
+					[ maketext('Yes') => 'yes' ]
 				],
 				id => 'delete_select', class => 'form-select form-select-sm' =%>
 		</div>
+	</div>
+	<div id="delete_confirm_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
+		<%= maketext('Please confirm it is okay to delete selected users permanently.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
@@ -2,8 +2,8 @@
 	<%= label_for edit_select => maketext('Edit which users?'), class => 'col-form-label col-form-label-sm col-auto' =%>
 	<div class="col-auto">
 		<%= select_field 'action.edit.scope' => [
-				[ maketext('all users')      => 'all' ],
-				[ maketext('selected users') => 'selected', selected => undef ]
+				[ maketext('all course users') => 'all' ],
+				[ maketext('selected users')   => 'selected', selected => undef ]
 			],
 			id => 'edit_select', class => 'form-select form-select-sm' =%>
 	</div>

--- a/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
@@ -1,3 +1,10 @@
 <div class="row mb-2">
-	<p><%= maketext('Select users to edit.') =%></p>
+	<%= label_for edit_select => maketext('Edit which users?'), class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.edit.scope' => [
+				[ maketext('all users')      => 'all' ],
+				[ maketext('selected users') => 'selected', selected => undef ]
+			],
+			id => 'edit_select', class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/edit_form.html.ep
@@ -1,11 +1,3 @@
 <div class="row mb-2">
-	<%= label_for edit_select => maketext('Edit which users?'), class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.edit.scope' => [
-				[ maketext('all users')      => 'all' ],
-				[ maketext('visible users')  => 'visible' ],
-				[ maketext('selected users') => 'selected', selected => undef ]
-			],
-			id => 'edit_select', class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select users to edit.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -4,8 +4,8 @@
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.export.scope' => [
-					[ maketext('all users')      => 'all' ],
-					[ maketext('selected users') => 'selected', selected => undef ],
+					[ maketext('all course users') => 'all' ],
+					[ maketext('selected users')   => 'selected', selected => undef ],
 				],
 				id => 'export_select_scope', class => 'form-select form-select-sm' =%>
 		</div>

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -1,5 +1,16 @@
 <div>
 	<div class="row mb-2">
+		<%= label_for export_select_scope => maketext('Export which users?'),
+			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.export.scope' => [
+					[ maketext('all users')      => 'all' ],
+					[ maketext('selected users') => 'selected', selected => undef ],
+				],
+				id => 'export_select_scope', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="row mb-2">
 		<%= label_for export_select_target => maketext('Export to what kind of file?'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -2,18 +2,6 @@
 %
 <div>
 	<div class="row mb-2">
-		<%= label_for export_select_scope => maketext('Export which users?'),
-			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
-		<div class="col-auto">
-			<%= select_field 'action.export.scope' => [
-					[ maketext('all users')      => 'all' ],
-					[ maketext('visible users')  => 'visible', selected => undef ],
-					[ maketext('selected users') => 'selected' ],
-				],
-				id => 'export_select_scope', class => 'form-select form-select-sm' =%>
-		</div>
-	</div>
-	<div class="row mb-2">
 		<%= label_for export_select_target => maketext('Export to what kind of file?'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
@@ -35,5 +23,8 @@
 				<span class="input-group-text font-monospace">.lst</span>
 			</div>
 		</div>
+	</div>
+	<div id="export_file_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
+		<%= maketext('Please input file name to export to.') %>
 	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -1,5 +1,3 @@
-% use WeBWorK::Utils::Instructor qw(getCSVList);
-%
 <div>
 	<div class="row mb-2">
 		<%= label_for export_select_target => maketext('Export to what kind of file?'),
@@ -7,7 +5,7 @@
 		<div class="col-auto">
 			<%= select_field 'action.export.target' => [
 					[ maketext('Enter filename below') => 'new' ],
-					getCSVList($ce)
+					@$CSVList
 				],
 				id => 'export_select_target', class => 'form-select form-select-sm' =%>
 		</div>

--- a/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
@@ -36,4 +36,7 @@
 			</div>
 		</div>
 	</div>
+	<div id="filter_err_msg" class="alert alert-danger p-1 mb-2 d-inline-flex d-none">
+		<%= maketext('Please enter in a value to match in the filter field.') =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
@@ -5,7 +5,6 @@
 		<div class="col-auto">
 			<%= select_field 'action.filter.scope' => [
 					[ maketext('all users')                         => 'all' ],
-					[ maketext('no users')                          => 'none' ],
 					[ maketext('selected users')                    => 'selected' ],
 					[ maketext('users who match on selected field') => 'match_regex', selected => undef ]
 				],

--- a/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/filter_form.html.ep
@@ -4,7 +4,7 @@
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.filter.scope' => [
-					[ maketext('all users')                         => 'all' ],
+					[ maketext('all course users')                  => 'all' ],
 					[ maketext('selected users')                    => 'selected' ],
 					[ maketext('users who match on selected field') => 'match_regex', selected => undef ]
 				],

--- a/templates/ContentGenerator/Instructor/UserList/import_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/import_form.html.ep
@@ -1,11 +1,9 @@
-% use WeBWorK::Utils::Instructor qw(getCSVList);
-%
 <div>
 	<div class="row mb-2">
 		<%= label_for import_select_source => maketext('Import users from what file?'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
-			<%= select_field 'action.import.source' => [ getCSVList($ce) ],
+			<%= select_field 'action.import.source' => [ @$CSVList ],
 				id => 'import_select_source', class => 'form-select form-select-sm', dir => 'ltr' =%>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/UserList/import_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/import_form.html.ep
@@ -3,7 +3,7 @@
 		<%= label_for import_select_source => maketext('Import users from what file?'),
 			class => 'col-form-label col-form-label-sm col-sm-auto' =%>
 		<div class="col-auto">
-			<%= select_field 'action.import.source' => [ @$CSVList ],
+			<%= select_field 'action.import.source' => $CSVList,
 				id => 'import_select_source', class => 'form-select form-select-sm', dir => 'ltr' =%>
 		</div>
 	</div>

--- a/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
@@ -3,8 +3,8 @@
 		class => 'col-form-label col-form-label-sm col-auto' =%>
 	<div class="col-auto">
 		<%= select_field 'action.password.scope' => [
-				[ maketext('all users')      => 'all' ],
-				[ maketext('selected users') => 'selected', selected => undef ]
+				[ maketext('all course users') => 'all' ],
+				[ maketext('selected users')   => 'selected', selected => undef ]
 			],
 			id => 'password_select', class => 'form-select form-select-sm' =%>
 	</div>

--- a/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
@@ -1,3 +1,11 @@
 <div class="row mb-2">
-	<p><%= maketext('Select users to give a new password.') =%></p>
+	<%= label_for password_select => maketext('Give new password to which users?'),
+		class => 'col-form-label col-form-label-sm col-auto' =%>
+	<div class="col-auto">
+		<%= select_field 'action.password.scope' => [
+				[ maketext('all users')      => 'all' ],
+				[ maketext('selected users') => 'selected', selected => undef ]
+			],
+			id => 'password_select', class => 'form-select form-select-sm' =%>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/password_form.html.ep
@@ -1,12 +1,3 @@
 <div class="row mb-2">
-	<%= label_for password_select => maketext('Give new password to which users?'),
-		class => 'col-form-label col-form-label-sm col-auto' =%>
-	<div class="col-auto">
-		<%= select_field 'action.password.scope' => [
-				[ maketext('all users')      => 'all' ],
-				[ maketext('visible users')  => 'visible' ],
-				[ maketext('selected users') => 'selected', selected => undef ]
-			],
-			id => 'password_select', class => 'form-select form-select-sm' =%>
-	</div>
+	<p><%= maketext('Select users to give a new password.') =%></p>
 </div>

--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -95,6 +95,9 @@
 	% end
 % }
 %
+<div id="select_user_err_msg" class="alert alert-danger p-1 mb-0 mt-2 d-inline-flex d-none">
+	<%= maketext('Please select at least one user.') %>
+</div>
 <div class="table-responsive">
 	<table id="classlist-table" class="table table-sm table-bordered caption-top font-sm <%=
 		$c->{editMode} || $c->{passwordMode} ? ' align-middle' : '' =%>">

--- a/templates/HelpFiles/InstructorAchievementList.html.ep
+++ b/templates/HelpFiles/InstructorAchievementList.html.ep
@@ -91,9 +91,8 @@
 	<dd>
 		<%= maketext('You can edit a single achievement by clicking on the pencil icon next to the achievement ID.  '
 			. 'You can edit multiple achievements by selecting which achievements to edit, then click the '
-			. '"Edit" button. You can edit all of the achievements by changing which achievements to edit form '
-			. '"selected achievements" to "all achievements", or click the checkbox next to the Achievement ID to '
-			. 'select all achievements.') =%>
+			. '"Edit" button. You can edit all of the achievements by first selecting them all using the checkbox '
+			. 'next to "Achievement ID", then editing them with the "Edit" button.') =%>
 	</dd>
 
 	<dt><%= maketext('Import/export achievements') %></dt>

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -43,9 +43,8 @@
 	<dd>
 		<%= maketext('You can edit the class list data for a single student by clicking on the pencil icon next to '
 			. 'their login name. To edit several students at once click on the "Select" checkbox next to their names, '
-			. 'click on the radio button for editing selected users and then click the "Edit" button. You can also '
-			. 'edit all visible users (those students currently being displayed) or even all users in the course '
-			. 'although this last option might take a long time to load for a large class.') =%>
+			. 'click on the radio button for editing selected users and then click the "Edit" button. This might '
+			. 'take a long time load if editing a large number of users.') =%>
 	</dd>
 
 	<dd>
@@ -97,7 +96,7 @@
 	<dt><%= maketext('Drop student from the course') %></dt>
 	<dd>
 		<%= maketext('To drop a student or students, select them for editing as described above and then set the '
-			. 'pop-up list to enrolled,drop, or audit. Dropped students cannot log in to the course, are not assigned '
+			. 'pop-up list to enrolled, drop, or audit. Dropped students cannot log in to the course, are not assigned '
 			. 'new sets and are not sent email. They can be re-enrolled simply by changing their status back '
 			. 'to enrolled. No data is lost, any assignments assigned before they were dropped are restored '
 			. 'unchanged.') =%>


### PR DESCRIPTION
On the UserList, ProblemSetList, and AchievementList managers, remove the scope option that helps determine which items to act on, instead users will always select which items to act on and can use filters to change the list of items to select from. This address #1991.

In addition add javascript form validation that will create a modal popup if the form is missing information, such as no items are selected, a text string is not provided, a valid file is not selected, and so on.

Last, make the import tabs not create a form if no valid files are found to import from.