### PR TITLE
allow customization of admin course ID

### DIFF
--- a/bin/update-OPL-statistics.pl
+++ b/bin/update-OPL-statistics.pl
@@ -111,7 +111,7 @@ foreach my $courseID (@courses) {
 		print "\n";
 	}
 
-	next if $courseID eq 'admin' || $courseID eq 'modelCourse';
+	next if $courseID eq $ce->{admin_course_id} || $courseID eq 'modelCourse';
 
 	# we extract the identifying information of the problem,
 	# the status, attempted flag, number of attempts.

--- a/bin/upgrade_admin_db.pl
+++ b/bin/upgrade_admin_db.pl
@@ -31,9 +31,9 @@ use WeBWorK::Utils::CourseIntegrityCheck;
 ##########################
 # update admin course
 ##########################
-my $upgrade_courseID = 'admin';
-
-my $ce = WeBWorK::CourseEnvironment->new({
+my $ce               = WeBWorK::CourseEnvironment->new({ webwork_dir => $ENV{WEBWORK_ROOT} });
+my $upgrade_courseID = $ce->{admin_course_id};
+$ce = WeBWorK::CourseEnvironment->new({
 	webwork_dir => $ENV{WEBWORK_ROOT},
 	courseName  => $upgrade_courseID,
 });

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -68,6 +68,16 @@ $server_root_url   = '';
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
 $webwork_server_admin_email = '';
 
+# The following is the name of the admin course where admin level users can  create
+# courses, delete courses, and more. It is named 'admin' by default but for security,
+# you may want to change to something that cannot be guessed. While installing WeBWorK,
+# leave this as 'admin'. Once everything is running well, use the 'admin' course to
+# create a new course to serve as the admin course. You may need to copy all archives
+# from the 'admin' course into this new course. Then change $admin_course_id to the ID
+# of the new course and restart webwork2. You may then also want to archive and delete
+# the original 'admin' course.
+$admin_course_id = 'admin';
+
 # password strings (or any other string allowing special characters) should be specified inside single quotes
 # otherwise a string such as "someone@nowhere" will interpolate the contents of the array @nowhere -- which is probably
 # empty, but still not what you want.  Similar things happen with % and $

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -249,7 +249,8 @@ sub startup ($app) {
 	$cg_r->get('/')->to('Home#go')->name('root');
 
 	# The course admin route is set up here because of its special stash value.
-	$cg_r->any('/admin')->to('CourseAdmin#go', courseID => 'admin')->name('course_admin');
+	$cg_r->any("/$ce->{admin_course_id}")->to('CourseAdmin#go', courseID => $ce->{admin_course_id})
+		->name('course_admin');
 
 	setup_content_generator_routes($cg_r);
 

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -197,7 +197,7 @@ async sub dispatch ($c) {
 
 		return (0, 'This course does not exist.')
 			unless (-e $ce->{courseDirs}{root}
-				|| -e "$ce->{webwork_courses_dir}/admin/archives/$routeCaptures{courseID}.tar.gz");
+				|| -e "$ce->{webwork_courses_dir}/$ce->{admin_course_id}/archives/$routeCaptures{courseID}.tar.gz");
 		return (0, 'This course has been archived and closed.') unless -e $ce->{courseDirs}{root};
 
 		debug("...we can create a database object...\n");

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -263,7 +263,7 @@ sub hasPermissions {
 				# Elevate all permissions greater than a student in the admin course to the
 				# create_and_delete_courses level.  This way a user either has access to all
 				# or only student level permissions tools in the admin course.
-				if (defined($ce->{courseName}) && $ce->{courseName} eq 'admin') {
+				if (defined($ce->{courseName}) && $ce->{courseName} eq $ce->{admin_course_id}) {
 					my $admin_permlevel = $userRoles->{ $permissionLevels->{create_and_delete_courses} };
 					$role_permlevel = $admin_permlevel
 						if $role_permlevel > $userRoles->{student} && $role_permlevel < $admin_permlevel;

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -322,7 +322,8 @@ sub do_add_course ($c) {
 		for my $userID ($db->listUsers) {
 			if ($userID eq $add_initial_userID) {
 				$c->addbadmessage($c->maketext(
-					'User "[_1]" will not be copied from admin course as it is the initial instructor.', $userID
+					'User "[_1]" will not be copied from [_2] course as it is the initial instructor.', $userID,
+					$ce->{admin_course_id}
 				));
 				next;
 			}
@@ -1264,7 +1265,7 @@ sub do_unarchive_course ($c) {
 	unarchiveCourse(
 		newCourseID => $new_courseID,
 		oldCourseID => $unarchive_courseID =~ s/\.tar\.gz$//r,
-		archivePath => "$ce->{webworkDirs}{courses}/admin/archives/$unarchive_courseID",
+		archivePath => "$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives/$unarchive_courseID",
 		ce          => $ce,
 	);
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -132,7 +132,7 @@ Lists the courses which have been archived (end in .tar.gz).
 
 sub listArchivedCourses {
 	my ($ce) = @_;
-	my $archivesDir = "$ce->{webworkDirs}{courses}/admin/archives";
+	my $archivesDir = "$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives";
 	surePathToFile($ce->{webworkDirs}{courses}, "$archivesDir/test");    # Ensure archives directory exists.
 	return grep {m/\.tar\.gz$/} readDirectory($archivesDir);
 }
@@ -754,7 +754,7 @@ sub archiveCourse {
 
 	# tmp_archive_path is used as the target of the tar.gz operation.
 	# After this is done the final tar.gz file is moved either to the admin course archives directory
-	# course/admin/archives or the supplied archive_path option if it is present.
+	# course/$ce->{admin_course_id}/archives or the supplied archive_path option if it is present.
 	# This prevents us from tarring a directory to which we have just added a file
 	# see bug #2022 -- for error messages on some operating systems
 	my $uuidStub         = create_uuid_as_string();
@@ -765,7 +765,7 @@ sub archiveCourse {
 	if (defined $options{archive_path} && $options{archive_path} =~ /\S/) {
 		$archive_path = $options{archive_path};
 	} else {
-		$archive_path = "$ce->{webworkDirs}{courses}/admin/archives/$courseID.tar.gz";
+		$archive_path = "$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives/$courseID.tar.gz";
 		surePathToFile($ce->{webworkDirs}{courses}, $archive_path);
 	}
 

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -26,7 +26,7 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
 
  root                                /
 
- course_admin                        /admin -> logout, options, instructor_tools
+ course_admin                        /$ce->{admin_course_id} -> logout, options, instructor_tools
 
  render_rpc                          /render_rpc
  instructor_rpc                      /instructor_rpc
@@ -160,7 +160,7 @@ my %routeParameters = (
 	course_admin => {
 		title  => x('Course Administration'),
 		module => 'CourseAdmin',
-		path   => '/admin'
+		path   => '/$ce->{admin_course_id}'
 	},
 
 	render_rpc => {

--- a/lib/WebworkWebservice/CourseActions.pm
+++ b/lib/WebworkWebservice/CourseActions.pm
@@ -40,7 +40,8 @@ sub createCourse {
 	die "Course actions disabled by configuration.\n" unless $admin_ce->{webservices}{enableCourseActions};
 
 	# Only users from the admin course with appropriate permissions are allowed to create a course.
-	die "Course creation allowed only for admin course users.\n" unless $admin_ce->{courseName} eq 'admin';
+	die "Course creation allowed only for admin course users.\n"
+		unless $admin_ce->{courseName} eq $admin_ce->{admin_course_id};
 
 	die "Course ID cannot exceed $admin_ce->{maxCourseIdLength} characters.\n"
 		if length($params->{name}) > $admin_ce->{maxCourseIdLength};

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -2,11 +2,12 @@
 	<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
 	<li><hr class="site-nav-separator"></li>
 	% if ($authz->hasPermissions($userID, 'create_and_delete_courses')) {
+		% my $admin_pattern = qr/$ce->{admin_course_id}$/;
 		<li class="list-group-item nav-item">
 			<%= $makelink->(
 				'set_list',
 				text   => maketext('Course Listings'),
-				active => !param('subDisplay') && $c->url_for =~ /admin$/ ? 1 : 0
+				active => !param('subDisplay') && $c->url_for =~ $admin_pattern ? 1 : 0
 			) %>
 		</li>
 		% for (

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -1,6 +1,6 @@
 % use WeBWorK::Utils qw(jitar_id_to_seq);
 %
-% if ($ce->{courseName} eq 'admin') {
+% if ($ce->{courseName} eq $ce->{admin_course_id}) {
 	<%= include 'ContentGenerator/Base/admin_links' =%>
 	% last;
 % }
@@ -78,7 +78,7 @@
 			<li class="list-group-item nav-item"><%= $makelink->('options') %></li>
 		% }
 		%
-		% unless ($restricted_navigation || $courseID eq 'admin') {
+		% unless ($restricted_navigation || $courseID eq $ce->{admin_course_id}) {
 			<li class="list-group-item nav-item"><%= $makelink->('grades') %></li>
 		% }
 		%

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -53,7 +53,7 @@
 	% my @courseIDs = listCourses($ce);
 	<ol>
 		% for (sort { lc($a) cmp lc($b) } listCourses($ce)) {
-			% next if $_ eq 'admin' || $_ eq 'modelCourse';
+			% next if $_ eq 'modelCourse';
 			<li><%= link_to $_ => 'set_list' => { courseID => $_ } =%></li>
 		% }
 	</ol>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -106,7 +106,7 @@
 		<%= maketext('To copy the templates and html folders from an existing course, select the course below.') =%>
 	</div>
 	<div class="row mb-3">
-		% my @existingCourses = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
+		% my @existingCourses = sort { lc($a) cmp lc($b) } listCourses($ce);
 		% unshift(@existingCourses, sort { lc($a) cmp lc($b) } @{ $ce->{modelCoursesForCopy} });
 		%
 		<%= label_for add_templates_course => maketext('Copy from:'),

--- a/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
@@ -79,7 +79,7 @@
 	% if ($all_tables_ok && $directories_ok) {
 		% # No missing tables, missing fields, or directories
 		% # Warn about overwriting an existing archive
-		% my $archive_path = "$ce2->{webworkDirs}{courses}/admin/archives/$archive_courseID.tar.gz";
+		% my $archive_path = "$ce2->{webworkDirs}{courses}/$ce2->{admin_course_id}/archives/$archive_courseID.tar.gz";
 		% if (-e $archive_path && -w $archive_path) {
 			<p class="text-danger fw-bold">
 				<%= maketext(

--- a/templates/ContentGenerator/Home.html.ep
+++ b/templates/ContentGenerator/Home.html.ep
@@ -2,10 +2,11 @@
 %
 % my $coursesDir = $ce->{webworkDirs}{courses};
 % my @courseIDs = listCourses($ce);
+% my $admin_course_id = $ce->{admin_course_id};
 %
 <p><%= maketext('Welcome to WeBWorK!') %></p>
 %
-% if ((grep { $_ eq 'admin' } @courseIDs) && !-f "$coursesDir/admin/hide_directory") {
+% if ((grep { $_ eq $admin_course_id } @courseIDs) && !-f "$coursesDir/$admin_course_id/hide_directory") {
 	<p><%=	link_to maketext('Course Administration') => url_for('course_admin') =%></p>
 % }
 %
@@ -13,7 +14,7 @@
 %
 <ul class="courses-list">
 	% for my $courseID (sort { lc($a) cmp lc($b) } @courseIDs) {
-		% next if $courseID eq 'admin';                        # Already shown above.
+		% next if $courseID eq $admin_course_id;               # Already shown above.
 		% next if -f "$coursesDir/$courseID/hide_directory";
 		<li>
 			<%= link_to $courseID =~ s/_/ /gr => url_for('set_list', courseID => $courseID) =%>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -52,7 +52,7 @@
 					unarchive_text => maketext('Unpack Archive')
 				},
 				%button =%>
-			% unless ($c->{courseName} eq 'admin') {
+			% unless ($c->{courseName} eq $c->ce->{admin_course_id}) {
 				<%= submit_button maketext('Archive Course'), id => 'ArchiveCourse', %button =%>
 			% }
 			<div class="d-none d-md-block" style="height: 10px"></div>


### PR DESCRIPTION
This allows a site to use something other than `admin` for the admin course ID. The purpose is to remove the ability for bad actors to know the location of the admin course.

To test, after loading this branch, you need to immediately edit `site.conf` to get the new line that initializes `$admin_course_id`. Then restart `webwork2`.

One thing the PR does is allow the "admin" course (or whatever its name is changed to) to be the source course to copy from when creating a new course. I'm not sure if this is necessary and maybe we can remove that change. But in any case, next make a new course (you can call it "my-admin" for testing). Its templates folder can be copied from the "admin" course. (And if #2290 is merged, then more could be copied as well.)

Then in `site.conf`, change `$admin_course_id` to be the ID of the new course, and restart `webwork2`. Now if you go to "admin", it should look like a regular course. And if you go to the new course, it should function as the admin course. In practice you would then also clean up by copying archive files from the old "admin" course to the new course (since they live parallel to `templates/` they did not copy over when creating the new course). And I think you would also archive and close the original "admin" course at that time.

