### PR TITLE
tailor AsciiMath better for MathObjects

### DIFF
--- a/htdocs/js/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/MathJaxConfig/mathjax-config.js
@@ -6,9 +6,9 @@ if (!window.MathJax) {
 		loader: { load: ['input/asciimath', '[tex]/noerrors'] },
 		startup: {
 			ready: function() {
-				var AM = MathJax.InputJax.AsciiMath.AM;
+				const AM = MathJax.InputJax.AsciiMath.AM;
 				// modify existing AsciiMath triggers
-				var i = AM.names.indexOf('**');
+				let i = AM.names.indexOf('**');
 				AM.symbols[i] = { input: "**", tag: "msup", output: "^", tex: null, ttype: AM.TOKEN.INFIX };
 
 				i = AM.names.indexOf('infty');
@@ -16,7 +16,7 @@ if (!window.MathJax) {
 				AM.symbols[i] = { input:"infinity", tag:"mo", output:"\u221E", tex:"infty", ttype:AM.TOKEN.CONST };
 
 				// add AsciiMath triggers for consistency with MathObjects
-				var newTriggers = {
+				const newTriggers = {
 					inf:     {precedes:'infinity',   symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
 					Infinity:{precedes:'Lambda',     symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
 					Inf:     {precedes:'Infinity',   symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
@@ -35,7 +35,7 @@ if (!window.MathJax) {
 					'><':    {precedes:'><|',        symbols:{tag:"mo",    output:"\u00D7",          tex:"times",    ttype:AM.TOKEN.CONST}},
 				};
 				for (const trigger in newTriggers) {
-					var i = AM.names.indexOf(newTriggers[trigger].precedes);
+					const i = AM.names.indexOf(newTriggers[trigger].precedes);
 					AM.names.splice(i, 0, trigger);
 					AM.symbols.splice(i, 0, {input:trigger, ...newTriggers[trigger].symbols});
 				}

--- a/htdocs/js/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/MathJaxConfig/mathjax-config.js
@@ -7,11 +7,39 @@ if (!window.MathJax) {
 		startup: {
 			ready: function() {
 				var AM = MathJax.InputJax.AsciiMath.AM;
-				for (var i = 0; i < AM.symbols.length; i++) {
-					if (AM.symbols[i].input == '**') {
-						AM.symbols[i] = { input: "**", tag: "msup", output: "^", tex: null, ttype: AM.TOKEN.INFIX };
-					}
+				// modify existing AsciiMath triggers
+				var i = AM.names.indexOf('**');
+				AM.symbols[i] = { input: "**", tag: "msup", output: "^", tex: null, ttype: AM.TOKEN.INFIX };
+
+				i = AM.names.indexOf('infty');
+				AM.names[i] = 'infinity';
+				AM.symbols[i] = { input:"infinity", tag:"mo", output:"\u221E", tex:"infty", ttype:AM.TOKEN.CONST };
+
+				// add AsciiMath triggers for consistency with MathObjects
+				var newTriggers = {
+					inf:     {precedes:'infinity',   symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
+					Infinity:{precedes:'Lambda',     symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
+					Inf:     {precedes:'Infinity',   symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
+					INFINITY:{precedes:'Inf',        symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
+					INF:     {precedes:'INFINITY',   symbols:{tag:"mo",    output:"\u221E",          tex:"infty",    ttype:AM.TOKEN.CONST}},
+					none:    {precedes:'norm',       symbols:{tag:"mtext", output:"NONE",            tex:null,       ttype:AM.TOKEN.CONST}},
+					None:    {precedes:'O/',         symbols:{tag:"mtext", output:"NONE",            tex:null,       ttype:AM.TOKEN.CONST}},
+					NONE:    {precedes:'None',       symbols:{tag:"mtext", output:"NONE",            tex:null,       ttype:AM.TOKEN.CONST}},
+					dne:     {precedes:'dot',        symbols:{tag:"mtext", output:"DNE",             tex:null,       ttype:AM.TOKEN.CONST}},
+					Dne:     {precedes:'EE',         symbols:{tag:"mtext", output:"DNE",             tex:null,       ttype:AM.TOKEN.CONST}},
+					DNE:     {precedes:'Delta',      symbols:{tag:"mtext", output:"DNE",             tex:null,       ttype:AM.TOKEN.CONST}},
+					Re:      {precedes:'Rightarrow', symbols:{tag:"mi",    output:"Re",              tex:null,       ttype:AM.TOKEN.UNARY, func:true}},
+					Im:      {precedes:'Inf',        symbols:{tag:"mi",    output:"Im",              tex:null,       ttype:AM.TOKEN.UNARY, func:true}},
+					log10:   {precedes:'lt',         symbols:{tag:"mi",    output:"log\u2081\u2080", tex:"log_{10}", ttype:AM.TOKEN.UNARY, func:true}},
+					U:       {precedes:'Xi',         symbols:{tag:"mo",    output:"\u222A",          tex:"cup",      ttype:AM.TOKEN.CONST}},
+					'><':    {precedes:'><|',        symbols:{tag:"mo",    output:"\u00D7",          tex:"times",    ttype:AM.TOKEN.CONST}},
+				};
+				for (const trigger in newTriggers) {
+					var i = AM.names.indexOf(newTriggers[trigger].precedes);
+					AM.names.splice(i, 0, trigger);
+					AM.symbols.splice(i, 0, {input:trigger, ...newTriggers[trigger].symbols});
 				}
+
 				return MathJax.startup.defaultReady()
 			}
 		},


### PR DESCRIPTION
This makes changes to the AsciiMath portion of the MathJax config so that it behaves more consistently with MathObjects. AsciiMath input is used by MathView and can be used when composing text that can have math that will be rendered (a student's essay answer or instructor feedback). Changes are:

- disable `in`, so you don't see a `∈` on your way to making `∞`.
- disable `ne` so you can enter `dne` and `none` without seeing `d≠` and `no≠`.
- as has been the case for a long time, let `**` be interpreted as `^`.
- replace AsciiMath's `infty` with `inf`.
- add `Re`, `Im`, `log10`, `U`, and `><`.

This is well on its way to addressing #638. Perhaps more can be done to get greater consistency with MathObjects and AsciiMath input, but the process is demonstrated now for removing, modifying, or adding triggers. 

