### PR TITLE
option to have courses hidden by default

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -79,11 +79,19 @@ $webwork_server_admin_email = '';
 $admin_course_id = 'admin';
 
 # When new courses are created using the admin course, this setting controls
-# whether or not they will be hidden.  This applies to courses created using
-# "Add Courses" as well as to courses created using "Unarchive Courses" when
-# a new ID is given to the unarchived course. (If it is not given a new ID,
-# its hidden status is preserved.)
-$hide_new_courses = 0;
+# whether or not they will be hidden.  Setting this to anything other than
+# "hidden" or "visible" (or leaving it unset) means that courses created using
+# "Add Courses" are not hidden, and all unarchived courses have whatever hidden
+# status they had when archived.
+# Setting this to "hidden" means that courses created using "Add Courses" and
+# courses created using "Unarchive Courses" with a new course ID will be hidden.
+# Unarchived courses that keep their original name will keep their hidden
+# status.
+# Setting this to "visible" means that courses created using "Add Courses" and
+# courses created using "Unarchive Courses" with a new course ID will be visible.
+# Unarchived courses that keep their original name will keep their hidden
+# status.
+#$new_courses_hidden_status = 'hidden';
 
 # password strings (or any other string allowing special characters) should be specified inside single quotes
 # otherwise a string such as "someone@nowhere" will interpolate the contents of the array @nowhere -- which is probably

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -78,6 +78,13 @@ $webwork_server_admin_email = '';
 # the original 'admin' course.
 $admin_course_id = 'admin';
 
+# When new courses are created using the admin course, this setting controls
+# whether or not they will be hidden.  This applies to courses created using
+# "Add Courses" as well as to courses created using "Unarchive Courses" when
+# a new ID is given to the unarchived course. (If it is not given a new ID,
+# its hidden status is preserved.)
+$hide_new_courses = 0;
+
 # password strings (or any other string allowing special characters) should be specified inside single quotes
 # otherwise a string such as "someone@nowhere" will interpolate the contents of the array @nowhere -- which is probably
 # empty, but still not what you want.  Similar things happen with % and $

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -285,6 +285,17 @@ sub addCourse {
 			"Failed to create $courseDirName directory '$courseDir': $!. You will have to create this directory manually.\n";
 	}
 
+	# hide the course?
+
+	if ($ce->{hide_new_courses}) {
+		my $hideDirFile = "$ce->{webworkDirs}{courses}/$courseID/hide_directory";
+		open(my $HIDEFILE, '>', $hideDirFile);
+		print $HIDEFILE 'Place a file named "hide_directory" in a course or other directory and it will not show up '
+			. 'in the courses list on the WeBWorK home page. It will still appear in the '
+			. 'Course Administration listing.';
+		close $HIDEFILE;
+	}
+
 	##### step 2: create course database #####
 
 	my $db               = new WeBWorK::DB($ce->{dbLayouts}->{$dbLayoutName});
@@ -979,9 +990,24 @@ sub unarchiveCourse {
 			"Failed to create html_temp directory '$tmpDir': $!. You will have to create this directory manually.\n";
 	}
 
+	# If the course was given a new name, honor $ce->{hide-new-courses}
+	if (defined $newCourseID && $newCourseID ne $currCourseID) {
+		my $hideDirFile = "$ce->{webworkDirs}{courses}/$currCourseID/hide_directory";
+		if ($ce->{hide_new_courses} && !(-f $hideDirFile)) {
+			open(my $HIDEFILE, '>', $hideDirFile);
+			print $HIDEFILE
+				'Place a file named "hide_directory" in a course or other directory and it will not show up '
+				. 'in the courses list on the WeBWorK home page. It will still appear in the '
+				. 'Course Administration listing.';
+			close $HIDEFILE;
+		} elsif (!$ce->{hide_new_courses} && -f $hideDirFile) {
+			unlink $hideDirFile;
+		}
+	}
+
 	##### step 6: rename course #####
 
-	if (defined $newCourseID and $newCourseID ne $currCourseID) {
+	if (defined $newCourseID && $newCourseID ne $currCourseID) {
 		renameCourse(
 			courseID     => $currCourseID,
 			ce           => $ce2,

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -285,9 +285,9 @@ sub addCourse {
 			"Failed to create $courseDirName directory '$courseDir': $!. You will have to create this directory manually.\n";
 	}
 
-	# hide the course?
+	# hide the new course?
 
-	if ($ce->{hide_new_courses}) {
+	if (defined $ce->{new_courses_hidden_status} && $ce->{new_courses_hidden_status} eq 'hidden') {
 		my $hideDirFile = "$ce->{webworkDirs}{courses}/$courseID/hide_directory";
 		open(my $HIDEFILE, '>', $hideDirFile);
 		print $HIDEFILE 'Place a file named "hide_directory" in a course or other directory and it will not show up '
@@ -990,17 +990,21 @@ sub unarchiveCourse {
 			"Failed to create html_temp directory '$tmpDir': $!. You will have to create this directory manually.\n";
 	}
 
-	# If the course was given a new name, honor $ce->{hide-new-courses}
-	if (defined $newCourseID && $newCourseID ne $currCourseID) {
+	# If the course was given a new name, honor $ce->{new_courses_hidden_status}
+	if (defined $newCourseID
+		&& $newCourseID ne $currCourseID
+		&& defined $ce->{new_courses_hidden_status}
+		&& $ce->{new_courses_hidden_status} =~ /^(hidden|visible)$/)
+	{
 		my $hideDirFile = "$ce->{webworkDirs}{courses}/$currCourseID/hide_directory";
-		if ($ce->{hide_new_courses} && !(-f $hideDirFile)) {
+		if ($ce->{new_courses_hidden_status} eq 'hidden' && !(-f $hideDirFile)) {
 			open(my $HIDEFILE, '>', $hideDirFile);
 			print $HIDEFILE
 				'Place a file named "hide_directory" in a course or other directory and it will not show up '
 				. 'in the courses list on the WeBWorK home page. It will still appear in the '
 				. 'Course Administration listing.';
 			close $HIDEFILE;
-		} elsif (!$ce->{hide_new_courses} && -f $hideDirFile) {
+		} elsif ($ce->{new_courses_hidden_status} eq 'visible' && -f $hideDirFile) {
 			unlink $hideDirFile;
 		}
 	}


### PR DESCRIPTION
This adds a new variable to site.conf, `$hide_new_courses`. With this PR, unarchiving a course and keeping its old name, you get a course with its hidden status unchanged. But for unarchiving a course with a new name or making a completely new course, this variable controls whether or not it will be born hidden. More specifically:

If it is false (the distribution default):
* new courses from "Add Courses" do not have the `hide_directory` file (no change)
* new courses that are unarchived with their original name have or don't have `hide_directory` as they were when archived (no change)
* new courses that are unarchived with a _new_ name get `hide_directory` removed, if it is present (this is a change)

If it is true:
* new courses from "Add Courses" get `hide_directory` file and this are born hidden (this is a change)
* new courses that are unarchived with their original name have or don't have `hide_directory` as they were when archived (no change)
* new courses that are unarchived with a _new_ name get `hide_directory` added, if not already present (this is a change)

This will be useful for Runestone, where we always hide all courses (except the demonstration courses). Up to now, I have to manually hide each course after its creation.

This is also helpful for my regular PCC server. Our practice is to leave the prior term's courses open, but hidden. Then they get archived and closed two terms after the course ended. So later, if an instructor wants a new course that is a clone of the old course, we unarchive their old course with a new name (that includes the current term). But without this PR, the new course is born hidden when we don't want it that way.