### PR TITLE
Fix achievement issues #2281 and #2279

### DIFF
--- a/htdocs/js/AchievementItems/achievementitems.js
+++ b/htdocs/js/AchievementItems/achievementitems.js
@@ -1,17 +1,33 @@
 (() => {
 	for (const setSelect of document.querySelectorAll('select[data-problems]')) {
 		setSelect.addEventListener('change', () => {
-			const max = parseInt(Array.from(setSelect.querySelectorAll('option'))
-				.find((option) => option.value === setSelect.value)?.dataset.max ?? '0');
+			const problemIds = JSON.parse(
+				Array.from(setSelect.querySelectorAll('option')).find((option) => option.value === setSelect.value)
+					?.dataset.problemIds ?? '[]'
+			);
 
-			document.querySelectorAll(`#${setSelect.dataset.problems} option`).forEach((option, index) => {
-				option.style.display = index < max ? '' : 'none';
-			});
+			const problemSelect = document.getElementById(setSelect.dataset.problems);
+			if (problemSelect) {
+				for (const option of problemSelect.querySelectorAll('option')) option.remove();
+				for (const id of problemIds) {
+					const option = document.createElement('option');
+					option.value = id;
+					option.text = id;
+					problemSelect.add(option);
+				}
+			}
 
 			// This is only used by the "Box of Transmogrification".
-			document.querySelectorAll(`#${setSelect.dataset.problems2} option`).forEach((option, index) => {
-				option.style.display = index < max ? '' : 'none';
-			});
+			const problemSelect2 = document.getElementById(setSelect.dataset.problems2);
+			if (problemSelect2) {
+				for (const option of problemSelect2.querySelectorAll('option')) option.remove();
+				for (const id of problemIds) {
+					const option = document.createElement('option');
+					option.value = id;
+					option.text = id;
+					problemSelect2.add(option);
+				}
+			}
 		});
 	}
 })();

--- a/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
+++ b/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
@@ -31,15 +31,13 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my $db = $c->db;
 
-	my $effectiveUserName = $c->param('effectiveUser') // $c->param('user');
-	my @unfilteredsets = $db->getMergedSets(map { [ $effectiveUserName, $_ ] } $db->listUserSets($effectiveUserName));
 	my @openGateways;
 
 	# Find the template sets of open gateway quizzes.
-	for my $set (@unfilteredsets) {
+	for my $set (@$sets) {
 		push(@openGateways, [ format_set_name_display($set->set_id) => $set->set_id ])
 			if $set->assignment_type =~ /gateway/
 			&& $set->set_id !~ /,v\d+$/

--- a/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
+++ b/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
@@ -44,6 +44,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			&& between($set->open_date, $set->due_date);
 	}
 
+	return unless @openGateways;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Add a new version for which test?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/DoubleProb.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleProb.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to make a problem worth double.
 
+use Mojo::JSON qw(encode_json);
+
 use WeBWorK::Utils qw(between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new ($class) {
@@ -28,30 +30,26 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# Construct a dropdown with open sets and another with problems.
-	# Javascript ensures the appropriate number of problems are shown for the selected set.
+	# Javascript ensures the appropriate problems are shown for the selected set.
 
-	my @openSets;
-	my $maxProblems = 0;
+	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default') {
+		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+			&& $sets->[$i]->assignment_type eq 'default'
+			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
+		{
 			push(
 				@openSets,
 				[
 					format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id,
-					data                                         => { max => $setProblemCount->[$i] }
+					data => { problem_ids => encode_json($setProblemIds->{ $sets->[$i]->set_id }) }
 				]
 			);
-			$maxProblems = $setProblemCount->[$i] if $setProblemCount->[$i] > $maxProblems;
+			@initialProblemIDs = @{ $setProblemIds->{ $sets->[$i]->set_id } } unless @initialProblemIDs;
 		}
-	}
-
-	my @problemIDs;
-
-	for my $i (1 .. $maxProblems) {
-		push(@problemIDs, [ $i => $i, $i > $openSets[0][3]{max} ? (style => 'display:none') : () ]);
 	}
 
 	return $c->c(
@@ -71,7 +69,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 			$c,
 			id                  => 'dbp_problem_id',
 			label_text          => $c->maketext('Problem Number'),
-			values              => \@problemIDs,
+			values              => \@initialProblemIDs,
 			menu_container_attr => { class => 'col-3' }
 		)
 	)->join('');

--- a/lib/WeBWorK/AchievementItems/DoubleProb.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleProb.pm
@@ -52,6 +52,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		}
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag(
 			'p',

--- a/lib/WeBWorK/AchievementItems/DoubleSet.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleSet.pm
@@ -36,6 +36,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Choose the set which you would like to be worth twice as much.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/DoubleSet.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleSet.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/DuplicateProb.pm
+++ b/lib/WeBWorK/AchievementItems/DuplicateProb.pm
@@ -52,6 +52,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		}
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag(
 			'p',

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -36,6 +36,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Choose the set whose close date you would like to extend.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -42,6 +42,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			&& between($set->open_date, $set->due_date);
 	}
 
+	return unless @openGateways;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Extend the close date for which test?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -29,15 +29,13 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my $db = $c->db;
 
-	my $effectiveUserName = $c->param('effectiveUser') // $c->param('user');
-	my @unfilteredsets = $db->getMergedSets(map { [ $effectiveUserName, $_ ] } $db->listUserSets($effectiveUserName));
 	my @openGateways;
 
 	# Find the template sets for open tests.
-	for my $set (@unfilteredsets) {
+	for my $set (@$sets) {
 		push(@openGateways, [ format_set_name_display($set->set_id) => $set->set_id ])
 			if $set->assignment_type =~ /gateway/
 			&& $set->set_id !~ /,v\d+$/

--- a/lib/WeBWorK/AchievementItems/FullCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditProb.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to give full credit on a single problem
 
+use Mojo::JSON qw(encode_json);
+
 use WeBWorK::Utils qw(between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new ($class) {
@@ -28,30 +30,26 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# Construct a dropdown with open sets and another with problems.
-	# Javascript ensures the appropriate number of problems are shown for the selected set.
+	# Javascript ensures the appropriate problems are shown for the selected set.
 
-	my @openSets;
-	my $maxProblems = 0;
+	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default') {
+		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+			&& $sets->[$i]->assignment_type eq 'default'
+			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
+		{
 			push(
 				@openSets,
 				[
 					format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id,
-					data                                         => { max => $setProblemCount->[$i] }
+					data => { problem_ids => encode_json($setProblemIds->{ $sets->[$i]->set_id }) }
 				]
 			);
-			$maxProblems = $setProblemCount->[$i] if $setProblemCount->[$i] > $maxProblems;
+			@initialProblemIDs = @{ $setProblemIds->{ $sets->[$i]->set_id } } unless @initialProblemIDs;
 		}
-	}
-
-	my @problemIDs;
-
-	for my $i (1 .. $maxProblems) {
-		push(@problemIDs, [ $i => $i, $i > $openSets[0][3]{max} ? (style => 'display:none') : () ]);
 	}
 
 	return $c->c(
@@ -71,7 +69,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 			$c,
 			id                  => 'fcp_problem_id',
 			label_text          => $c->maketext('Problem Number'),
-			values              => \@problemIDs,
+			values              => \@initialProblemIDs,
 			menu_container_attr => { class => 'col-3' }
 		)
 	)->join('');

--- a/lib/WeBWorK/AchievementItems/FullCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditProb.pm
@@ -52,6 +52,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		}
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag(
 			'p',

--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -36,6 +36,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Please choose the set for which all problems should be given full credit.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -52,6 +52,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		}
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag(
 			'p',

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to give half credit on a single problem.
 
+use Mojo::JSON qw(encode_json);
+
 use WeBWorK::Utils qw(between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new ($class) {
@@ -28,30 +30,26 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# Construct a dropdown with open sets and another with problems.
-	# Javascript ensures the appropriate number of problems are shown for the selected set.
+	# Javascript ensures the appropriate problems are shown for the selected set.
 
-	my @openSets;
-	my $maxProblems = 0;
+	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default') {
+		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+			&& $sets->[$i]->assignment_type eq 'default'
+			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
+		{
 			push(
 				@openSets,
 				[
 					format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id,
-					data                                         => { max => $setProblemCount->[$i] }
+					data => { problem_ids => encode_json($setProblemIds->{ $sets->[$i]->set_id }) }
 				]
 			);
-			$maxProblems = $setProblemCount->[$i] if $setProblemCount->[$i] > $maxProblems;
+			@initialProblemIDs = @{ $setProblemIds->{ $sets->[$i]->set_id } } unless @initialProblemIDs;
 		}
-	}
-
-	my @problemIDs;
-
-	for my $i (1 .. $maxProblems) {
-		push(@problemIDs, [ $i => $i, $i > $openSets[0][3]{max} ? (style => 'display:none') : () ]);
 	}
 
 	return $c->c(
@@ -70,7 +68,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			$c,
 			id                  => 'hcp_problem_id',
-			values              => \@problemIDs,
+			values              => \@initialProblemIDs,
 			label_text          => $c->maketext('Problem Number'),
 			menu_container_attr => { class => 'col-3' }
 		)

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -36,6 +36,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Please choose the set for which all problems should have half credit added.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -40,6 +40,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Choose the set which you would like to enable partial credit for.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -32,7 +32,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
+++ b/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
@@ -52,6 +52,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		}
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag(
 			'p',

--- a/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
+++ b/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
@@ -18,6 +18,8 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to reset number of incorrect attempts.
 
+use Mojo::JSON qw(encode_json);
+
 use WeBWorK::Utils qw(between x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new ($class) {
@@ -28,30 +30,26 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# Construct a dropdown with open sets and another with problems.
-	# Javascript ensures the appropriate number of problems are shown for the selected set.
+	# Javascript ensures the appropriate problems are shown for the selected set.
 
-	my @openSets;
-	my $maxProblems = 0;
+	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default') {
+		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+			&& $sets->[$i]->assignment_type eq 'default'
+			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
+		{
 			push(
 				@openSets,
 				[
 					format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id,
-					data                                         => { max => $setProblemCount->[$i] }
+					data => { problem_ids => encode_json($setProblemIds->{ $sets->[$i]->set_id }) }
 				]
 			);
-			$maxProblems = $setProblemCount->[$i] if $setProblemCount->[$i] > $maxProblems;
+			@initialProblemIDs = @{ $setProblemIds->{ $sets->[$i]->set_id } } unless @initialProblemIDs;
 		}
-	}
-
-	my @problemIDs;
-
-	for my $i (1 .. $maxProblems) {
-		push(@problemIDs, [ $i => $i, $i > $openSets[0][3]{max} ? (style => 'display:none') : () ]);
 	}
 
 	return $c->c(
@@ -73,7 +71,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 			$c,
 			id                  => 'ria_problem_id',
 			label_text          => $c->maketext('Problem Number'),
-			values              => \@problemIDs,
+			values              => \@initialProblemIDs,
 			menu_container_attr => { class => 'col-3' }
 		)
 	)->join('');

--- a/lib/WeBWorK/AchievementItems/ResurrectGW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectGW.pm
@@ -45,6 +45,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 				|| ($set->reduced_scoring_date && after($set->reduced_scoring_date)));
 	}
 
+	return unless @closed_gateway_sets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Resurrect which test?')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ResurrectGW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectGW.pm
@@ -18,10 +18,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to extend the due date on a gateway
 
-use strict;
-use warnings;
-
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64 format_set_name_display);
+use WeBWorK::Utils qw(after x nfreeze_base64 thaw_base64 format_set_name_display);
 
 sub new ($class) {
 	return bless {
@@ -34,17 +31,18 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my $db = $c->db;
 
-	my $effectiveUserName = $c->param('effectiveUser') // $c->param('user');
-	my @unfilteredsets = $db->getMergedSets(map { [ $effectiveUserName, $_ ] } $db->listUserSets($effectiveUserName));
-	my @sets;
+	my @closed_gateway_sets;
 
 	# Find the template sets of gateway quizzes.
-	for my $set (@unfilteredsets) {
-		push(@sets, [ format_set_name_display($set->set_id) => $set->set_id ])
-			if ($set->assignment_type =~ /gateway/ && $set->set_id !~ /,v\d+$/);
+	for my $set (@$sets) {
+		push(@closed_gateway_sets, [ format_set_name_display($set->set_id) => $set->set_id ])
+			if $set->assignment_type =~ /gateway/
+			&& $set->set_id !~ /,v\d+$/
+			&& (after($set->due_date)
+				|| ($set->reduced_scoring_date && after($set->reduced_scoring_date)));
 	}
 
 	return $c->c(
@@ -53,7 +51,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 			$c,
 			id         => 'resgw_gw_id',
 			label_text => $c->maketext('Test Name'),
-			values     => \@sets,
+			values     => \@closed_gateway_sets,
 			menu_attr  => { dir => 'ltr' }
 		)
 	)->join('');

--- a/lib/WeBWorK/AchievementItems/ResurrectHW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectHW.pm
@@ -40,6 +40,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 				|| ($sets->[$i]->reduced_scoring_date && after($sets->[$i]->reduced_scoring_date)));
 	}
 
+	return unless @closedSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Choose the set which you would like to resurrect.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/ResurrectHW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectHW.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# List all of the sets that are closed or past their reduced scoring date.
 
 	my @closedSets;
@@ -37,7 +37,7 @@ sub print_form ($self, $sets, $setProblemCount, $c) {
 		push(@closedSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
 			if $sets->[$i]->assignment_type eq 'default'
 			&& (after($sets->[$i]->due_date)
-				|| ($sets->[$i]->reduced_scoring_date && after($$sets[$i]->reduced_scoring_date)));
+				|| ($sets->[$i]->reduced_scoring_date && after($sets->[$i]->reduced_scoring_date)));
 	}
 
 	return $c->c(

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	my @openSets;
 
 	for my $i (0 .. $#$sets) {

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -36,6 +36,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
+	return unless @openSets;
+
 	return $c->c(
 		$c->tag('p', $c->maketext('Choose the set whose close date you would like to extend.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(

--- a/lib/WeBWorK/AchievementItems/Surprise.pm
+++ b/lib/WeBWorK/AchievementItems/Surprise.pm
@@ -28,7 +28,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub print_form ($self, $sets, $setProblemCount, $c) {
+sub print_form ($self, $sets, $setProblemIds, $c) {
 	# The form opens the file "suprise_message.txt" in the achievements
 	# folder and prints the contents of the file.
 

--- a/templates/ContentGenerator/Achievements/achievement_items.html.ep
+++ b/templates/ContentGenerator/Achievements/achievement_items.html.ep
@@ -16,34 +16,37 @@
 				<h3><%= maketext($item->name) %></h3>
 			% }
 			<p><%= maketext($item->description) %></p>
+			% my $form = $item->print_form($sets, $setProblemIds, $c);
 			% # Print a modal popup for each item which contains the form necessary to get the data to use the item.
 			<%= link_to maketext('Use Reward') => '#modal_' . $item->id,
 					role  => 'button',
-					class => 'btn btn-secondary',
+					class => 'btn btn-secondary' . ($form ? '' : ' disabled'),
 					id    => 'popup_' . $item->id,
-					data  => { bs_toggle => 'modal' } =%>
-			<div id="<%= 'modal_' . $item->id %>" class="modal hide fade" tabindex="-1">
-				<div class="modal-dialog modal-dialog-centered">
-					<div class="modal-content">
-						<div class="modal-header">
-							<h4 class="modal-title"><%= maketext($item->name) %></h4>
-							<button type="button" class="btn-close" data-bs-dismiss="modal"
-								aria-label="<%= maketext('close') %>"></button>
+					$form ? (data  => { bs_toggle => 'modal' }) : () =%>
+			% if ($form) {
+				<div id="<%= 'modal_' . $item->id %>" class="modal hide fade" tabindex="-1">
+					<div class="modal-dialog modal-dialog-centered">
+						<div class="modal-content">
+							<div class="modal-header">
+								<h4 class="modal-title"><%= maketext($item->name) %></h4>
+								<button type="button" class="btn-close" data-bs-dismiss="modal"
+									aria-label="<%= maketext('close') %>"></button>
+							</div>
+							<%= form_for current_route, method => 'POST', name => "itemform_$itemNumber",
+								class => 'achievementitemform', begin =%>
+								<div class="modal-body">
+									<%= $form =%>
+									<%= hidden_field useditem => $itemNumber =%>
+									<%= $c->hidden_authen_fields("achievement_${itemNumber}_") =%>
+								</div>
+								<div class="modal-footer">
+									<%= submit_button maketext('Submit'), class => 'btn btn-primary' =%>
+								</div>
+							<%= end =%>
 						</div>
-						<%= form_for current_route, method => 'POST', name => "itemform_$itemNumber",
-							class => 'achievementitemform', begin =%>
-							<div class="modal-body">
-								<%= $item->print_form($sets, $setProblemIds, $c) =%>
-								<%= hidden_field useditem => $itemNumber =%>
-								<%= $c->hidden_authen_fields("achievement_${itemNumber}_") =%>
-							</div>
-							<div class="modal-footer">
-								<%= submit_button maketext('Submit'), class => 'btn btn-primary' =%>
-							</div>
-						<%= end =%>
 					</div>
 				</div>
-			</div>
+			% }
 		</div>
 		% $itemNumber++;
 	% }

--- a/templates/ContentGenerator/Achievements/achievement_items.html.ep
+++ b/templates/ContentGenerator/Achievements/achievement_items.html.ep
@@ -33,7 +33,7 @@
 						<%= form_for current_route, method => 'POST', name => "itemform_$itemNumber",
 							class => 'achievementitemform', begin =%>
 							<div class="modal-body">
-								<%= $item->print_form($sets, $setProblemCount, $c) =%>
+								<%= $item->print_form($sets, $setProblemIds, $c) =%>
 								<%= hidden_field useditem => $itemNumber =%>
 								<%= $c->hidden_authen_fields("achievement_${itemNumber}_") =%>
 							</div>


### PR DESCRIPTION
When the achievement item modal dialogs for the  'Use Reward' buttons on the achievements page are generated, instead of just storing a max problem id for each set option, store the json encoded list of problem ids.  Initially only the options for the first set are provided.  The javascript then rebuilds the options list when a new set is selected that only includes the problem ids for that set.

Make the "Use Reward" button disabled if there are no sets that the achievement item can act one.  With a little more effort a message could be shown when the button is clicked instead.

This also restructures the code that obtains the achievement item data from the database to be a bit more efficient.  When this data is obtained gateway tests are no longer filtered out.  The current code for each achievement item that does not act on gateway tests is already set up to filter these out.  The achievement items that do act on gateway tests no longer need to load data from the database on their own.  They can use the given list and filter out non-gateway sets.

There seems to have been a minor bug in the `ResurrectGW` achievement in that it showed all gateway sets to be possibly "resurrected" when it should only show gateway sets that are past due.  That has also been fixed, so now it only shows past due gateway sets for "resurrection".
