### PR TITLE
Reduced scoring improvements for achievements and the progress bar

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -143,6 +143,7 @@ $institutionName = 'MAA (Mathematical Association of America)';
 $achievementsEnabled = 0;
 $achievementItemsEnabled = 0;
 $achievementPointsPerProblem = 5;
+$achievementPointsPerProblemReduced = 3;
 $achievementPreambleFile = "preamble.at";
 $achievementExcludeSet = [];
 $mail{achievementEmailFrom} = '';
@@ -1640,6 +1641,15 @@ $ConfigValues = [
 			var  => 'achievementPointsPerProblem',
 			doc  => x('Achievement Points Per Problem'),
 			doc2 => x('This is the number of achievement points given to each user for completing a problem.'),
+			type => 'number'
+		},
+		{
+			var  => 'achievementPointsPerProblemReduced',
+			doc  => x('Achievement Points Per Problem in Reduced Scoring Period'),
+			doc2 => x(
+				'This is the number of achievement points given to each user for completing a problem if the '
+					. 'problem is in a set that is in the reduced scoring period.'
+			),
 			type => 'number'
 		},
 		{

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -136,10 +136,13 @@ sub checkForAchievements ($problem_in, $pg, $c, %options) {
 	# Otherwise only check the current problem.
 	for ($isGatewaySet ? @setProblems : $problem) {
 		if ($_->status >= 1 && $_->num_correct == 1) {
-			$globalUserAchievement->achievement_points(
-				$globalUserAchievement->achievement_points + $ce->{achievementPointsPerProblem});
-			# This variable is shared and should be considered iffy. (What does this mean? What is iffy?)
-			$achievementPoints += $ce->{achievementPointsPerProblem};
+			my $pointsEarned =
+				defined $_->{reduced_score} && $_->{reduced_score} < 1
+				? $ce->{achievementPointsPerProblemReduced}
+				: $ce->{achievementPointsPerProblem};
+			$globalUserAchievement->achievement_points($globalUserAchievement->achievement_points + $pointsEarned);
+			# This variable is shared and should be considered iffy.
+			$achievementPoints += $pointsEarned;
 			$globalData->{completeProblems} += 1;
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -29,7 +29,8 @@ use WeBWorK::Utils qw(decodeAnswers is_restricted path_is_subdir before after be
 	wwRound is_jitar_problem_closed is_jitar_problem_hidden jitar_problem_adjusted_status
 	jitar_id_to_seq seq_to_jitar_id jitar_problem_finished format_set_name_display);
 use WeBWorK::Utils::Rendering qw(getTranslatorDebuggingOptions renderPG);
-use WeBWorK::Utils::ProblemProcessing qw/process_and_log_answer jitar_send_warning_email compute_reduced_score/;
+use WeBWorK::Utils::ProblemProcessing qw(process_and_log_answer jitar_send_warning_email compute_reduced_score
+	compute_unreduced_score);
 use WeBWorK::AchievementEvaluator qw(checkForAchievements);
 use WeBWorK::DB::Utils qw(global2user);
 use WeBWorK::Localize;
@@ -738,6 +739,7 @@ sub siblings ($c) {
 	my $total_correct    = 0;
 	my $total_incorrect  = 0;
 	my $total_inprogress = 0;
+	my $is_reduced       = 0;
 	my $currentProblemID = $c->{invalidProblem} ? 0 : $c->{problem}->problem_id;
 
 	my $progressBarEnabled = $c->ce->{pg}{options}{enableProgressBar};
@@ -762,7 +764,8 @@ sub siblings ($c) {
 			$num_of_problems++;
 			my $total_attempts = $problemRecord->num_correct + $problemRecord->num_incorrect;
 
-			my $status = $problemRecord->status;
+			my $status = compute_unreduced_score($ce, $problemRecord, $c->{set});
+			$is_reduced = 1 if $status > $problemRecord->status;
 			if ($isJitarSet) {
 				$status = jitar_problem_adjusted_status($problemRecord, $db);
 			}
@@ -841,6 +844,7 @@ sub siblings ($c) {
 		total_correct    => $total_correct,
 		total_incorrect  => $total_incorrect,
 		total_inprogress => $total_inprogress,
+		is_reduced       => $is_reduced
 	);
 }
 

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -40,6 +40,7 @@ use Caliper::Entity;
 our @EXPORT_OK = qw(
 	process_and_log_answer
 	compute_reduced_score
+	compute_unreduced_score
 	create_ans_str_from_responses
 	jitar_send_warning_email
 );
@@ -304,6 +305,19 @@ sub compute_reduced_score ($ce, $problem, $set, $score, $submitTime) {
 
 	# Return the reduced score.
 	return $problem->sub_status + $ce->{pg}{ansEvalDefaults}{reducedScoringValue} * ($score - $problem->sub_status);
+}
+
+# Compute the "unreduced" score for a problem.
+# If reduced scoring is enabled for the set and the sub_status is less than the status, then the status is the
+# reduced score.  In that case compute and return the unreduced score that resulted in that reduced score.
+sub compute_unreduced_score ($ce, $problem, $set) {
+	return
+		$set->enable_reduced_scoring
+		&& $ce->{pg}{ansEvalDefaults}{reducedScoringValue}
+		&& defined $problem->sub_status && $problem->sub_status < $problem->status
+		? (($problem->status - $problem->sub_status) / $ce->{pg}{ansEvalDefaults}{reducedScoringValue} +
+			$problem->sub_status)
+		: $problem->status;
 }
 
 # create answer string from responses hash

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -29,6 +29,7 @@ use Digest::MD5 qw(md5_hex);
 use Encode qw(encode_utf8);
 
 use WeBWorK::Utils qw(formatDateTime);
+use WeBWorK::Utils::ProblemProcessing qw(compute_unreduced_score);
 
 our @EXPORT_OK = qw(constructPGOptions getTranslatorDebuggingOptions renderPG);
 
@@ -120,18 +121,8 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 	# State Information
 	$options{numOfAttempts} =
 		($problem->num_correct || 0) + ($problem->num_incorrect || 0) + ($formFields->{submitAnswers} ? 1 : 0);
-	$options{problemValue} = $problem->value;
-	# If reduced scoring is enabled for the set and the sub_status is less than the status, then the status is the
-	# reduced score.  In that case compute the unreduced score that resulted in that reduced score to submit as the
-	# currently recorded score.
-	$options{recorded_score} =
-		($set->enable_reduced_scoring
-			&& $ce->{pg}{ansEvalDefaults}{reducedScoringValue}
-			&& defined $problem->sub_status
-			&& $problem->sub_status < $problem->status)
-		? (($problem->status - $problem->sub_status) / $ce->{pg}{ansEvalDefaults}{reducedScoringValue} +
-			$problem->sub_status)
-		: $problem->status;
+	$options{problemValue}         = $problem->value;
+	$options{recorded_score}       = compute_unreduced_score($ce, $problem, $set);
 	$options{num_of_correct_ans}   = $problem->num_correct;
 	$options{num_of_incorrect_ans} = $problem->num_incorrect;
 

--- a/templates/ContentGenerator/Problem/siblings.html.ep
+++ b/templates/ContentGenerator/Problem/siblings.html.ep
@@ -15,9 +15,14 @@
 					aria-label="correct progress bar for current problem set" role="figure"
 					data-bs-toggle="tooltip" data-bs-placement="bottom" tabindex="0"
 					data-bs-title="<%= maketext('Correct: [_1]/[_2]', $total_correct, $num_of_problems) %>">
-					% # Perfect scores deserve some stars (&#9733;)!
 					% if ($total_correct == $num_of_problems) {
-						&#9733;Perfect&#9733;
+						% if ($is_reduced) {
+							% # If any of the scores are reduced the set is not perfect. It is merely complete.
+							<%= maketext('Complete') %>
+						% } else {
+							% # Perfect scores deserve some stars (&#9733;)!
+							&#9733;<%= maketext('Perfect') %>&#9733;
+						% }
 					% }
 				</div>
 			% }


### PR DESCRIPTION
Achievements now compute and use the unreduced score for problems for determining if a problem is complete/correct.  That is set as the `status` that is passed into the achievement evaluators.  The reduced score is cached in a hash key of the `$problem` object named reduced_score in case an achievement evaluator wants that information also (although none of them use this at this point).
    
This fixes issue #2285.

Make the problem siblings work with unreduced scores for determining correctness/completion of a problem.  The siblings problem list shows a checkmark by problems for which the maximum possible score has been obtained, even if that is not 100% for the problem due to being in the reduced scoring period.  Also when all problems are complete in the set and there are problems with reduced scores, then the progress bar shows "Complete" without stars instead of the usual "Perfect" with stars.
    
Mark "Perfect" for translation.  For some reason it was not before.
