### PR TITLE
Add the AuthorComment css back once again.

### DIFF
--- a/htdocs/themes/math4/math4.scss
+++ b/htdocs/themes/math4/math4.scss
@@ -702,6 +702,17 @@ ul.courses-list {
 	}
 }
 
+// Do not delete this.  Although it is a duplicate of the rule in PG's problem.scss file, webwork2 adds these author
+// comments to the page (in the PG problem editor and the library browser) when the PG problems are in iframes and the
+// comments are outside of the iframes.  Thus the styles in the problem.scss file do not apply.
+div.AuthorComment {
+	background-color: #00e0e0;
+	color: black;
+	padding: 0.25rem;
+	border: 1px solid transparent;
+	border-radius: 0.25rem;
+}
+
 /* Footer */
 #footer {
 	font-size: 0.8em;


### PR DESCRIPTION
I keep forgetting why this is needed both here and in PG (actually it technically is not needed for PG), and so delete it here.  The issue is that author comments are rendered on pages (the PG problem editor and library browser) where the problems are rendered in iframes, and the comment is outside of the iframe.  So the problem.scss styles of PG only apply to what is inside the iframe, and this style is needed here to apply to the author comments not in the iframe.

To prevent me from deleting this again (or anyone else), I added a comment this time to remind me.