### PR TITLE
Fix instructor feedback not being given when showPartialCorrectAnswers is false.

### DIFF
--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -233,7 +233,8 @@ async sub renderProblem {
 		showAttemptPreviews      => $rh->{showAttemptPreviews}
 			// ($rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		showAttemptResults      => $rh->{showAttemptResults} // ($rh->{WWsubmit} || $rh->{WWcorrectAns}),
-		forceShowAttemptResults => $rh->{forceShowAttemptResults},
+		forceShowAttemptResults => $rh->{forceShowAttemptResults} || ($rh->{isInstructor}
+			&& ($rh->{showAttemptResults} // ($rh->{WWsubmit} || $rh->{WWcorrectAns}))),
 		showMessages       => $rh->{showMessages}       // ($rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		showCorrectAnswers => $rh->{showCorrectAnswers} // $rh->{WWcorrectAns},
 		debuggingOptions   => {


### PR DESCRIPTION
This applies to problems rendered in the library browser or PG problem editor.  In that case if $showPartialCorrectAnswers is false, then the instructor is not given the problem status (correct/incorrect) in the feedback.  This is because the renderProblem method does not set the forceShowAttemptResults (which overrides the $showPartialCorrectAnswers variable in PG) option.  So that is fixed by setting that option from the submit buttons for instructors.