### PR TITLE
Share strict to the PG safe zone.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1276,6 +1276,7 @@ ${pg}{modules} = [
 	[qw(Rserve Class::Tiny IO::Handle)],
 	[qw(DragNDrop)],
 	[qw(Types::Serialiser)],
+	[qw(strict)],
 ];
 
 ##### Problem creation defaults


### PR DESCRIPTION
Versions of Perl prior to 5.34 need this.  Otherwise warnings are issue by the `BEGIN { strict->import }` approach now used in place of the old `BEGIN { be_strict() }` approach.

This fixes the issue reported in https://github.com/openwebwork/pg/pull/968#issuecomment-1910760107.