### PR TITLE
Change the preview button name for the RPC endpoints.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -139,9 +139,9 @@ sub formatRenderedProblem {
 		get_problem_lang_and_dir($rh_result->{flags}, $ce->{perProblemLangAndDirSettingMode}, $formLanguage);
 	my $PROBLEM_LANG_AND_DIR = join(' ', map {qq{$_="$PROBLEM_LANG_AND_DIR{$_}"}} keys %PROBLEM_LANG_AND_DIR);
 
-	my $previewMode     = defined($ws->{inputs_ref}{preview})      || 0;
-	my $submitMode      = defined($ws->{inputs_ref}{WWsubmit})     || 0;
-	my $showCorrectMode = defined($ws->{inputs_ref}{WWcorrectAns}) || 0;
+	my $previewMode     = defined($ws->{inputs_ref}{previewAnswers}) || 0;
+	my $submitMode      = defined($ws->{inputs_ref}{WWsubmit})       || 0;
+	my $showCorrectMode = defined($ws->{inputs_ref}{WWcorrectAns})   || 0;
 	# A problemUUID should be added to the request as a parameter.  It is used by PG to create a proper UUID for use in
 	# aliases for resources.  It should be unique for a course, user, set, problem, and version.
 	my $problemUUID   = $ws->{inputs_ref}{problemUUID} // '';

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -228,14 +228,14 @@ async sub renderProblem {
 		isInstructor             => $rh->{isInstructor}       // 0,
 		forceScaffoldsOpen       => $rh->{forceScaffoldsOpen} // 0,
 		QUIZ_PREFIX              => $rh->{answerPrefix},
-		showFeedback             => $rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns},
+		showFeedback             => $rh->{previewAnswers} || $rh->{WWsubmit} || $rh->{WWcorrectAns},
 		showAttemptAnswers       => $rh->{showAttemptAnswers} // 1,
 		showAttemptPreviews      => $rh->{showAttemptPreviews}
-			// ($rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
+			// ($rh->{previewAnswers} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		showAttemptResults      => $rh->{showAttemptResults} // ($rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		forceShowAttemptResults => $rh->{forceShowAttemptResults} || ($rh->{isInstructor}
 			&& ($rh->{showAttemptResults} // ($rh->{WWsubmit} || $rh->{WWcorrectAns}))),
-		showMessages       => $rh->{showMessages}       // ($rh->{preview} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
+		showMessages       => $rh->{showMessages} // ($rh->{previewAsnwers} || $rh->{WWsubmit} || $rh->{WWcorrectAns}),
 		showCorrectAnswers => $rh->{showCorrectAnswers} // ($rh->{WWcorrectAns} ? 2 : 0),
 		debuggingOptions   => {
 			show_resource_info          => $rh->{show_resource_info}          // 0,

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -100,7 +100,8 @@
 							% # Submit buttons (all are shown by default)
 							% if ($showPreviewButton ne '0') {
 								<%= submit_button $lh->maketext('Preview My Answers'),
-									name => 'preview', id => 'previewAnswers_id', class => 'btn btn-primary mb-1' %>
+									name => 'previewAnswers', id => 'previewAnswers_id',
+									class => 'btn btn-primary mb-1' %>
 							% }
 							% if ($showCheckAnswersButton ne '0') {
 								<%= submit_button $lh->maketext('Check Answers'),

--- a/templates/RPCRenderFormats/default.json.ep
+++ b/templates/RPCRenderFormats/default.json.ep
@@ -33,7 +33,7 @@
 			% id => 'problem-result-score'),
 	% body_part700 => join('', '<p>',
 		% $showPreviewButton eq '0' ? '' : submit_button($lh->maketext('Preview My Answers'),
-			% name => 'preview', id => 'previewAnswers_id', class => 'btn btn-primary mb-1'),
+			% name => 'previewAnswers', id => 'previewAnswers_id', class => 'btn btn-primary mb-1'),
 		% $showCheckAnswersButton eq '0' ? '' : submit_button($lh->maketext('Check Answers'),
 			% name => 'WWsubmit', class => 'btn btn-primary mb-1'),
 		% $showCorrectAnswersButton eq '0' ? '' : submit_button($lh->maketext('Show Correct Answers'),


### PR DESCRIPTION
This fixes issue #2310 in the simple way I mention there.  This also only makes the change mentioned for the preview button, and does not address the submit/check answers button issue.

A discussion is needed on the best fix for this though.