### PR TITLE
Add pattern validation to the email address field on the feedback page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -99,27 +99,29 @@ sub initialize ($c) {
 
 		# Determine the sender of the email.
 		my $sender;
-		if ($user) {
-			if ($user->email_address) {
-				$sender = $user->rfc822_mailbox;
-			} else {
-				if ($user->full_name) {
-					$sender = $user->full_name . " <$from>";
-				} else {
-					$sender = $from;
-				}
-			}
-		} else {
-			$sender = $from;
+		if ($user && $user->email_address) {
+			$from   = $user->email_address;
+			$sender = $user->rfc822_mailbox;
 		}
 
-		unless ($sender) {
+		unless ($from) {
 			$c->stash->{send_error} = $c->maketext('No Sender specified.');
+			return;
+		}
+		unless ($from =~ /^[a-zA-Z0-9.!#$%&\'*+\/=?^_`~\-]+@[a-zA-Z0-9\-]+\.[a-zA-Z0-9.\-]+$/) {
+			$c->stash->{send_error} = $c->maketext('Sender is not a valid email address.');
 			return;
 		}
 		unless ($feedback) {
 			$c->stash->{send_error} = $c->maketext('Message was blank.');
 			return;
+		}
+		unless ($sender) {
+			if ($user && $user->full_name) {
+				$sender = $user->full_name . " <$from>";
+			} else {
+				$sender = $from;
+			}
 		}
 
 		my %subject_map = (

--- a/templates/ContentGenerator/Feedback.html.ep
+++ b/templates/ContentGenerator/Feedback.html.ep
@@ -32,8 +32,16 @@
 		<div class="row mb-3">
 			<%= label_for 'from', class => 'col-form-label col-auto', begin =%><b><%= maketext('From:') %></b><% end =%>
 			<div class="col-auto">
-				<%= text_field from => $user_email_address, class => 'form-control', size => 40, id => 'from',
-					$user_email_address ? (disabled => undef, readonly => undef) : (required => undef) =%>
+				<%= email_field from => $user_email_address, class => 'form-control', size => 40, id => 'from',
+					$user_email_address
+						? (disabled => undef, readonly => undef)
+						: (
+							required       => undef,
+							placeholder    => 'Email address',
+							autocorrect    => 'off',
+							autocapitalize => 'off',
+							pattern        => '^[a-zA-Z0-9.!#$%&\'*+\\/=?^_`~\\-]+@[a-zA-Z0-9\\-]+\\.[a-zA-Z0-9.\\-]+$'
+						) =%>
 			</div>
 		</div>
 		% if (stash 'send_error') {


### PR DESCRIPTION
Also add some other attributes to the field that are useful for such a field (placeholder, autocorrect: off, and autocapitalization: off), and make the field of type "email" instead of "text" to begin with.

It also wouldn't hurt to add server side validation of this fields contents in case an email saved for the user in the database is not valid, but that is not done yet here.

This addresses issue #2312.