### PR TITLE
Fix an uninitialized value used in pattern match.

### DIFF
--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -127,7 +127,7 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 	$options{num_of_incorrect_ans} = $problem->num_incorrect;
 
 	# This means that there are essay questions in the problem that have not been graded.
-	$options{needs_grading} = $problem->flags =~ /:needs_grading$/;
+	$options{needs_grading} = ($problem->flags // '') =~ /:needs_grading$/;
 
 	# Persistent problem data
 	$options{PERSISTENCE_HASH} = decode_json($problem->problem_data || '{}');


### PR DESCRIPTION
This is caused by trying to match the problem flags with `/:needs_grading$/' when there isn't a real problem.  For instance when a set info file is rendered.