### PR TITLE
Update the `actions/checkout` action used by the Github workflows.

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -17,7 +17,7 @@ jobs:
     container:
       image: perl:5.34
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: perl -V
         run: perl -V
       - name: Install dependencies


### PR DESCRIPTION
The workflows currently use `actions/checkout@v3` which used node version 16.  This results in a warning that Node.js 16 actions are deprecated.  So this updates to `actions/checkout@v4`.

This is just a maintenance pull request.  Thanks to @pstaabp for observing this.