### PR TITLE
Add optional certbot renewal routes.

### DIFF
--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -78,6 +78,32 @@ server_group: www-data
 # used when serving the webwork2 app directly.
 redirect_http_to_https: 0
 
+# Change enable_certbot_webroot_routes to 1 to enable routes in the webwork2 app
+# used by certbot for certificate renewal with the webroot option. Note that
+# this should only be used when serving the webwork2 app directly. You will also
+# need to add "- http://*:80" as well as "- http://*:443" to the hypnotoad
+# listen values below for this to work.
+# Then execute
+# sudo certbot certonly --webroot -w /opt/webwork/webwork2/tmp \
+#   -d your.domain.edu \
+#   --post-hook "chown -R www-data:www-data /etc/letsencrypt && systemctl reload webwork2"
+# to renew certificates without needing to stop the webwork2 app. That command
+# will renew the certificate for the first time, and also set up autorenewal in
+# the future. Obviously your.domain.edu needs to be changed to your actual
+# domain name. Note that /opt/webwork/webwork2/tmp is the default value of
+# $webworkDirs{tmp}. If you customize $webworkDirs{tmp} in localOverrides.conf,
+# then you will need to use what you have that variable set to instead. Be
+# careful since the default value of $webworkDirs{tmp} depends on the value of
+# $webworkDirs{root} (which is /opt/webwork/webwork2 by default). So if you
+# customize $webworkDirs{root}, then you will need to adjust the path
+# accordingly. Also, change www-data:www-data in the command to be
+# server_user:server_group where server_user and server_group are the values of
+# those settings above. The post hook in the command will run every time that
+# certificates are automatically renewed, and will fix permissions on the new
+# certificates so that the webwork2 app can read them, and will hot reload the
+# webwork2 app to load the new certificates (with zero downtime).
+enable_certbot_webroot_routes: 0
+
 # hypnotoad server configuration
 # See https://docs.mojolicious.org/Mojo/Server/Daemon
 # Any of the attributes listed there can be set in this section.

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -243,6 +243,17 @@ sub startup ($app) {
 		}
 	}
 
+	# Letsencrypt renewal route.
+	if ($config->{enable_certbot_webroot_routes}) {
+		$r->any(
+			"/.well-known/*static" => sub ($c) {
+				my $file = "$ce->{webworkDirs}{tmp}/.well-known/" . $c->stash('static');
+				return $c->reply->file($file) if -r $file;
+				return $c->render(data => 'File not found', status => 404);
+			}
+		);
+	}
+
 	# Note that these routes must come last to support the case that $webwork_url is '/'.
 
 	my $cg_r = $r->under($webwork_url)->name('root');


### PR DESCRIPTION
To enable these routes set `enable_certbot_renewal_routes: 1` in `conf/webwork2.mojolicious.yml`.

Then execute
```
sudo certbot certonly --webroot -w /opt/webwork/webwork2/tmp \
  -d your.domain.edu \
  --post-hook "chown -R www-data:www-data /etc/letsencrypt && systemctl reload webwork2"
```
to renew certificates without needing to stop the webwork2 app. That command will renew the certificate for the first time, and also set up autorenewal in the future. Obviously your.domain.edu needs to be changed to your actual domain name. Note that `/opt/webwork/webwork2/tmp` is the default value of `$webworkDirs{tmp}`. If you customize `$webworkDirs{tmp}` in `localOverrides.conf`, then you will need to use what you have that variable set to instead. Be careful since the default value of `$webworkDirs{tmp}` depends on the value of `$webworkDirs{root}` (which is `/opt/webwork/webwork2` by default). So if you customize `$webworkDirs{root}`, then you will need to adjust the path accordingly. Also, change `www-data:www-data` in the command to be `server_user:server_group` where `server_user` and `server_group` are the values of those settings above. The post hook in the command will run every time that certificates are automatically renewed, and will fix permissions on the new certificates so that the webwork2 app can read them, and will hot reload the webwork2 app to load the new certificates (with zero downtime).

Edit: Note that for this to work `http://*:80` needs to be included in the hypnotoad `listen` list in addition to `https://*:443?...`.  I added a comment about this in `webwork2.mojolicious.dist.yml`.