### PR TITLE
Fix BOM removal when a classlist file is read.

### DIFF
--- a/lib/WeBWorK/File/Classlist.pm
+++ b/lib/WeBWorK/File/Classlist.pm
@@ -54,7 +54,7 @@ sub parse_classlist($) {
 
 		# Remove a byte order mark from the beginning of the file if present.  Excel inserts this on some systems, and
 		# the presence of this multibyte character causes a classlist import to fail.
-		s/^\xEF\xBB\xBF//;
+		s/^\x{FEFF}//;
 
 		s/^\s*//;
 		s/\s*$//;


### PR DESCRIPTION
This was broken when the UTF-8 encoding method was changed in #1831. Since the file contents are now UTF-8 decoded, a different regular expression is needed to match a BOM.

This replaces #2305.  That pull request will be closed.

Here is the file with the BOM from that pull request for testing: https://github.com/openwebwork/webwork2/files/14039829/StudentsList_course_csv_utf-8_w_BOM.csv