### PR TITLE
Add a patch for the dvisvgm issue observed in https://github.com/openwebwork/pg/issues/1023.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -213,6 +213,7 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 
 # Patch files that are applied below
 COPY docker-config/imagemagick-allow-pdf-read.patch /tmp
+COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
 
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& mkdir /run/webwork2 /etc/ssl/local \
@@ -230,7 +231,9 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& cd $PG_ROOT/htdocs \
 		&& npm install \
 	&& patch -p1 -d / < /tmp/imagemagick-allow-pdf-read.patch \
-	&& rm /tmp/imagemagick-allow-pdf-read.patch
+	&& rm /tmp/imagemagick-allow-pdf-read.patch \
+	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
+	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
 
 # ==================================================================
 # Phase 7 - Final setup and prepare docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -95,6 +95,7 @@ RUN apt-get update \
 	libextutils-helpers-perl \
 	libextutils-installpaths-perl \
 	libextutils-xsbuilder-perl \
+	libfile-copy-recursive-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
 	libfuture-asyncawait-perl \
@@ -131,7 +132,6 @@ RUN apt-get update \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
-	libsql-abstract-classic-perl \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -57,6 +57,7 @@ RUN apt-get update \
 	libextutils-helpers-perl \
 	libextutils-installpaths-perl \
 	libextutils-xsbuilder-perl \
+	libfile-copy-recursive-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
 	libfuture-asyncawait-perl \
@@ -93,7 +94,6 @@ RUN apt-get update \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
-	libsql-abstract-classic-perl \
 	libsql-abstract-perl \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
@@ -139,7 +139,7 @@ RUN apt-get update \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
-	&& curl -fsSL https://deb.nodesource.com/setup_16.x | bash - \
+	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
 	&& apt-get clean \
 	&& rm -fr /var/lib/apt/lists/* /tmp/*

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -75,6 +75,7 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 
 # Patch files that are applied below
 COPY docker-config/imagemagick-allow-pdf-read.patch /tmp
+COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
 
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& mkdir /run/webwork2 /etc/ssl/local \
@@ -92,7 +93,9 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& cd $PG_ROOT/htdocs \
 		&& npm install \
 	&& patch -p1 -d / < /tmp/imagemagick-allow-pdf-read.patch \
-	&& rm /tmp/imagemagick-allow-pdf-read.patch
+	&& rm /tmp/imagemagick-allow-pdf-read.patch \
+	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
+	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
 
 # ==================================================================
 # Phase 5 - Final setup and prepare docker-entrypoint.sh

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -208,7 +208,8 @@ chmod ug+w htdocs/tmp
 
 # Even if the admin and courses directories already existed their permissions
 # might not be correct.
-# chown www-data:www-data  $APP_ROOT/courses
+chown www-data:www-data  $APP_ROOT/courses
+chown www-data:www-data  $APP_ROOT/courses/admin
 chown www-data:www-data  $APP_ROOT/courses/admin/*
 
 # Symbolic links which have no target outside the Docker container

--- a/docker-config/pgfsys-dvisvmg-bbox-fix.patch
+++ b/docker-config/pgfsys-dvisvmg-bbox-fix.patch
@@ -1,0 +1,19 @@
+--- a/usr/share/texlive/texmf-dist/tex/generic/pgf/systemlayer/pgfsys-dvisvgm.def	2024-02-22 13:30:26.167777811 -0600
++++ b/usr/share/texlive/texmf-dist/tex/generic/pgf/systemlayer/pgfsys-dvisvgm.def	2024-02-22 13:36:29.820956330 -0600
+@@ -127,7 +127,15 @@
+   \dp#1=0pt%
+   \leavevmode%
+   \pgf@xa=\pgf@trimleft@final\relax  \ifdim\pgf@xa=0pt \else\kern\pgf@xa\fi%
+-  \raise-\pgf@ya\hbox{\ifpgf@sys@svg@inpicture\else\special{dvisvgm:bbox \pgf@sys@tonumber\pgf@picmaxx\space\pgf@sys@tonumber\pgf@picmaxy}\fi\box#1}%
++  \raise-\pgf@ya\hbox{%
++    \ifpgf@sys@svg@inpicture
++      \box#1%
++    \else
++      \special{dvisvgm:bbox \pgf@sys@tonumber\pgf@picmaxx\space\pgf@sys@tonumber\pgf@picmaxy}%
++      \special{dvisvgm:bbox lock}%
++      \box#1%
++      \special{dvisvgm:bbox unlock}%
++    \fi}%
+   \pgf@xa=\pgf@trimright@final\relax \ifdim\pgf@xa=0pt \else\kern\pgf@xa\fi%
+ }
+


### PR DESCRIPTION
This patch is applied in the docker build.

It can be applied on your server with the command
`sudo patch -p1 -d / < /opt/webwork/webwork2/docker-config/pgfsys-dvisvmg-bbox-fix.patch`

Note this patch is specific to Ubuntu 22.04, so don't try it on other versions of Ubuntu or other linux distributions (or other operating systems).

This was the change made in https://github.com/pgf-tikz/pgf/pull/1276 that was merged into the master branch of the pgf-tikz latex package on October 23, 2023 that fixes the issue reported in https://github.com/pgf-tikz/pgf/issues/1275.