### PR TITLE
skip over hidden folders and files in the library browser

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -85,7 +85,7 @@ sub get_library_sets ($c, $top, $dir) {
 	}
 	return (0) if grep {/^=library-ignore$/} @lis;
 
-	my @pgfiles = grep { m/\.pg$/ && (!m/(Header|-text)(File)?\.pg$/) && -f "$dir/$_" } @lis;
+	my @pgfiles = grep { m/^[^.].*\.pg$/ && (!m/(Header|-text)(File)?\.pg$/) && -f "$dir/$_" } @lis;
 	my $pgcount = scalar(@pgfiles);
 	my $pgname  = $dir;
 	$pgname =~ s!.*/!!;
@@ -94,6 +94,8 @@ sub get_library_sets ($c, $top, $dir) {
 
 	my @pgdirs;
 	my @dirs = grep { !$ignoredir{$_} && -d "$dir/$_" } @lis;
+	# Filter out hidden directories
+	@dirs = grep { $_ !~ /^\./ } @dirs;
 	if ($top == 1) {
 		@dirs = grep { !$c->{problibs}{$_} } @dirs;
 	}


### PR DESCRIPTION
Chemistry faculty here have a library they manage with git. It has a `.git` folder at the top level that shows up in the library browser's list of folders containing PG files (if you click the button to view this library). It could be managed like the OPL, with an intermediate folder, but this seems like a good change anyway. Namely, filter out any files or folders that start with a dot.