### PR TITLE
Switch to using a Mojolicious session for cookies.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -886,12 +886,6 @@ $sessionKeyLength = 32;
 # (you can comment this out to remove practice user support)
 $practiceUserPrefix = "practice";
 
-# There is a practice user who can be logged in multiple times.  He's
-# commented out by default, though, so you don't hurt yourself.  It is
-# kindof a backdoor to the practice user system, since he doesn't have a
-# password.  Come to think of it, why do we even have this?!
-#$debugPracticeUser = "practice666";
-
 # Option for gateway tests; $gatewayGracePeriod is the time in seconds
 # after the official due date during which we'll still grade the test
 $gatewayGracePeriod = 120;
@@ -900,51 +894,51 @@ $gatewayGracePeriod = 120;
 # Session Management
 ################################################################################
 
-## Session management, i.e., checking whether the session has timed out,
-## can be handled either using the key database, the traditional method,
-## or by using session cookies.  If one is using the key database
-## for session_management and is using WeBWorK's password authentication,
-## then one has the option of keeping a Login cookie with a duration
-## of up to 30 days.  However, if one uses cookies for session management,
-## then one cannot also use Login cookies.  So session management using
-## cookies is more appropriate when external authentication systems
-## are used, e.g., LDAP, LTIAdvanced, etc.
-##
+# Session management can be handled either using the key database, the
+# traditional method, or by using signed session cookies.
 
-## The following ability to update the cookie timestamp instead of the timestamp in the database
-## has been disabled for now.  It opens a potential security hole.
-## Setting $session_management_via="session_cookies" sets a session cookie automatically
-## even if you don't ask for it explicitly and this login cookie contains a session_key which
-## allows you to reenter your course (within 20 minutes or so) even if you move away from the
-## webwork HTML page and loose the session_key embedded in the HTML page.
-## However the time stamp in the cookie is not used currently used for anything.
-##
-#### NOT CURRENT:  The reason one might want to use cookies for session management
-#### is to avoid having to obtain a write lock on the Key database
-#### every time a request is received in order to update the timestamp
-#### in the Key database.  When cookies are used for session management,
-#### one obtains a write lock on the Key database for the original
-#### login request in order to write the new session key and its initial
-#### timestamp to the Key database, but on subsequent requests,
-#### one merely obtains a read lock on the Key database in order
-#### to verify that the session key in the session cookie is the
-#### same as the session key in the Key database.  The session timestamp
-#### is maintained in the cookie, not in the Key database, which will
-#### only show the timestamp of the original login.
+# Setting $session_management_via="key" uses the key database for session
+# management. If password authentication is used, then a user can opt to use a
+# session cookie with a duration determined by the $CookieLifeTime setting below
+# by checking the "Remember Me" checkbox on the login page.
 
+# Setting $session_management_via="session_cookies" uses a session cookie to
+# manage the session. Note that even in this case a key is stored in the
+# database which is compared to the key stored in the session cookie.
 
-
-## For session management using session_cookies, uncomment the first of the
-## following lines.
-## For session management using keys stored
-## in the  key  database and, possibly, enduring cookies if any have been set,
-## uncomment the second line.
-
-## These choices can be overridden locally in the localOverrides.conf file.
-## The default is to use "session_cookie".
+# Note that the key database method is less secure as the key must be embeded in
+# the page and added as a url parameter in order to maintain the session. These
+# things can be accessed by malicious javascript. The session cookies are http
+# only cookies which can not be accessed via javascript.
 
 $session_management_via = "session_cookie";
-#$session_management_via = "key";
+
+################################################################################
+# Cookie control settings
+################################################################################
+
+# Set the value of the samesite attribute of the session cookie:
+# See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+# Notes about the $CookieSameSite options:
+# The "None" setting should only be used with HTTPS and when $CookieSecure is
+# set to 1 below. The "None" setting is also less secure and can allow certain
+# types of cross-site attacks.  The "Strict" setting can break the links in the
+# system generated feedback emails when read in a web mail client.  Due to those
+# factors, the "Lax" setting is probably the optimal choice for typical webwork2
+# servers.
+$CookieSameSite = "Lax";
+
+# Set the value of the secure cookie attribute.
+# The default is 0, as 1 will not work without https.
+$CookieSecure = 0;
+
+# The CookieLifeTime setting determines how long the browser should retain the
+# cookie. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie.
+# The CookieLifeTime value should be numeric and in seconds, or should be set to
+# "session", in which case the cookie will expire when the browser session ends
+# (a "session cookie"). Note that a value of 0 also means the cookie will expire
+# when the browser session ends. The default value is 7 days.
+$CookieLifeTime = 604800;
 
 ################################################################################
 # WeBWorK Caliper
@@ -953,36 +947,6 @@ $session_management_via = "session_cookie";
 # Caliper is disabled by default.  See localOverrides.conf.dist for configuration
 # options when enabling Caliper.
 $caliper{enabled} = 0;
-
-################################################################################
-# Cookie control settings
-################################################################################
-
-# The following variables can be set to control cookie behavior.
-
-# Set the value of the samesite attribute of the WeBWorK cookie:
-# See: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
-#      https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-#      https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
-
-# Notes about the $CookieSameSite options:
-# The "None" setting should only be used with HTTPS and when $CookieSecure = 1; is set below. The "None" setting is
-# also less secure and can allow certain types of cross-site attacks.
-# The "Strict" setting can break the links in the system generated feedback emails when read in a web mail client.
-# Due to those factors, the "Lax" setting is probably the optimal choice for typical WeBWorK servers.
-
-$CookieSameSite = "Lax";
-
-# Set the value of the secure cookie attribute:
-# Default is 0 here, as 1 will not work without https
-$CookieSecure = 0;
-
-# The CookieLifeTime setting determines how long the browser should retain the cookie.
-# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-# The CookieLifeTime value should be numeric and in seconds, or should be set to "session", in which case
-# the Cookie will expire when the browser session ends (a "session cookie").
-# The default value is 7 days.
-$CookieLifeTime = 604800;
 
 ################################################################################
 # PG subsystem options

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -470,18 +470,29 @@ $mail{feedbackRecipients}    = [
 # Session Management
 ################################################################################
 
-## For a discussion of session_management_via session_cookies or the
-## Key database, see the   Session Management section
-## of defaults.config.dist
+# Session management can be handled either using the key database, the
+# traditional method, or by using signed session cookies.
 
-## For session management using the key database table, uncomment the following line,
-## which will override the setting  $session_management_via = "session_cookie"
-## set in defaults.config.
+# Setting $session_management_via="key" uses the key database for session
+# management. If password authentication is used, then a user can opt to use a
+# session cookie with a duration determined by the $CookieLifeTime setting below
+# by checking the "Remember Me" checkbox on the login page.
+
+# Setting $session_management_via="session_cookies" uses a session cookie to
+# manage the session. Note that even in this case a key is stored in the
+# database which is compared to the key stored in the session cookie.
+
+# Note that the key database method is less secure as the key must be embeded in
+# the page and added as a url parameter in order to maintain the session. These
+# things can be accessed by malicious javascript. The session cookies are http
+# only cookies which can not be accessed via javascript.
+
+# The default value for $session_management_via is "session_cookie".
 
 #$session_management_via = "key";
 
-## This is the length of time (in seconds) after which a user's session becomes
-## invalid if they have no activity. The default is 30 minutes (60*30 seconds).
+# This is the length of time (in seconds) after which a user's session becomes
+# invalid if they have no activity. The default is 30 minutes (60*30 seconds).
 
 #$sessionKeyTimeout = 60*60*2;
 
@@ -489,32 +500,29 @@ $mail{feedbackRecipients}    = [
 # Cookie control settings
 ################################################################################
 
-# The following variables can be set to control cookie behavior.
-
-# Set the value of the samesite attribute of the WeBWorK cookie:
-# See: https://blog.chromium.org/2019/10/developers-get-ready-for-new.html
-#      https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
-#      https://tools.ietf.org/html/draft-west-cookie-incrementalism-00
-
+# Set the value of the samesite attribute of the session cookie:
+# See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 # Notes about the $CookieSameSite options:
-# The "None" setting should only be used with HTTPS and when $CookieSecure = 1; is set below. The "None" setting is
-# also less secure and can allow certain types of cross-site attacks.
-# The "Strict" setting can break the links in the system generated feedback emails when read in a web mail client.
-# Due to those factors, the "Lax" setting is probably the optimal choice for typical WeBWorK servers.
-
+# The CookieLifeTime setting determines how long the browser should retain the
+# cookie. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie.
+# The CookieLifeTime value should be numeric and in seconds, or should be set to
+# "session", in which case the cookie will expire when the browser session ends
+# (a "session cookie"). Note that a value of 0 also means the cookie will expire
+# when the browser session ends. The default value is 7 days.
 #$CookieSameSite = "None";
 #$CookieSameSite = "Strict";
 #$CookieSameSite = "Lax";
 
-# Set the value of the secure cookie attribute:
-# Default is 0 here, as 1 will not work without https
+# Set the value of the secure cookie attribute.
+# The default is 0, as 1 will not work without https.
 #$CookieSecure = 1;
 
-# The CookieLifeTime setting determines how long the browser should retain the cookie.
-# See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie
-# The CookieLifeTime value should be numeric and in seconds, or should be set to "session", in which case
-# the Cookie will expire when the browser session ends (a "session cookie").
-# The default value is 7 days.
+# The CookieLifeTime setting determines how long the browser should retain the
+# cookie. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie.
+# The CookieLifeTime value should be numeric and in seconds, or should be set to
+# "session", in which case the cookie will expire when the browser session ends
+# (a "session cookie"). Note that a value of 0 also means the cookie will expire
+# when the browser session ends. The default value is 7 days.
 #$CookieLifeTime = 604800;
 #$CookieLifeTime = "session";
 

--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -1,4 +1,12 @@
 ---
+# Make sure to change this to your own secret.  Any long random string of
+# characters will work.  Note that you can add new secrets to this list, and it
+# is recommended that you do so once in a while. Only add to the beginning of
+# the list (and move the old secrets down).  The first secret is the only one
+# that will be used for signing new cookies, but the old secrets will be used
+# for validating signatures on existing cookies. Eventually the old secrets
+# should be removed (roughly after the length of time set for $CookieLifeTime in
+# localOverrides.conf or defaults.config).
 secrets:
   - 607280d0b2c621220b554a1c6ed123aa1a96f2de
 

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -21,23 +21,23 @@ WeBWorK::Authen - Check user identity, manage session keys.
 
 =head1 SYNOPSIS
 
- # get the name of the appropriate Authen class, based on the %authen hash in $ce
- my $class_name = WeBWorK::Authen::class($ce, "user_module");
+    # Get the name of the appropriate Authen class, based on the %authen hash in $ce.
+    my $class_name = WeBWorK::Authen::class($ce, "user_module");
 
- # load that class
- require $class_name;
+    # Load that class.
+    runtime_use $class_name;
 
- # create an authen object
- my $authen = $class_name->new($c);
+    # Create an authen object.
+    my $authen = $class_name->new($c);
 
- # verify credentials
- $authen->verify or die "Authentication failed";
+    # Verify credentials.
+    $authen->verify or die "Authentication failed";
 
- # verification status is stored for quick retrieval later
- my $auth_ok = $authen->was_verified;
+    # Verification status is stored for quick retrieval later.
+    my $auth_ok = $authen->was_verified;
 
- # for some reason, you might want to clear that cache
- $authen->forget_verification;
+    # For some reason, you might want to clear that cache.
+    $authen->forget_verification;
 
 =head1 DESCRIPTION
 
@@ -49,36 +49,41 @@ subclasses.
 
 use strict;
 use warnings;
-use version;
 
 use Date::Format;
-use Socket qw/unpack_sockaddr_in inet_ntoa/;    # for logging
-use Carp;
 use Scalar::Util qw(weaken);
-use Mojo::Util qw(url_escape url_unescape);
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw/writeCourseLog runtime_use/;
+use WeBWorK::Utils qw(x writeCourseLog runtime_use);
 use WeBWorK::Localize;
 use Caliper::Sensor;
 use Caliper::Entity;
 
-our $GENERIC_ERROR_MESSAGE = "";                # define in new
+use constant GENERIC_ERROR_MESSAGE => x('Invalid user ID or password.');
 
-################################################################################
-# Public API
-################################################################################
+=head1 CONSTRUCTOR
 
-=head1 FACTORY
+Instantiates a new WeBWorK::Authen object for the given WeBWorK::Controller C<$c>.
 
-=over
+=cut
 
-=item class($ce, $type)
+sub new {
+	my ($invocant, $c) = @_;
+	my $self = { c => $c };
+	weaken $self->{c};
+	return bless $self, ref($invocant) || $invocant;
+}
+
+=head1 METHODS
+
+=head2 class
+
+Usage: C<class($ce, $type)>
 
 This subroutine consults the given WeBWorK::CourseEnvironment object to
-determine which WeBWorK::Authen subclass should be used. $type can be any key
-given in the %authen hash in the course environment. If the type is not found in
-the %authen hash, an exception is thrown.
+determine which WeBWorK::Authen subclass should be used. C<$type> can be any key
+given in the C<%authen> hash in the course environment. If the type is not found in
+the C<%authen> hash, an exception is thrown.
 
 =cut
 
@@ -88,7 +93,6 @@ sub class {
 	if (exists $ce->{authen}{$type}) {
 		if (ref $ce->{authen}{$type} eq "ARRAY") {
 			my $authen_type = shift @{ $ce->{authen}{$type} };
-			#debug("ref of authen_type = |" . ref($authen_type) . "|");
 			if (ref($authen_type) eq "HASH") {
 				if (exists $authen_type->{ $ce->{dbLayoutName} }) {
 					return $authen_type->{ $ce->{dbLayoutName} };
@@ -124,148 +128,87 @@ sub call_next_authen_method {
 	my $ce   = $c->{ce};
 
 	my $user_authen_module = WeBWorK::Authen::class($ce, "user_module");
-	#debug("user_authen_module = |$user_authen_module|");
-	if (!defined($user_authen_module) or ($user_authen_module eq "")) {
+	if (!defined $user_authen_module || $user_authen_module eq '') {
 		$self->{error} = $c->maketext(
 			"No authentication method found for your request.  If this recurs, please speak with your instructor.");
 		$self->{log_error} .= "None of the specified authentication modules could handle the request.";
-		return (0);
+		return 0;
 	} else {
 		runtime_use $user_authen_module;
 		my $authen = $user_authen_module->new($c);
-		#debug("Using user_authen_module $user_authen_module: $authen\n");
 		$c->authen($authen);
-
 		return $authen->verify;
 	}
 }
 
-=back
-
-=cut
-
-=head1 CONSTRUCTOR
-
-=over
-
-=item new($c)
-
-Instantiates a new WeBWorK::Authen object for the given WeBWorK::Controller ($c).
-
-=cut
-
-sub new {
-	my ($invocant, $c) = @_;
-	my $class = ref($invocant) || $invocant;
-	my $self  = { c => $c, };
-	weaken $self->{c};
-	#initialize
-	$GENERIC_ERROR_MESSAGE = $c->maketext("Invalid user ID or password.");
-	bless $self, $class;
-	return $self;
-}
-
-=back
-
-=cut
-
-=head1 METHODS
-
-=over
-
-=cut
-
 sub request_has_data_for_this_verification_module {
-	#debug("Authen::request_has_data_for_this_verification_module will return a 1");
-	return (1);
+	return 1;
 }
 
 sub verify {
-	debug("BEGIN VERIFY");
 	my $self = shift;
 	my $c    = $self->{c};
 
-	if (!($self->request_has_data_for_this_verification_module)) {
-		return ($self->call_next_authen_method());
-	}
+	debug('BEGIN VERIFY');
 
-	my $result    = $self->do_verify;
-	my $error     = $self->{error};
-	my $log_error = $self->{log_error};
+	return $self->call_next_authen_method if !$self->request_has_data_for_this_verification_module;
 
-	$self->{was_verified} = $result ? 1 : 0;
+	$self->{was_verified} = $self->do_verify;
 
-	if ($self->can("site_fixup")) {
-		$self->site_fixup;
-	}
+	$self->site_fixup if $self->can('site_fixup');
 
-	if ($result) {
+	if ($self->{was_verified}) {
 		$self->write_log_entry("LOGIN OK") if $self->{initial_login};
 		$self->maybe_send_cookie;
 		$self->set_params;
 	} else {
-		if (defined $log_error) {
-			$self->write_log_entry("LOGIN FAILED $log_error");
-		}
+		$self->write_log_entry("LOGIN FAILED $self->{log_error}") if defined $self->{log_error};
 		$self->maybe_kill_cookie;
-		# if error message has a least one non-space character.
-		if (defined($error) and $error =~ /\S/) {
-			$c->stash(authen_error => $error);
-			# FIXME this is a hack to accomodate the webworkservice remixes
-		}
+		$c->stash(authen_error => $self->{error}) if $self->{error} && $self->{error} =~ /\S/;
 	}
 
-	my $caliper_sensor = Caliper::Sensor->new($self->{c}->ce);
-	if ($caliper_sensor->caliperEnabled() && $result && $self->{initial_login}) {
-		my $login_event = {
-			'type'    => 'SessionEvent',
-			'action'  => 'LoggedIn',
-			'profile' => 'SessionProfile',
-			'object'  => Caliper::Entity::webwork_app()
-		};
-		$caliper_sensor->sendEvents($self->{c}, [$login_event]);
+	my $caliper_sensor = Caliper::Sensor->new($c->ce);
+	if ($caliper_sensor->caliperEnabled && $self->{was_verified} && $self->{initial_login}) {
+		$caliper_sensor->sendEvents(
+			$c,
+			[ {
+				'type'    => 'SessionEvent',
+				'action'  => 'LoggedIn',
+				'profile' => 'SessionProfile',
+				'object'  => Caliper::Entity::webwork_app()
+			} ]
+		);
 	}
 
 	debug("END VERIFY");
-	debug("result $result");
-	return $result;
+	debug("result $self->{was_verified}");
+	return $self->{was_verified};
 }
 
-=item was_verified()
+=head2 was_verified
 
-Returns true if verify() returned true the last time it was called.
+Returns true if C<verify> returned true the last time it was called.
 
 =cut
 
 sub was_verified {
-	my ($self) = @_;
-
-	return 1 if exists $self->{was_verified} and $self->{was_verified};
-	return 0;
+	my $self = shift;
+	return $self->{was_verified};
 }
 
-=item forget_verification()
+=head2 forget_verification
 
-Future calls to was_verified() will return false, until verify() is called again and succeeds.
+Future calls to C<was_verified> will return false, until C<verify> is called again and succeeds.
 
 =cut
 
 sub forget_verification {
-	my ($self) = @_;
-	my $c      = $self->{c};
-	my $ce     = $c->ce;
-
+	my $self = shift;
 	$self->{was_verified} = 0;
-
+	return;
 }
 
-=back
-
-=cut
-
-################################################################################
 # Helper functions (called by verify)
-################################################################################
 
 sub do_verify {
 	my $self = shift;
@@ -274,27 +217,27 @@ sub do_verify {
 
 	return 0 unless $db;
 	debug("db ok");
+
 	return 0 unless $self->get_credentials;
 	debug("credentials ok");
+
 	return 0 unless $self->check_user;
 	debug("check user ok");
-	if (defined($self->{login_type}) && $self->{login_type} eq "guest") {
+
+	if (defined $self->{login_type} && $self->{login_type} eq 'guest') {
 		return $self->verify_practice_user;
 	} else {
 		return $self->verify_normal_user;
 	}
 }
 
-sub trim {    # used to trim leading and trailing white space from user_id and password
-			  # in get_credentials
+# Used to trim leading and trailing white space from user_id and password in get_credentials.
+sub trim {
 	my $s = shift;
-	# If the value was NOT defined, we want to leave it undefined, so
-	# we can still catch session-timeouts and report them properly.
-	# Thus we only do the following substitution if $s is defined.
-	# Otherwise return the undefined value so a non-defined password
-	# can be caught later by authenticate() for the case of a
-	# session-timeout.
-	$s =~ s/(^\s+|\s+$)//g if (defined($s));
+	# If the value was NOT defined, we want to leave it undefined, so we can still catch session-timeouts and report
+	# them properly.  Thus we only do the following substitution if $s is defined.  Otherwise return the undefined value
+	# so a non-defined password can be caught later by authenticate() for the case of a session-timeout.
+	$s =~ s/(^\s+|\s+$)//g if defined $s;
 	return $s;
 }
 
@@ -303,8 +246,10 @@ sub get_credentials {
 	my $c      = $self->{c};
 	my $ce     = $c->ce;
 	my $db     = $c->db;
-	debug("self is $self ");
-	# allow guest login: if the "Guest Login" button was clicked, we find an unused
+
+	debug("self is $self");
+
+	# Allow guest login: If the "Guest Login" button was clicked, we find an unused
 	# practice user and create a session for it.
 	if ($c->param("login_practice_user")) {
 		my @allowedGuestUserIDs =
@@ -313,15 +258,11 @@ sub get_credentials {
 			$db->getUsersWhere({ user_id => { like => "$ce->{practiceUserPrefix}\%" } });
 
 		for my $userID (List::Util::shuffle(@allowedGuestUserIDs)) {
-			if (not $self->unexpired_session_exists($userID)) {
-				my $newKey = $self->create_session($userID);
-				$self->{initial_login} = 1;
-
+			if (!$self->unexpired_session_exists($userID)) {
 				$self->{user_id}           = $userID;
-				$self->{session_key}       = $newKey;
 				$self->{login_type}        = "guest";
 				$self->{credential_source} = "none";
-				debug("guest user '", $userID . "' key '", $newKey . "'");
+				debug("guest user: $userID");
 				return 1;
 			}
 		}
@@ -333,24 +274,19 @@ sub get_credentials {
 
 	my ($cookieUser, $cookieKey, $cookieTimeStamp) = $self->fetchCookie;
 
-	if (defined $cookieUser and defined $c->param("user")) {
-		if ($cookieUser ne $c->param("user")) {
-			#croak ("cookieUser = $cookieUser and paramUser = ". $c->param("user") . " are different.");
-			$self->maybe_kill_cookie;    # use parameter "user" rather than cookie "user";
-		}
-		# Use session key for verification
-		# else   use cookieKey for verification
-		# else    use cookie user name but use password provided by request.
+	if (defined $cookieUser && defined $c->param('user')) {
+		$self->maybe_kill_cookie if $cookieUser ne $c->param('user');
+
+		# If the "key" parameter is defined, then use the session key for verification.  Next, use the cookie key for
+		# verification if that is defined.  Finally, use the cookie user name with the password provided by request.
 
 		if (defined $c->param("key")) {
-			$self->{user_id}           = $c->param("user");
+			$self->{user_id}           = trim($c->param("user"));
 			$self->{session_key}       = $c->param("key");
-			$self->{password}          = $c->param("passwd");
+			$self->{password}          = trim($c->param("passwd"));
 			$self->{login_type}        = "normal";
 			$self->{credential_source} = "params";
-			$self->{user_id}           = trim($self->{user_id});
-			$self->{password}          = trim($self->{password});
-			debug("params user '", $self->{user_id}, "' key '", $self->{session_key}, "'");
+			debug('credential source: "params", user: "', $self->{user_id}, '" key: "', $self->{session_key}, '"');
 			return 1;
 		} elsif (defined $cookieKey) {
 			$self->{user_id}           = $cookieUser;
@@ -358,44 +294,37 @@ sub get_credentials {
 			$self->{cookie_timestamp}  = $cookieTimeStamp;
 			$self->{login_type}        = "normal";
 			$self->{credential_source} = "cookie";
-			$self->{user_id}           = trim($self->{user_id});
 			debug(
-				"cookie user '",
-				$self->{user_id}, "' key '", $self->{session_key},
-				"' cookie_timestamp '",
-				$self->{cookieTimeStamp}, "' "
+				'credential source: "cookie", user: "',
+				$self->{user_id}, '", key: "', $self->{session_key},
+				'", timestamp: "',
+				$self->{cookie_timestamp}, '"'
 			);
 			return 1;
 		} else {
 			$self->{user_id}           = $cookieUser;
-			$self->{session_key}       = $cookieKey;                # will be undefined
-			$self->{password}          = $c->param("passwd");
+			$self->{session_key}       = $cookieKey;                  # will be undefined
+			$self->{password}          = trim($c->param("passwd"));
 			$self->{cookie_timestamp}  = $cookieTimeStamp;
 			$self->{login_type}        = "normal";
 			$self->{credential_source} = "params_and_cookie";
-			$self->{user_id}           = trim($self->{user_id});
-			$self->{password}          = trim($self->{password});
 			debug(
-				"params and cookie user '",
-				$self->{user_id}, "' params and cookie session key = '",
-				$self->{session_key},
-				"' cookie_timestamp '",
-				$self->{cookieTimeStamp}, "' "
+				'credential soure: "cookie (password from params)", user: "',
+				$self->{user_id}, '", key: "', $self->{session_key},
+				'", timestamp = "',
+				$self->{cookie_timestamp}, '"'
 			);
 			return 1;
 		}
 	}
-	# at least the user ID is available in request parameters
+
 	if (defined $c->param("user")) {
-		$self->{user_id}           = $c->param("user");
+		$self->{user_id}           = trim($c->param("user"));
 		$self->{session_key}       = $c->param("key");
-		$self->{password}          = $c->param("passwd");
+		$self->{password}          = trim($c->param("passwd"));
 		$self->{login_type}        = "normal";
 		$self->{credential_source} = "params";
-		$self->{user_id}           = trim($self->{user_id});
-		$self->{password}          = trim($self->{password});
-		debug("params user '",     $self->{user_id},  "' key '", $self->{session_key}, "'");
-		debug("params password '", $self->{password}, "' key '", $self->{session_key}, "'");
+		debug('credential source: "params", user: "', $self->{user_id}, '" key: "', $self->{session_key}, '"');
 		return 1;
 	}
 
@@ -405,27 +334,26 @@ sub get_credentials {
 		$self->{cookie_timestamp}  = $cookieTimeStamp;
 		$self->{login_type}        = "normal";
 		$self->{credential_source} = "cookie";
-		$self->{user_id}           = trim($self->{user_id});
 		debug(
-			"cookie user '",
-			$self->{user_id}, "' key '", $self->{session_key},
-			"' cookie_timestamp '",
-			$self->{cookieTimeStamp}, "' "
+			'credential source: "cookie", user: "',
+			$self->{user_id}, '", key: "', $self->{session_key},
+			'", timestamp: "',
+			$self->{cookie_timestamp}, '"'
 		);
 		return 1;
 	}
+
+	return 0;
 }
 
 sub check_user {
-	my $self  = shift;
-	my $c     = $self->{c};
-	my $ce    = $c->ce;
-	my $db    = $c->db;
-	my $authz = $c->authz;
+	my $self = shift;
+	my $c    = $self->{c};
+	my $db   = $c->db;
 
 	my $user_id = $self->{user_id};
 
-	if (defined $user_id and $user_id eq "") {
+	if (defined $user_id && $user_id eq '') {
 		$self->{log_error} = "no user id specified";
 		$self->{error} .= $c->maketext("You must specify a user ID.");
 		return 0;
@@ -435,11 +363,9 @@ sub check_user {
 
 	unless ($User) {
 		$self->{log_error} = "user unknown";
-		$self->{error}     = $GENERIC_ERROR_MESSAGE;
+		$self->{error}     = $c->maketext(GENERIC_ERROR_MESSAGE);
 		return 0;
 	}
-
-	# FIXME "fix invalid status values" used to be here, but it needs to move to $db->getUser
 
 	return 1;
 }
@@ -466,16 +392,9 @@ sub verify_practice_user {
 			}
 		} else {
 			if ($timestampValid) {
-				my $debugPracticeUser = $ce->{debugPracticeUser};
-				if (defined $debugPracticeUser and $user_id eq $debugPracticeUser) {
-					$self->{session_key}   = $self->create_session($user_id);
-					$self->{initial_login} = 1;
-					return 1;
-				} else {
-					$self->{log_error} = "guest account in use";
-					$self->{error}     = "That guest account is in use.";
-					return 0;
-				}
+				$self->{log_error} = "guest account in use";
+				$self->{error}     = "That guest account is in use.";
+				return 0;
 			} else {
 				$self->{session_key}   = $self->create_session($user_id);
 				$self->{initial_login} = 1;
@@ -499,24 +418,24 @@ sub verify_normal_user {
 	my ($sessionExists, $keyMatches, $timestampValid) = $self->check_session($user_id, $session_key, 1);
 	debug("sessionExists='", $sessionExists, "' keyMatches='", $keyMatches, "' timestampValid='", $timestampValid, "'");
 
-	if ($sessionExists and $keyMatches and $timestampValid) {
+	if ($sessionExists && $keyMatches && $timestampValid) {
 		return 1;
 	} else {
 		my $auth_result = $self->authenticate;
 
 		if ($auth_result > 0) {
-			# deny certain roles (dropped students, proctor roles)
+			# Deny certain roles (dropped students, proctor roles).
 			unless ($self->{login_type} =~ /^proctor/
 				|| $c->ce->status_abbrev_has_behavior($c->db->getUser($user_id)->status, "allow_course_access"))
 			{
 				$self->{log_error} = "user not allowed course access";
-				$self->{error}     = "This user is not allowed to log in to this course";
+				$self->{error}     = $c->maketext('This user is not allowed to log in to this course');
 				return 0;
 			}
-			# deny permission levels below "login" permission level
+			# Deny permission levels below "login" permission level.
 			unless ($c->authz->hasPermissions($user_id, "login")) {
 				$self->{log_error} = "user not permitted to login";
-				$self->{error}     = "This user is not allowed to log in to this course";
+				$self->{error}     = $c->maketext('This user is not allowed to log in to this course');
 				return 0;
 			}
 			$self->{session_key}   = $self->create_session($user_id);
@@ -524,10 +443,11 @@ sub verify_normal_user {
 			return 1;
 		} elsif ($auth_result == 0) {
 			$self->{log_error} = "authentication failed";
-			$self->{error}     = $GENERIC_ERROR_MESSAGE;
+			$self->{error}     = $c->maketext(GENERIC_ERROR_MESSAGE);
 			return 0;
-		} else {    # ($auth_result < 0) => required data was not present
-			if ($keyMatches and not $timestampValid) {
+		} else {
+			# Required data was not present.
+			if ($keyMatches && !$timestampValid) {
 				$self->{log_error} = "inactivity timeout";
 				$self->{error} .= $c->maketext("Your session has timed out due to inactivity. Please log in again.");
 			}
@@ -536,21 +456,11 @@ sub verify_normal_user {
 	}
 }
 
-#  1 == authentication succeeded
-#  0 == required data was present, but authentication failed
-# -1 == required data was not present (i.e. password missing)
+# Returns 1 if authentication succeeded, returns 0 if required data was present but authentication failed,
+# and returns -1 if the password is missing.
 sub authenticate {
 	my $self = shift;
-	my $c    = $self->{c};
-
-	my $user_id  = $self->{user_id};
-	my $password = $self->{password};
-
-	if (defined $password) {
-		return $self->checkPassword($user_id, $password);
-	} else {
-		return -1;
-	}
+	return defined $self->{password} ? $self->checkPassword($self->{user_id}, $self->{password}) : -1;
 }
 
 sub maybe_send_cookie {
@@ -562,24 +472,22 @@ sub maybe_send_cookie {
 
 	my ($cookie_user, $cookie_key, $cookie_timestamp, $setID) = $self->fetchCookie;
 
-	# we send a cookie if any of these conditions are met:
+	# Send a cookie if any of these conditions are met:
 
 	# (a) a cookie was used for authentication
-	my $used_cookie = ($self->{credential_source} eq "cookie");
+	my $used_cookie = $self->{credential_source} eq "cookie";
 
-	# (b) a cookie was sent but not used for authentication, and the
-	#     credentials used for authentication were the same as those in
-	#     the cookie
+	# (b) a cookie was sent but not used for authentication, and the credentials used for
+	# authentication were the same as those in the cookie
 	my $unused_valid_cookie =
-		($self->{credential_source} ne "cookie"
-			and defined $cookie_user
-			and $self->{user_id} eq $cookie_user
-			and defined $cookie_key
-			and $self->{session_key} eq $cookie_key);
+		$self->{credential_source} ne "cookie"
+		&& defined $cookie_user
+		&& $self->{user_id} eq $cookie_user
+		&& defined $cookie_key
+		&& $self->{session_key} eq $cookie_key;
 
 	# (c) the user asked to have a cookie sent and is not a guest user.
-	my $user_requests_cookie = ($self->{login_type} ne "guest" and ($c->param("send_cookie") // 0))
-		;    # prevent warning if "send_cookie" param is not defined.
+	my $user_requests_cookie = $self->{login_type} ne "guest" && ($c->param("send_cookie") // 0);
 
 	# (d) session management is done via cookies.
 	my $session_management_via_cookies = $ce->{session_management_via} eq "session_cookie";
@@ -592,63 +500,54 @@ sub maybe_send_cookie {
 		"'"
 	);
 
-	if ($used_cookie or $unused_valid_cookie or $user_requests_cookie or $session_management_via_cookies) {
-		#debug("Authen::maybe_send_cookie is sending a cookie");
+	if ($used_cookie || $unused_valid_cookie || $user_requests_cookie || $session_management_via_cookies) {
 		$self->sendCookie($self->{user_id}, $self->{session_key}, $setID);
 	} else {
 		$self->killCookie;
 	}
+
+	return;
 }
 
 sub maybe_kill_cookie {
 	my $self = shift;
-
 	return if $self->{c}{rpc};
-
-	$self->killCookie(@_);
+	$self->killCookie;
+	return;
 }
 
 sub set_params {
 	my $self = shift;
 	my $c    = $self->{c};
 
-	# A2 - params are not non-modifiable, with no explanation or workaround given in docs. WTF!
-	$c->param("user",   $self->{user_id});
-	$c->param("key",    $self->{session_key});
-	$c->param("passwd", "") unless $c->{rpc};
+	$c->param('user',   $self->{user_id});
+	$c->param('key',    $self->{session_key});
+	$c->param('passwd', '') unless $c->{rpc};
 
 	debug("params user='", $c->param("user"), "' key='", $c->param("key"), "'");
+
+	return;
 }
 
-################################################################################
 # Password management
-################################################################################
 
 sub checkPassword {
 	my ($self, $userID, $possibleClearPassword) = @_;
 	my $db = $self->{c}->db;
 
-	my $Password = $db->getPassword($userID);    # checked
+	my $Password = $db->getPassword($userID);
 	if (defined $Password) {
-		# check against WW password database
+		# Check against the password in the database.
 		my $possibleCryptPassword = crypt $possibleClearPassword, $Password->password;
 		my $dbPassword            = $Password->password;
-		# This next line explicitly insures that
-		# blank or null passwords from the database can never
-		# succeed in matching an entered password
-		# Use case: Moodle wwassignment stores null passwords and forces the creation
-		# of a key -- Moodle wwassignment does not use  passwords for authentication, only keys.
-		# The following line was modified to also reject cases when the database has a crypted password
-		# which matches a submitted all white-space or null password by requiring that the
-		# $possibleClearPassword contain some non-space character. This is intended to address
-		# the issue raised in http://webwork.maa.org/moodle/mod/forum/discuss.php?d=4529 .
-		# Since several authentication modules fall back to calling this function without
-		# trimming the possibleClearPassword as done during get_credentials() here in
-		# lib/WeBWorK/Authen.pm we do not assume that an all-white space password would have
-		# already been converted to an empty string and instead explicitly test it for a non-space
-		# character.
-		if (($possibleClearPassword =~ /\S/) && ($dbPassword =~ /\S/) && $possibleCryptPassword eq $Password->password)
-		{
+		# This next line explicitly insures that blank or null passwords from the database can never succeed in matching
+		# an entered password.  This also rejects cases when the database has a crypted password which matches a
+		# submitted all white-space or null password by requiring that the $possibleClearPassword contain some non-space
+		# character.  Since several authentication modules fall back to calling this function without trimming the
+		# possibleClearPassword as is done during get_credentials in this module, we do not assume that an all-white
+		# space password would have already been converted to an empty string and instead explicitly test it for a
+		# non-space character.
+		if ($possibleClearPassword =~ /\S/ && $dbPassword =~ /\S/ && $possibleCryptPassword eq $Password->password) {
 			$self->write_log_entry("AUTH WWDB: password accepted");
 			return 1;
 		} else {
@@ -690,7 +589,7 @@ sub checkPassword {
 # user's password in the course database if it succeeds:
 # 	sub site_checkPassword {
 # 		my ($self, $userID, $clearTextPassword) = @_;
-# 		my $realCryptPassword = (getpwnam $userID)[1] or return 0;
+# 		my $realCryptPassword = (getpwnam $userID)[1] || return 0;
 # 		my $possibleCryptPassword = crypt($possibleClearPassword, $realCryptPassword); # user real PW as salt
 # 		if ($possibleCryptPassword eq $realCryptPassword) {
 # 			# update WeBWorK password
@@ -706,138 +605,107 @@ sub checkPassword {
 # 		}
 # 	}
 
-################################################################################
 # Session key management
-################################################################################
 
 sub unexpired_session_exists {
 	my ($self, $userID) = @_;
-	my $ce = $self->{c}->ce;
-	my $db = $self->{c}->db;
-
-	my $Key = $db->getKey($userID);    # checked
-	return 0 unless defined $Key;
-	if (time <= $Key->timestamp() + $ce->{sessionKeyTimeout}) {
-		# unexpired, but leave timestamp alone
-		return 1;
-	} else {
-		# expired -- delete key
-		# NEW: no longer delete the key here -- a user re-visiting with a formerly-valid key should
-		# always get a "session expired" message. formerly, if they i.e. reload the login screen
-		# the message disappears, which is confusing (i claim ;)
-		#$db->deleteKey($userID);
-		return 0;
-	}
+	my $Key = $self->{c}->db->getKey($userID);
+	return defined $Key && time <= $Key->timestamp + $self->{c}->ce->{sessionKeyTimeout};
 }
 
-# clobbers any existing session for this $userID
-# if $newKey is not specified, a random key is generated
-# the key is returned
+# Clobbers any existing session for this $userID.
+# A random key is generated, and that key is returned.
 # When this is called in Proctor.pm, the actual user id is passed in via $trueUserID.
 # The $userID is modified in that case and will not work in the hasPermissions call.
 sub create_session {
-	my ($self, $userID, $newKey, $trueUserID) = @_;
+	my ($self, $userID, $trueUserID) = @_;
 	my $c  = $self->{c};
 	my $ce = $c->ce;
 	my $db = $c->db;
 
-	my $timestamp = time;
-	unless ($newKey) {
-		my @chars  = @{ $ce->{sessionKeyChars} };
-		my $length = $ce->{sessionKeyLength};
+	my @chars = @{ $ce->{sessionKeyChars} };
 
-		srand;
-		$newKey = join("", @chars[ map rand(@chars), 1 .. $length ]);
-	}
+	srand;
+	my $newKey = join('', @chars[ map rand(@chars), 1 .. $ce->{sessionKeyLength} ]);
 
 	my $setID = !$c->authz->hasPermissions($trueUserID // $userID, 'navigation_allowed') ? $c->stash('setID') : '';
 
-	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => $timestamp, set_id => $setID);
+	my $Key = $db->newKey(user_id => $userID, key => $newKey, timestamp => time, set_id => $setID);
 
 	# DBFIXME this should be a REPLACE
 	eval { $db->deleteKey($userID) };
 	eval { $db->addKey($Key) };
-	my $fail_to_addKey = 1 if $@;
-	if ($fail_to_addKey) {
-		warn "Difficulty adding key for userID $userID: $@ ";
-	}
-	if ($fail_to_addKey) {
+	if ($@) {
+		warn "Difficulty adding key for userID $userID: $@";
 		eval { $db->putKey($Key) };
 		warn "Couldn't put key for userid $userID either: $@" if $@;
 	}
 
-	#if ($ce -> {session_management_via} eq "session_cookie"),
-	#    then the subroutine maybe_send_cookie should send a cookie.
-
 	return $newKey;
 }
 
-# returns ($sessionExists, $keyMatches, $timestampValid)
-# if $updateTimestamp is true, the timestamp on a valid session is updated
+=head2 check_session
+
+Usage: C<< $authen->check_session($userID, $possibleKey, $updateTimestamp) >>
+
+This method returns 0 if no session is found for the given C<$useriD>.  If a
+session is found, then this method returns a list of three boolean values. The
+first will be 1 in this case and indicates the existence of the session, the
+second whether the given C<$possibleKey> matches the stored key, and the third
+whether the time stamp is valid.  If C<$updateTimestamp> is true, the session
+time stamp is updated.
+
+=cut
+
 sub check_session {
 	my ($self, $userID, $possibleKey, $updateTimestamp) = @_;
 	my $ce = $self->{c}->ce;
 	my $db = $self->{c}->db;
 
-	my $Key = $db->getKey($userID);    # checked
+	my $Key = $db->getKey($userID);
 	return 0 unless defined $Key;
 
-	my $keyMatches = (defined $possibleKey and $possibleKey eq $Key->key);
+	my $keyMatches = defined $possibleKey && $possibleKey eq $Key->key;
 
-	my $time_now = time();
+	my $timestampValid = time <= $Key->timestamp + $ce->{sessionKeyTimeout};
 
-	# Want key not be too old. Use timestamp from DB and
-	# sessionKeyTimeout to determine this even when using cookies
-	# as we do not trust the timestamp provided by a user's browser.
-	my $timestampValid = ($time_now <= $Key->timestamp() + $ce->{sessionKeyTimeout});
-
-	# first part of if clause is disabled for now until we figure out long term fix for using cookies
-	# safely (see pull request #576)   This means that the database key time is always being used
-	# even when in "session_cookie" mode
-	#	if ($ce -> {session_management_via} eq "session_cookie" and defined($self->{cookie_timestamp})) {
-	#		$timestampValid = (time <= $self -> {cookie_timestamp} + $ce->{sessionKeyTimeout});
-	#	} else {
-	if ($keyMatches and $timestampValid and $updateTimestamp) {
+	if ($keyMatches && $timestampValid && $updateTimestamp) {
 		$Key->timestamp(time);
 		$db->putKey($Key);
 	}
-	#	}
+
 	return (1, $keyMatches, $timestampValid);
 }
 
 sub killSession {
 	my $self = shift;
-
-	my $c  = $self->{c};
-	my $ce = $c->{ce};
-	my $db = $c->{db};
+	my $c    = $self->{c};
+	my $ce   = $c->{ce};
 
 	my $caliper_sensor = Caliper::Sensor->new($ce);
-	if ($caliper_sensor->caliperEnabled()) {
-		my $login_event = {
-			'type'    => 'SessionEvent',
-			'action'  => 'LoggedOut',
-			'profile' => 'SessionProfile',
-			'object'  => Caliper::Entity::webwork_app()
-		};
-		$caliper_sensor->sendEvents($self->{c}, [$login_event]);
+	if ($caliper_sensor->caliperEnabled) {
+		$caliper_sensor->sendEvents(
+			$c,
+			[ {
+				'type'    => 'SessionEvent',
+				'action'  => 'LoggedOut',
+				'profile' => 'SessionProfile',
+				'object'  => Caliper::Entity::webwork_app()
+			} ]
+		);
 	}
 
 	$self->forget_verification;
-	if ($ce->{session_management_via} eq "session_cookie") {
-		$self->killCookie();
-	}
+	$self->killCookie                     if $ce->{session_management_via} eq 'session_cookie';
+	$c->{db}->deleteKey($self->{user_id}) if defined $self->{user_id};
 
-	my $userID = $c->param("user");
-	if (defined($userID)) {
-		$db->deleteKey($userID);
-	}
+	return;
 }
 
-################################################################################
 # Cookie management
-################################################################################
 
+# Note that this does not really "fetch" the session cookie. It just gets
+# the user_id, key, timestamp, and set_id from the cookie.
 sub fetchCookie {
 	my $self = shift;
 	my $c    = $self->{c};
@@ -845,25 +713,22 @@ sub fetchCookie {
 
 	return if $c->{rpc};
 
-	my $cookie = $c->cookie('WeBWorKCourseAuthen.' . $c->stash('courseID'));
+	my $userID    = $c->session->{user_id};
+	my $key       = $c->session->{key};
+	my $timestamp = $c->session->{timestamp};
+	my $setID     = $c->session->{set_id};
 
-	if ($cookie) {
-		$cookie = url_unescape($cookie);
-		debug("cookie has this value: '", $cookie, "'");
-		my ($userID, $key, $timestamp, $setID) = split "\t", $cookie;
-		if (defined $userID and defined $key and $userID ne "" and $key ne "") {
-			debug("looks good, returning userID='$userID' key='$key'");
-			return ($userID, $key, $timestamp, $setID);
-		} else {
-			debug("malformed cookie. returning nothing.");
-			return;
-		}
+	if ($userID && $key) {
+		debug(qq{fetchCookie: Returning userID="$userID", key="$key", timestamp="}, $timestamp, '"');
+		return ($userID, $key, $timestamp, $setID);
 	} else {
-		debug("found no cookie for this course. returning nothing.");
+		debug('fetchCookie: Session cookie does not contain valid information. Returning nothing.');
 		return;
 	}
 }
 
+# Note that this does not actually "send" the cookie.  It merely sets the default session values in the cookie.
+# The session cookie is actually sent by Mojolicious when the response is rendered.
 sub sendCookie {
 	my ($self, $userID, $key, $setID) = @_;
 	my $c  = $self->{c};
@@ -875,61 +740,24 @@ sub sendCookie {
 
 	# This sets the setID in the cookie on initial login.
 	$setID = $c->stash('setID')
-		if !$setID
-		&& $c->authen->was_verified
-		&& !$c->authz->hasPermissions($userID, 'navigation_allowed');
+		if !$setID && $c->authen->was_verified && !$c->authz->hasPermissions($userID, 'navigation_allowed');
 
-	my $timestamp = time;
-
-	my $cookie_params = {
-		path     => $ce->{webworkURLRoot},
-		samesite => $ce->{CookieSameSite},
-		secure   => $ce->{CookieSecure}
-	};
-
-	# Set how long the browser should retain the cookie. Using max_age is now recommended,
-	# and overrides expires, but some very old browsers only support expires.
-	my $lifetime = $ce->{CookieLifeTime};
-	if ($lifetime ne 'session') {
-		$cookie_params->{expires} = $timestamp + $lifetime;
-		$cookie_params->{max_age} = $lifetime;
-	}
-	# When $lifetime eq 'session' the cookie will be a "session cookie" and expire when the browser session is closed.
-	# At present the CookieLifeTime setting only effects how long the browser is to told to retain the cookie.
-	# Ideally, when $ce->{session_management_via} eq "session_cookie", and if the timestamp in the cookie was
-	# secured again client-side tampering, the timestamp and lifetime could be used to provide ongoing session
-	# authentication.
-
-	# If the hostname is 'localhost' or '127.0.0.1', then the cookie domain must be omitted.
-	my $hostname = $c->req->url->to_abs->host;
-	$cookie_params->{domain} = $hostname if ($hostname ne 'localhost' && $hostname ne '127.0.0.1');
-
-	$c->cookie(
-		"WeBWorKCourseAuthen.$courseID" => url_escape("$userID\t$key\t$timestamp" . ($setID ? "\t$setID" : '')),
-		$cookie_params
+	$c->session(
+		user_id   => $userID,
+		key       => $key,
+		timestamp => time,
+		$setID ? (set_id => $setID) : (),
+		# Set how long the browser should retain the cookie.
+		expiration => $ce->{CookieLifeTime} eq 'session' ? 0 : $ce->{CookieLifeTime}
 	);
+
+	return;
 }
 
 sub killCookie {
 	my ($self) = @_;
-	my $c      = $self->{c};
-	my $ce     = $c->ce;
-
-	my $courseID = $c->stash('courseID') // '';
-
-	my $cookie_params = {
-		max_age  => 0,
-		expires  => 0,
-		path     => $ce->{webworkURLRoot},
-		samesite => $ce->{CookieSameSite},
-		secure   => $ce->{CookieSecure}
-	};
-
-	# If the hostname is 'localhost' or '127.0.0.1', then the cookie domain must be omitted.
-	my $hostname = $c->req->url->to_abs->host;
-	$cookie_params->{domain} = $hostname if ($hostname ne 'localhost' && $hostname ne '127.0.0.1');
-
-	$c->cookie("WeBWorKCourseAuthen.$courseID" => '', $cookie_params);
+	$self->{c}->session(expires => 1);
+	return;
 }
 
 # This method is only used for a user that does not have the navigation_allowed permission,
@@ -942,15 +770,11 @@ sub get_session_set_id {
 		my $Key = $self->{c}->db->getKey($self->{c}->param('user'));
 		return $Key->set_id;
 	} else {
-		my $setID;
-		(undef, undef, undef, $setID) = $self->fetchCookie;
-		return $setID;
+		return $self->{c}->session->{set_id};
 	}
 }
 
-################################################################################
 # Utilities
-################################################################################
 
 sub write_log_entry {
 	my ($self, $message) = @_;
@@ -968,6 +792,8 @@ sub write_log_entry {
 		. "host=$remote_host port=$remote_port UA=$user_agent";
 	debug("Writing to login log: '$log_msg'.\n");
 	writeCourseLog($c->ce, 'login_log', $log_msg);
+
+	return;
 }
 
 1;

--- a/lib/WeBWorK/Controller.pm
+++ b/lib/WeBWorK/Controller.pm
@@ -59,6 +59,28 @@ sub param ($c, $name = undef, $val = undef) {
 	return wantarray ? @{ $c->{paramcache}{$name} } : $c->{paramcache}{$name}[0];
 }
 
+# Override the Mojolicious::Controller session method to set the cookie parameters
+# from the course environment the first time it is called.
+sub session ($c, @args) {
+	# Initialize the cookie session the first time this is called.
+	unless ($c->stash->{'webwork2.cookie_session_initialized'}) {
+		$c->stash->{'webwork2.cookie_session_initialized'} = 1;
+
+		$c->app->sessions->cookie_name(
+			$c->stash('courseID') ? 'WeBWorKCourseSession.' . $c->stash('courseID') : 'WeBWorKGeneralSession');
+
+		# If the hostname is 'localhost' or '127.0.0.1', then the cookie domain must be omitted.
+		my $hostname = $c->req->url->to_abs->host;
+		$c->app->sessions->cookie_domain($hostname) if $hostname ne 'localhost' && $hostname ne '127.0.0.1';
+
+		$c->app->sessions->cookie_path($c->ce->{webworkURLRoot});
+		$c->app->sessions->samesite($c->ce->{CookieSameSite});
+		$c->app->sessions->secure($c->ce->{CookieSecure});
+	}
+
+	return $c->SUPER::session(@args);
+}
+
 =head1 METHODS
 
 =over


### PR DESCRIPTION
The primary advantage of this switch is that now cookies are signed. That means that unlike webwork2's current cookies, the data stored in the session cookies can be trusted to not have been tampered with. Note that setting the secrets in the `conf/webwork2.mojolicious.yml` file is now important (and not just something that we tell system administrators to do).  That secret is the private key that is used to sign cookies.

The documentation on session management in defaults.config and localOverrides.conf.dist has been updated.  Most of that was obsolete nonsense.

Note that the $debugPracticeUser has been removed.  As stated in the comments about it in defaults.config, "Why de we even have this?"