### PR TITLE
Delay file creation when a new file is created in the file manager.

### DIFF
--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -54,8 +54,8 @@
 			}
 		});
 
-		// If on the confirmation page, then focus the "name" input.
-		form.querySelector('input[name="name"]')?.focus();
+		// If on the confirmation page (and not the edit page), then focus the "name" input.
+		if (!form.getElementsByName('data')[0]) form.getElementsByName('name')[0]?.focus();
 	}
 
 	// The bits for types from least to most significant digit are set in the directoryListing method of

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -588,20 +588,11 @@ sub unpack_archive ($c, $archive) {
 	return $num_extracted == @members;
 }
 
-# Make a new file and edit it
+# Open the edit page with no contents. This does not actually create a file.
+# That is done when the user clicks save on the edit page.
 sub NewFile ($c) {
-	if ($c->param('confirmed')) {
-		my $name = $c->param('name');
-		if (my $file = $c->verifyName($name, 'file')) {
-			if (open(my $NEWFILE, '>:encoding(UTF-8)', $file)) {
-				close $NEWFILE;
-				return $c->RefreshEdit('', $name);
-			} else {
-				$c->addbadmessage($c->maketext(q{Can't create file: [_1]}, $!));
-			}
-		}
-	}
-
+	return $c->RefreshEdit('', $c->param('name'))
+		if $c->param('confirmed') && $c->verifyName($c->param('name'), 'file');
 	return $c->Confirm($c->maketext('New file name:'), '', $c->maketext('New File'));
 }
 

--- a/templates/ContentGenerator/Instructor/FileManager/refresh_edit.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh_edit.html.ep
@@ -12,10 +12,17 @@
 	</div>
 </div>
 <div class="row">
-	<div class="col-md-2 col-4 my-2"><%= submit_button maketext('Cancel'), %button %></div>
-	<div class="col-md-2 col-4 my-2"><%= submit_button maketext('Revert'), %button %></div>
-	<div class="col-md-2 col-4 my-2"><%= submit_button maketext('Save'), %button %></div>
-	<div class="col-md-6 col-12 my-2">
+	% my $canRevert = -f "$c->{courseRoot}/$c->{pwd}/$file";
+	<div class="col-md-2 <%= $canRevert ? 'col-4' : 'col-6' %> my-2">
+		<%= submit_button maketext('Cancel'), %button %>
+	</div>
+	% if ($canRevert) {
+		<div class="col-md-2 col-4 my-2"><%= submit_button maketext('Revert'), %button %></div>
+	% }
+	<div class="col-md-2 <%= $canRevert ? 'col-4' : 'col-6' %> my-2">
+		<%= submit_button maketext('Save'), %button %>
+	</div>
+	<div class="<%= $canRevert ? 'col-md-6' : 'col-md-8' %> col-12 my-2">
 		<div class="input-group">
 			<%= submit_button maketext('Save As'), name => 'action', class => 'btn btn-sm btn-secondary' =%>
 			<%= text_field name => '', size => 20, class => 'form-control form-control-sm' =%>


### PR DESCRIPTION
Instead of creating the file when the new file confirmation page is submitted, create the file when "Save" (or "Save As") is clicked from the edit page that opens next.

This was requested in issue #2326.

Also, don't focus the `name` input on the edit page.  That is a bit annoying.  Only focus that input on the confirmation page.  That is the only page that has a `data` input.