### PR TITLE
Separate the LTI 1.3 access token audience and URL.

### DIFF
--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -100,6 +100,7 @@ $LTI{v1p3}{ClientID}        = '';
 $LTI{v1p3}{DeploymentID}    = '';
 $LTI{v1p3}{PublicKeysetURL} = '';
 $LTI{v1p3}{AccessTokenURL}  = '';
+$LTI{v1p3}{AccessTokenAUD}  = '';
 $LTI{v1p3}{AuthReqURL}      = '';
 
 # In the process of LTI 1.3 authentication a request is sent to the LMS in response to its

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -202,9 +202,9 @@ sub get_credentials ($self) {
 	}
 
 	# Get the target_link_uri from the claims.
-	$c->stash->{LTILauncRedirect} = $claims->{'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'};
+	$c->stash->{LTILaunchRedirect} = $claims->{'https://purl.imsglobal.org/spec/lti/claim/target_link_uri'};
 
-	unless (defined $c->stash->{LTILauncRedirect}) {
+	unless (defined $c->stash->{LTILaunchRedirect}) {
 		$self->{error} = $c->maketext(
 			'There was an error during the login process.  Please speak to your instructor or system administrator.');
 		warn 'LTI is not properly configured (failed to obtain target_link_uri). '
@@ -215,7 +215,7 @@ sub get_credentials ($self) {
 
 	# Get the courseID from the target_link_uri and verify that it is the same as the one that was in the state.
 	my $location = $c->location;
-	my $target   = $c->url_for($c->stash->{LTILauncRedirect})->path;
+	my $target   = $c->url_for($c->stash->{LTILaunchRedirect})->path;
 	my $courseID;
 	$courseID = $1 if $target =~ m|$location/([^/]*)|;
 

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -138,7 +138,7 @@ async sub get_access_token ($self) {
 	my $jwt = eval {
 		encode_jwt(
 			payload => {
-				aud => $ce->{LTI}{v1p3}{AccessTokenURL},
+				aud => $ce->{LTI}{v1p3}{AccessTokenAUD},
 				iss => $c->url_for('root')->to_abs->to_string,
 				sub => $ce->{LTI}{v1p3}{ClientID},
 				jti => $private_key->{kid}

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -139,7 +139,7 @@ async sub get_access_token ($self) {
 		encode_jwt(
 			payload => {
 				aud => $ce->{LTI}{v1p3}{AccessTokenAUD},
-				iss => $c->url_for('root')->to_abs->to_string,
+				iss => $ce->{LTI}{v1p3}{ClientID},
 				sub => $ce->{LTI}{v1p3}{ClientID},
 				jti => $private_key->{kid}
 			},

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -24,7 +24,7 @@ sub login ($c) {
 }
 
 sub launch ($c) {
-	return $c->redirect_to($c->systemLink($c->url_for($c->stash->{LTILauncRedirect})));
+	return $c->redirect_to($c->systemLink($c->url_for($c->stash->{LTILaunchRedirect})));
 }
 
 sub keys ($c) {


### PR DESCRIPTION
This adds a new LTI 1.3 authentication parameter named `$LTI{v1p3}{AccessTokenAUD}`.  This is used for the audience (`aud`) in the signed JWT that is sent when requesting an access token from the LMS.  This access token is used for grade passback.

Previously the `$LTI{v1p3}{AccessTokenURL}` was used for both the audience and the actual URL that the access token request containing the signed JWT is sent to.  I suspect that the audience and the URL may not be the same for all LMS's.  They are the same for Moodle.  These also needed to be the same for testing on my local Canvas instance.  However, @Alex-Jordan showed me some information from D2L that indicates these are different there.  I suspect these may need to be different for Canvas in production as well.