### PR TITLE
Fix a warning that occurs for proctor authentication.

### DIFF
--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -175,9 +175,9 @@ sub set_params {
 # rewrite the userID to include both the proctor's and the student's user ID
 # and then call the default create_session method.
 sub create_session {
-	my ($self, $userID, $newKey) = @_;
+	my ($self, $userID) = @_;
 
-	return $self->SUPER::create_session($self->proctor_key_id($userID), $newKey, $userID);
+	return $self->SUPER::create_session($self->proctor_key_id($userID), $userID);
 }
 
 # rewrite the userID to include both the proctor's and the student's user ID


### PR DESCRIPTION
This is a stopgap measure since this is already fixed in #2334, but this was missed in #2333.  #2334 completely rewrites this module.

The `WeBWorK::Authen::create_session` method no longer accepts a prior database key object for its second argument, so the optional third argument (which is now the optional second argument) is in the wrong place for the `WeBWorK::Authen::Proctor` modules override of this method.