### PR TITLE
Remove user override check boxes when editing set details for a user.

### DIFF
--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -421,37 +421,6 @@
 	// Render all problems on page load if requested.
 	if (document.getElementById('auto_render')?.checked) renderAll();
 
-	// Make the override checkboxes for text type inputs checked or unchecked appropriately
-	// as determined by the value of the input when that value changes.
-	document
-		.querySelectorAll('input[type="text"][data-override],input[type="hidden"][data-override]')
-		.forEach((input) => {
-			const overrideCheck = document.getElementById(input.dataset.override);
-			if (!overrideCheck) return;
-			const changeHandler = () => (overrideCheck.checked = input.value != '');
-			input.addEventListener('change', changeHandler);
-			if (input.parentElement.classList.contains('flatpickr')) {
-				// Attach the keyup and blur handlers to the flatpickr alternate input.
-				input.previousElementSibling?.addEventListener('keyup', changeHandler);
-				input.previousElementSibling?.addEventListener('blur', () => {
-					if (input.previousElementSibling.value == '') overrideCheck.checked = false;
-				});
-			} else {
-				input.addEventListener('keyup', changeHandler);
-				input.addEventListener('blur', () => {
-					if (input.value == '') overrideCheck.checked = false;
-				});
-			}
-		});
-
-	// Make the override checkboxes for selects checked or unchecked appropriately
-	// as determined by the value of the select when that value changes.
-	document.querySelectorAll('select[data-override]').forEach((select) => {
-		const overrideCheck = document.getElementById(select.dataset.override);
-		if (!overrideCheck) return;
-		select.addEventListener('change', () => (overrideCheck.checked = select.value != ''));
-	});
-
 	// This changes the set header textbox text to the currently selected option in the select menu.
 	document.querySelectorAll('.combo-box').forEach((comboBox) => {
 		const comboBoxText = comboBox.querySelector('.combo-box-text');

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -105,7 +105,7 @@
 					'Edit set [_1] for this user.',
 					link_to(
 						$setID => $c->systemLink(
-							$setDetailPage, params => { effectiveUser => $user->user_id, editForUser => $user->user_id }
+							$setDetailPage, params => { editForUser => $user->user_id }
 						)
 					)
 				) =%>
@@ -348,16 +348,16 @@
 						<%= maketext('Hide All') =%>
 					</button>
 				</div>
-			% } else {
+			% } elsif (!$isGatewaySet || $editingSetVersion) {
 				<div class="input-group d-inline-flex flex-nowrap w-auto py-1 me-3">
 					<button id="randomize_seeds" type="button" class="btn btn-secondary">
 						<%= maketext('Randomize Seeds') =%>
 					</button>
-					<label class="form-check-label input-group-text ps-0">
-						<%= check_box excludeCorrect => 0,
-							id => 'excludeCorrect', class => 'form-check-input mx-2' =%>
-						<%= maketext('if status less than 1') =%>
-					</label>
+					<div class="input-group-text">
+						<%= check_box excludeCorrect => 0, id => 'excludeCorrect', class => 'form-check-input mt-0' =%>
+					</div>
+					<%= label_for excludeCorrect => maketext('if status less than 1'),
+						class => "form-check-label input-group-text mt-0" =%>
 				</div>
 			% }
 			% if (!@editForUser) {
@@ -395,14 +395,21 @@
 			% my @problemRows;
 			%
 			% for my $problemID (@$problemIDList) {
-				% my $problemRecord =
-					% @editForUser == 1
-					% ? $mergedProblems->{$problemID}
-					% : $globalProblems->{$problemID};
+				% # The version merge for the source file needs to be performed
+				% # with code since we don't have the merged problem version.
+				% my $sourceFile = @editForUser == 1
+					% ? (
+						% $userProblemVersions->{$problemID} && $userProblemVersions->{$problemID}->source_file
+						% ? $userProblemVersions->{$problemID}->source_file
+						% : (
+							% $userProblems->{$problemID} && $userProblems->{$problemID}->source_file
+							% ? $userProblems->{$problemID}->source_file : $globalProblems->{$problemID}->source_file
+						% )
+					% )
+					% : $globalProblems->{$problemID}->source_file;
 				%
 				% my $problemFile =
-					% ((param("problem.$problemID.source_file") || $problemRecord->source_file) =~ s|^/||r) =~
-					% s|\.\.||gr;
+					% ((param("problem.$problemID.source_file") || $sourceFile) =~ s|^/||r) =~ s|\.\.||gr;
 				%
 				% # Warn of repeat problems
 				% if (defined $shownYet{$problemFile}) {
@@ -439,7 +446,8 @@
 				%
 				% # When editing a set version, make sure to use the merged problem in the edit, as problem groups could
 				% # be in use for which the problem is generated and then stored in the problem version.
-				% my $problemToShow = $editingSetVersion ? $mergedProblems->{$problemID} : $userProblems->{$problemID};
+				% my $problemToShow =
+					% $editingSetVersion ? $userProblemVersions->{$problemID} : $userProblems->{$problemID};
 				%
 				% my @source_file_parts = $c->fieldHTML($userToShow, $setID, $problemID, $globalProblems->{$problemID},
 					% $problemToShow, 'source_file');
@@ -557,21 +565,11 @@
 									<% end =%>
 								% }
 							</div>
-							<div class="col-md-2 col-3 order-md-2 order-3">
-								% if (@editForUser) {
-									<div class="form-check form-check-inline col-form-label col-form-label-sm
-										text-nowrap">
-										<%= $source_file_parts[0] =%>
-										<%= $source_file_parts[1] =%>
-									</div>
-								% } else {
-									<div class="col-auto col-form-label col-form-label-sm text-nowrap">
-										<%= $source_file_parts[0] =%>
-									</div>
-								% }
+							<div class="col-md-2 col-3 col-form-label col-form-label-sm order-md-2 order-3 text-nowrap">
+								<%= $source_file_parts[0] =%>
 							</div>
 							<div class="<%= @editForUser ? 'col-md-6' : 'col-md-5' %> col-9 order-md-3 order-4">
-								<%= $source_file_parts[ @editForUser ? 3 : 2 ] =%>
+								<%= $source_file_parts[2] =%>
 								<%= hidden_field "problem_${problemID}_default_source_file" =>
 									$globalProblems->{$problemID}->source_file,
 									id => "problem_${problemID}_default_source_file" =%>
@@ -579,7 +577,7 @@
 							% if (!@editForUser) {
 								<div class="accordion col-md-1 col-2 d-flex align-items-center justify-content-end
 									order-md-last order-2">
-									<button href="#" class="accordion-button pdr_detail_collapse ps-0 w-auto"
+									<button class="accordion-button pdr_detail_collapse ps-0 w-auto"
 										type="button" aria-expanded="true" aria-controls="pdr_details_<%= $problemID %>"
 										aria-label="<%= maketext('Collapse Problem Details') %>"
 										data-bs-toggle="collapse" data-bs-target="#pdr_details_<%= $problemID %>"
@@ -594,35 +592,37 @@
 								<div class="col-md-6 d-flex flex-row order-md-first order-last">
 									% if (!@editForUser) {
 										<div class="form-check form-check-inline form-control-sm">
-											<label class="form-check-label">
-												<%= check_box deleteProblem => $problemID,
-													class => 'form-check-input' =%>
-												<%= maketext('Delete it?') =%>
-											</label>
+											<%= check_box deleteProblem => $problemID, id =>
+												"delete-problem-$problemID", class => 'form-check-input' =%>
+											<%= label_for "delete-problem-$problemID" => maketext('Delete it?'),
+												class => 'form-check-label' =%>
 										</div>
 									% }
 									% if (@editForUser != 1) {
 										<div class="form-check form-check-inline form-control-sm">
-											<label class="form-check-label">
-												<%= check_box markCorrect => $problemID,
-													id    => "problem.${problemID}.mark_correct",
-													class => 'form-check-input' =%>
-												<%= maketext('Mark Correct?') =%>
-											</label>
+											<%= check_box markCorrect => $problemID,
+												id    => "problem.${problemID}.mark_correct",
+												class => 'form-check-input' =%>
+											<%= label_for "problem.${problemID}.mark_correct" =>
+													maketext('Mark Correct?'),
+												class => 'form-check-label' =%>
 										</div>
 									% }
 								</div>
 								% if (@editForUser) {
-									<div class="col-md-6 offset-md-0 col-9 offset-3 font-sm order-md-last order-first">
-										<%= $source_file_parts[4] =%>
+									<div class="<%= @editForUser ? 'col-md-6' : 'col-md-5'
+										%> offset-md-0 col-9 offset-3 font-sm order-md-last order-first">
+										<%= $source_file_parts[3] =%>
 									</div>
 								% }
 							</div>
 							<div class="row">
 								<div class="col-md-5">
 									<%= $c->fieldTable(
-										$userToShow,                   $setID,         $problemID,
-										$globalProblems->{$problemID}, $problemToShow, $setRecord->assignment_type
+										$userToShow, $setID, $problemID,
+										$globalProblems->{$problemID},
+										$problemToShow,
+										$setRecord->assignment_type
 									) =%>
 								</div>
 								<div class="font-sm col-md-7">

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail/attempts_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail/attempts_row.html.ep
@@ -1,11 +1,10 @@
 <tr>
-	<td></td>
 	<td><%= label_for "problem.$problemID.attempts.id" => maketext('Attempts') =%></td>
 	<td></td>
 	<td>
 		<%= text_field "problem.$problemID.attempts",
 			($problemRecord->num_correct || 0) + ($problemRecord->num_incorrect || 0),
-			id => "problem.$problemID.attempts.id", class => 'form-control form-control-sm',
+			id => "problem.$problemID.attempts.id", class => 'form-control-plaintext form-control-sm',
 			readonly => undef, size => 5 =%>
 	</td>
 	<td></td>

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail/ip_locations_row.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail/ip_locations_row.html.ep
@@ -1,24 +1,18 @@
 <tr class="align-top">
-	% if ($forUsers) {
-		<td>
-			<%= check_box "set.$setID.selected_ip_locations.override",
-				id => "set.$setID.selected_ip_locations.override_id", class => 'form-check-input',
-				$ipOverride ? (checked => undef) : () =%>
-		</td>
-	% }
 	<td>
-		<%= label_for $forUsers ? "set.$setID.selected_ip_locations.override_id"
-			: "set.$setID.selected_ip_locations_id" => maketext('Restrict Locations'),
-			$forUsers ? (id => "set.$setID.selected_ip_locations.label", class => 'form-check-label')
-			: (class => 'form-label') =%>
+		<%= label_for "set.$setID.selected_ip_locations_id" => maketext('Restrict Locations'),
+			$forUsers
+				? (id => "set.$setID.selected_ip_locations.label", class => 'form-check-label')
+				: (class => 'form-label') =%>
 	</td>
 	<td></td>
 	<td>
-		<%= select_field "set.$setID.selected_ip_locations" =>
-			[ map { [ $_ => $_, $defaultLocations->{$_} ? (selected => undef) : () ] } @$locations ],
+		<%= select_field "set.$setID.selected_ip_locations" => [
+				$forUsers ? [ maketext('Set Default') => '', %$defaultLocations ? () : (selected => undef) ] : (),
+				map { [ $_ => $_, $defaultLocations->{$_} ? (selected => undef) : () ] } @$locations
+			],
 			id => "set.$setID.selected_ip_locations_id", size => 5, multiple => undef,
-			class => 'form-select form-select-sm',
-			$forUsers ? ('aria-labelledby' => "set.$setID.selected_ip_locations.label") : () =%>
+			class => 'form-select form-select-sm' =%>
 	</td>
 	% if ($forUsers) {
 		<td>

--- a/templates/HelpFiles/InstructorProblemSetDetail.html.ep
+++ b/templates/HelpFiles/InstructorProblemSetDetail.html.ep
@@ -37,11 +37,9 @@
 	<dt><%= maketext('Save Changes') %></dt>
 	<dd>
 		<%== maketext('This button is present both at top and the bottom of the page. Any and all changes made to any '
-			. 'part of the set will be saved with one important exception: When editing the set for one or more '
-			. 'students, you can choose to override the default value (defined for the set in general) by clicking on '
-			. 'the checkbox and providing a value (or possibly leaving blank) and checking the override checkbox. If '
-			. 'you do <strong>NOT</strong> check the checkbox, the override value will be discarded and the default '
-			. 'value for the set will be used for the users currently being edited.') =%>
+			. 'part of the set will be saved. When editing the set for one or more students, you can choose to '
+			. 'override the default value (defined for the set in general) by providing a value. If a value is not '
+			. 'provided then the default value for the set will be used for the users currently being edited.') =%>
 	</dd>
 
 	<dt><%= maketext('Reset Form') %></dt>


### PR DESCRIPTION
This builds on #2345, and makes the same sort of changes for this page.

The dates check on the problem set detail was synchronized with the check for the user detail page.  Most importantly, a test version's open, close, and answer dates can not be nullified. In fact, no set's open, close, and answer dates can be entirely nullified.  In other words, a global set must have the open, close, and answer dates set.
    
Note that the set values column was left at the end on this page (instead of before the user override values as it now is on the user detail page).  There are issues with moving that first on this page.  There are cases where there are no set values, but there are user values at all (for example, for the problem seed, problem status, and problem attempts). So moving set values first would leave an ugly gap between the label and the user value.
    
The 10 year limit on future set dates was removed as was done for the user detail page.
    
There were some check boxes (not override checks) that had the check box input inside the label instead of the input and label being siblings.  That is not correct for Bootstrap's expectations for the `form-check` class.  In particular, the check box and the label "if status is less than 1" (for the "Randomize Seeds" button) were not aligned correctly due to this.  So those issues were fixed.