### PR TITLE
Fix course listings in the admin course.

### DIFF
--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -50,10 +50,9 @@
 	% }
 	%
 	<h2><%= maketext('Courses') %></h2>
-	% my @courseIDs = listCourses($ce);
 	<ol>
 		% for (sort { lc($a) cmp lc($b) } listCourses($ce)) {
-			% next if $_ eq 'modelCourse';
+			% next if $_ eq $ce->{admin_course_id} || $_ eq 'modelCourse';
 			<li><%= link_to $_ => 'set_list' => { courseID => $_ } =%></li>
 		% }
 	</ol>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -107,7 +107,7 @@
 			. 'select the course and check which components to copy.') =%>
 	</div>
 	<div class="row mb-1">
-		% my @existingCourses = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
+		% my @existingCourses = sort { lc($a) cmp lc($b) } listCourses($ce);
 		% unshift(@existingCourses, sort { lc($a) cmp lc($b) } @{ $ce->{modelCoursesForCopy} });
 		%
 		<%= label_for copy_from_course => maketext('Copy Components From:'),


### PR DESCRIPTION
There are three lines of code changed.

Line 53 of `templates/ContentGenerator/CourseAdmin.html.ep` was deleted. That line should not exist.  That saves a list of all courses to the `@courseIDs` variable that is never used.  The `listCourses` method is called again on line 56 (now 55).

On line 56 (now 55) of that same file, the admin course is omitted from the listing.  This is how it used to be, and was removed in #2295.  I don't believe that the admin course should be listed on the admin course listings page.

On line 110 of `templates/ContentGenerator/CourseAdmin/add_course_form.html.ep` the admin course is kept in the listing.  This is the list of courses that can be copied.  This was how it was set up in #2295, but was reverted in #2290 (probably in merge resolution, or maybe my changes to that pull request?).  The intent was to allow the admin course to be copied to change to a new course to use for the admin course.

The first line changed is not controversial, but the second two are up for discussion.