### PR TITLE
let instructor's change course title

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -862,6 +862,10 @@ $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 	download_hardcopy_format_pdf => "guest",
 	download_hardcopy_format_tex => "ta",
 	download_hardcopy_change_theme=> "ta",
+
+	##### Permission to edit a row from the setting table #####
+	##### must have form setting_table_[key]              #####
+	setting_table_courseTitle      => "professor",
 );
 
 # This is the default permission level given to new students and students with

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1405,6 +1405,11 @@ include("conf/localOverrides.conf");
 #  'checkboxlist' for variables that hold a list of values which can be independently picked yes/no as checkboxes,
 #  'popuplist' for variables that hold a list of values to be selected from.
 
+# var key indicates this is a course environment variable
+# setting key indicates this is a setting from the course's setting table in the database
+#   and in this case, only text type is presently supported since there are not presently
+#   other types of data in the setting table that could conceivably be up for manual reassignment
+
 # Localization Info:  The doc strings in this portion are reproduced in
 # lib/WeBWorK/Localize.pm solely so that xgettext.pl will
 # include them when creating .pot files.
@@ -1418,6 +1423,11 @@ sub x { return @_; }
 $ConfigValues = [
 	[
 		x('General'),
+		{
+			setting => 'courseTitle',
+			doc     => 'Title for course displayed on the Assignments page',
+			type    => 'text'
+		},
 		{
 			var  => 'courseFiles{course_info}',
 			doc  => x('Name of course information file'),

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -144,6 +144,7 @@ sub getConfigValues ($c, $ce) {
 		my $item = shift;
 		if (
 			ref($item) =~ /HASH/
+			&& defined $item->{var}
 			&& ($item->{var} =~
 				/^(defaultTheme|hardcopyThemesSite|hardcopyThemes|hardcopyTheme|hardcopyThemePGEditor)$/)
 			)
@@ -156,7 +157,7 @@ sub getConfigValues ($c, $ce) {
 	};
 	my $modifyLanguages = sub {
 		my $item = shift;
-		if (ref($item) =~ /HASH/ and $item->{var} eq 'language') {
+		if (ref($item) =~ /HASH/ && defined $item->{var} && $item->{var} eq 'language') {
 			$item->{values} = $languages;
 		}
 	};
@@ -220,7 +221,12 @@ sub pre_header_initialize ($c) {
 					$fileoutput .= $conobject->save_string($con->get_value($ce3), 1);
 				} else {
 					# We reached the tab with entry objects
-					$fileoutput .= $conobject->save_string($con->get_value($ce3));
+					if (defined $conobject->{var}) {
+						$fileoutput .= $conobject->save_string($con->get_value($ce3));
+					} else {
+						# this was something to set in the course's setting table
+						$c->db->setSettingValue($conobject->{setting}, $c->{paramcache}{ $conobject->{setting} }[0]);
+					}
 				}
 			}
 			$tab--;

--- a/templates/ContentGenerator/Instructor/Config.html.ep
+++ b/templates/ContentGenerator/Instructor/Config.html.ep
@@ -39,6 +39,10 @@
 				</tr>
 				% for my $con (@configSectionArray) {
 					% my $conobject = $c->objectify($con);
+					% next unless (
+						% defined $conobject->{var}
+						% || $authz->hasPermissions(param('user'), "setting_table_$conobject->{setting}")
+					% );
 					% my $name      = defined $conobject->{var}
 							% ? ($conobject->{var} =~ s/[{]/-/gr) =~ s/[}]//gr
 							% : $conobject->{setting};

--- a/templates/ContentGenerator/Instructor/Config.html.ep
+++ b/templates/ContentGenerator/Instructor/Config.html.ep
@@ -39,11 +39,15 @@
 				</tr>
 				% for my $con (@configSectionArray) {
 					% my $conobject = $c->objectify($con);
-					% my $name      = ($conobject->{var} =~ s/[{]/-/gr) =~ s/[}]//gr;
+					% my $name      = defined $conobject->{var}
+							% ? ($conobject->{var} =~ s/[{]/-/gr) =~ s/[}]//gr
+							% : $conobject->{setting};
 					<tr>
 						<td><%= $conobject->what_string %></td>
 						<td class="text-center">
-							<%= $conobject->display_value($con->get_value($c->{default_ce})) %>
+							% if (defined $conobject->{var}) {
+								<%= $conobject->display_value($con->get_value($c->{default_ce})) %>
+							% }
 						</td>
 						<td><%= $conobject->entry_widget($con->get_value($ce4)) =%></td>
 					</tr>

--- a/templates/ContentGenerator/Instructor/Config/config_help.html.ep
+++ b/templates/ContentGenerator/Instructor/Config/config_help.html.ep
@@ -17,12 +17,22 @@
 					<div class="modal-content">
 						<div class="modal-header">
 							<h1 class="modal-title fs-4" id="<%= "$configObject->{name}_help_title" %>">
-								<%= maketext('Variable Documentation') %>
+								% if (defined $configObject->{var}) {
+									<%= maketext('Variable Documentation') %>
+								% } else {
+									<%= maketext('Setting Documentation') %>
+								% }
 							</h1>
 							<button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
 						</div>
 						<div class="modal-body">
-							<h2 class="fs-4"><code>$<%= $configObject->{var} %></code></h2>
+							<h2 class="fs-4"><code>
+								% if (defined $configObject->{var}) {
+									$<%= $configObject->{var} %>
+								% } else {
+									<%= $configObject->{setting} %> setting
+								% }
+							</code></h2>
 							<div><%== $configObject->{doc2} || $configObject->{doc} %></div>
 						</div>
 					</div>


### PR DESCRIPTION
This makes some changes to the Course Config module so that in addition to course environment variables, settings from the course's `_setting` table in the database can be set. Then it applies this possibility to the course title.

The upshot is an instructor can visit Course Config and change the course title on their own now. Previously the only way to update the course title is to have the WW admin use the admin course to do that (or otherwise do it from the command line).