### PR TITLE
Fix the Job Manager for the admin course.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -59,8 +59,9 @@ use constant SORT_SUBS => {
 sub initialize ($c) {
 	$c->stash->{taskNames}   = TASK_NAMES();
 	$c->stash->{actionForms} = ACTION_FORMS();
-	$c->stash->{fields} = $c->stash->{courseID} eq 'admin' ? FIELDS() : [ grep { $_ ne 'courseID' } @{ FIELDS() } ];
-	$c->stash->{jobs}   = {};
+	$c->stash->{fields} =
+		$c->stash->{courseID} eq $c->ce->{admin_course_id} ? FIELDS() : [ grep { $_ ne 'courseID' } @{ FIELDS() } ];
+	$c->stash->{jobs}               = {};
 	$c->stash->{visibleJobs}        = {};
 	$c->stash->{selectedJobs}       = {};
 	$c->stash->{sortedJobs}         = [];
@@ -91,7 +92,7 @@ sub initialize ($c) {
 		$job->{courseID} = $job->{notes}{courseID};
 
 		$c->stash->{jobs}{ $job->{id} } = $job
-			if $c->stash->{courseID} eq 'admin' || $job->{courseID} eq $c->stash->{courseID};
+			if $c->stash->{courseID} eq $c->ce->{admin_course_id} || $job->{courseID} eq $c->stash->{courseID};
 	}
 
 	if (defined $c->param('visible_jobs')) {

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -94,7 +94,7 @@
 							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'id' =%>
 						</div>
 					</th>
-					% if ($courseID eq 'admin') {
+					% if ($courseID eq $ce->{admin_course_id}) {
 						<th>
 							<div class="d-flex justify-content-between align-items-end gap-1">
 								<%= link_to maketext('Course Id') => '#', class => 'sort-header',
@@ -155,7 +155,7 @@
 							</td>
 							<td><%= label_for "job_${jobID}_checkbox" => $jobID =%></td>
 						% }
-						% if ($courseID eq 'admin') {
+						% if ($courseID eq $ce->{admin_course_id}) {
 							<td class="text-nowrap"><%= $jobs->{$jobID}{courseID} =~ s/_/ /gr =%></td>
 						% }
 						<td class="text-nowrap">

--- a/templates/ContentGenerator/Instructor/JobManager/filter_form.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager/filter_form.html.ep
@@ -18,7 +18,7 @@
 			<div class="col-auto">
 				<%= select_field 'action.filter.field' => [
 						[ maketext('Id')    => 'id', selected => undef ],
-						$courseID eq 'admin' ? [ maketext('Course Id')    => 'courseID' ] : (),
+						$courseID eq $ce->{admin_course_id} ? [ maketext('Course Id')    => 'courseID' ] : (),
 						[ maketext('Task')  => 'task' ],
 						[ maketext('State') => 'state' ]
 					],


### PR DESCRIPTION
When the admin course ID was made customizable, this page was not updated for that change.