### PR TITLE
accessibility updates to student orientation

### DIFF
--- a/assets/pg/Student_Orientation/feedback.pg
+++ b/assets/pg/Student_Orientation/feedback.pg
@@ -27,24 +27,33 @@ When you Submit an answer, a feedback button appears near the answer blank.
 
 * If you answer correctly, you see a green checkmark[@
     MODES(
-        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-success" disabled><i class="correct"></i></button>',
+        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-success" disabled aria-label="Correct">'
+		. '<i class="correct"></i>'
+		. '</button>',
         TeX => ''
     )@]*.
 * If you answer incorrectly, you see a red alert[@
     MODES(
-        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-danger" disabled><i class="incorrect"></i></button>',
+        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-danger" disabled aria-label="Incorrect">'
+		. '<i class="incorrect"></i>'
+		. '</button>',
         TeX => ''
     )@]*.
 * If you earn partial credit, you see a yellow warning[@
     MODES(
-        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-warning" disabled><i class="partially-correct"></i></button>',
+        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-warning" disabled aria-label="Partially Correct">'
+		. '<i class="partially-correct"></i>'
+		. '</button>',
         TeX => ''
     )@]*.
 
 Each of these buttons is something you can click to see more information about the answer you tried. And if there is an
 actual feedback message, you will see a small circle in the upper right corner of the button[@
     MODES(
-        HTML => ', like <button class="ww-feedback-btn btn btn-sm btn-danger with-message" disabled><i class="incorrect"></i></button>',
+        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-danger with-message" '
+		. 'disabled aria-label="Incorrect with message">'
+		. '<i class="incorrect"></i>'
+		. '</button>',
         TeX => ''
     )@]*.
 
@@ -53,7 +62,8 @@ feedback message will tell you the correct answer. What number am I thinking of?
 
 If you type an answer and click to "Preview my Answers", you will see an info button[@
     MODES(
-        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-info" disabled><i/></button>',
+        HTML => ': <button class="ww-feedback-btn btn btn-sm btn-info" disabled aria-label="Answer Preview"><i/>'
+		. '</button>',
         TeX => ''
     )
 @]* instead of the correct/incorrect buttons.

--- a/assets/pg/Student_Orientation/hardcopy.pg
+++ b/assets/pg/Student_Orientation/hardcopy.pg
@@ -24,7 +24,8 @@ From the *Assignments* page (which you may or may not have permission to viist),
 "Download Hardcopy for Current Set" button.
 
 This file is something that you can read onscreen while you are offline. You can even print it off and take it to a
-tutoring center or somewhere comfortable to work on.
+tutoring center or somewhere comfortable to work on. If you would like a Braille file for the assignment, that may be
+possible with some assistance from your institutional staff.
 
 To check that you understand how this works, download the PDF version of this Orientation assignment. At the end of
 this problem in the PDF, you will find the answer that is expected here: [_]{Compute("$a")}{4}


### PR DESCRIPTION
Changes here make the disabled buttons in the student orientation sound more like the actual buttons an AT user will run into while using WeBWorK. This is perhaps pending https://github.com/openwebwork/pg/pull/1039, in case the text "Preview Information" changes.

This also adds an alert to users that a Braille hardcopy might be available upon request from institutional staff. They can usually work with .tex source to make that. (In the future, we could make a PTX hardcopy file and use PTX Braille production to automate Braille hardcopy production. I don't think PTX Braille production is ready yet in the PTX command line tool, so it's too early to try that yet.)