### PR TITLE
student login activity graph

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -412,6 +412,11 @@ $mail{feedbackRecipients}    = [
 # following line.  The R server needs to be installed and running in order for
 # this to work.  See http://webwork.maa.org/wiki/R_in_WeBWorK for more info.
 
+# For student activity graphs to work, you must also install the following R
+# packages: ggplot2, svglite, fasttime. If the R server is local, run R as root
+# and execute:
+# install.packages(c('ggplot2', 'svglite', 'fasttime'))
+
 #$pg{specialPGEnvironmentVars}{Rserve} = {host => "localhost"};
 
 # use this setting when running Rserve in a docker container.

--- a/lib/WeBWorK/ContentGenerator/Activity.pm
+++ b/lib/WeBWorK/ContentGenerator/Activity.pm
@@ -1,0 +1,73 @@
+################################################################################
+# WeBWorK Online Homework Delivery System
+# Copyright &copy; 2000-2023 The WeBWorK Project, https://github.com/openwebwork
+#
+# This program is free software; you can redistribute it and/or modify it under
+# the terms of either: (a) the GNU General Public License as published by the
+# Free Software Foundation; either version 2, or (at your option) any later
+# version, or (b) the "Artistic License" which comes with this package.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+# Artistic License for more details.
+################################################################################
+
+package WeBWorK::ContentGenerator::Activity;
+use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
+
+=head1 NAME
+
+WeBWorK::ContentGenerator::Activity - Display activity (logins, answer submissions) over time by user.
+
+=cut
+
+use Mojo::File;
+use Statistics::R::IO;
+
+sub displayStudentActivity ($c, $studentID) {
+	my $ce = $c->ce;
+
+	my $login_log = Mojo::File::path($ce->{courseFiles}{logs}{login_log})->slurp('UTF-8');
+	# we just want the "LOGIN OK" lines
+	my @login_ok = grep {/^.* LOGIN OK .*$/} split("\n", $login_log);
+	# now convert lines to a suitable format for data analysis
+	for (@login_ok) {
+		$_ = [ $_ =~ /^\[(.*?)\] LOGIN OK user_id=(\S*) .* credential_source=(\S*) .*UA=(.*)$/g ];
+		$_ = join('|', @{$_});
+	}
+	my $logins_table_string = join('|', @login_ok);
+
+	my $query = join(
+		"\n",
+		'library(ggplot2)',
+		'library(svglite)',
+		'library(fasttime)',
+		"table_string <- '$logins_table_string'",
+		'setClass("myDate")',
+		'setAs("character", "myDate", function(from) as.POSIXct(from, format="%a %b %d %H:%M:%S %Y"))',
+		'logins <- read.table(text=table_string, sep = "|", '
+			. ' col.names=c("date", "user", "credential", "UA"), colClasses=c("myDate", "factor", "factor", "character"))',
+		'our_logins <- logins[logins$user=="' . $c->{studentID} . '",]',
+		's <- svgstring(width = 10, height = 2)',
+		'plot(ggplot(our_logins, aes(x=date, y=0)) '
+			. '+ggtitle("Logins (see logs folder in File Manager for more detail)") '
+			. '+theme(aspect.ratio=1/8) '
+			. '+geom_hline(yintercept=0, color = "black", size=0.3) '
+			. '+geom_point(aes(y=0), size=3) '
+			. '+theme(axis.line.y=element_blank(), axis.text.y=element_blank(), axis.title.y=element_blank(), '
+			. 'axis.ticks.y=element_blank(), legend.position = "bottom") '
+			. ')',
+		's()',
+
+	);
+
+	my $rserve = Rserve::access(server => $ce->{pg}{specialPGEnvironmentVars}{Rserve}{host}, _usesocket => 1);
+	my $result = Rserve::try_eval($rserve, $query);
+	$rserve->close();
+	$result =~ s/^\s*character\(|\)\s*$//g;
+	return ($result);
+
+}
+
+1;

--- a/templates/ContentGenerator/Instructor/Stats/student_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/student_stats.html.ep
@@ -2,6 +2,7 @@
 % # WeBWorK::ContentGenerator::Instructor::StudentProgress.
 %
 % use WeBWorK::ContentGenerator::Grades;
+% use WeBWorK::ContentGenerator::Activity;
 %
 % my $studentRecord = $db->getUser($c->{studentID});
 % unless ($studentRecord) {
@@ -28,3 +29,8 @@
 		$c->systemLink(url_for('set_list'), params => { effectiveUser => $c->{studentID} }) =%>
 % }
 <%= WeBWorK::ContentGenerator::Grades::displayStudentStats($c, $c->{studentID}) =%>
+% if ($ce->{pg}{specialPGEnvironmentVars}{Rserve}{host}) {
+	<div class="activity-svg">
+		<%== WeBWorK::ContentGenerator::Activity::displayStudentActivity($c, $c->{studentID}) %>
+	</div>
+% }


### PR DESCRIPTION
This implements a chart of logins when viewing a user's statistics page, like so:

<img width="1163" alt="Screenshot 2024-03-19 at 1 51 37 PM" src="https://github.com/openwebwork/webwork2/assets/4732672/7fd937a9-9cf3-4082-9195-10803d489e1f">

This is meant to just get our feet wet with data visualization, and if this works out I hope it will grow to show things like:

- all of a student's attempts over time
- all attempts over time made on any one assignment

with appropriate enhancements, like was the attempt successful, which problem number, etc. But that's for the future.

This uses `R` to do the data crunching. So you have to have `$pg{specialPGEnvironmentVars}{Rserve}` set in `localOverrides.conf` (should that actually be a `site.conf` setting?) If you are not using `R`, no problem. If `$pg{specialPGEnvironmentVars}{Rserve}` is unset, this will be skipped over. Otherwise, the page will take a little longer to load while the data is crunched, and you will see a picture like the screenshot.

Also for this to work you need to install some `R` packages that you might not already have. You can run `R` as root, and then do `install.packages(c('ggplot2', 'svglite', 'fasttime'))` to get them. (To exit `R`, run `q()`.)

Before I went any further with learning enough `R` to do those other things I mentioned, I wanted to check in about the infrastructure. In particular this will be reading the log files, not accessing login records form the database (since we don't keep those). Does that raise any red flags? Later with answer submissions, I would probably use the course answer log too, unless there's a better way to access past answers from the database.