### PR TITLE
Fix the OPL-update script (or really the download-OPL-metadata-release.pl script)

### DIFF
--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -56,9 +56,12 @@ say 'Downloaded release archive, now extracting.';
 
 my $arch = Archive::Tar->new($releaseFile);
 die "An error occurred while creating the tar file: $releaseFile" unless $arch;
-$arch->setcwd($path);
-$arch->extract();
+$arch->setcwd($ce->{webworkDirs}{tmp});
+$arch->extract;
 die "There was an error extracting the metadata release: $arch->error" if $arch->error;
+
+die "The downloaded archive did not contain the expected files."
+	unless -e "$ce->{webworkDirs}{tmp}/webwork-open-problem-library";
 
 # Copy the json files into htdocs.
 for (glob("$ce->{webworkDirs}{tmp}/webwork-open-problem-library/JSON-SAVED/*.json")) {


### PR DESCRIPTION
The `download-OPL-metadata-release.pl` is extracting the downloaded metadata release to the wrong directory, and so the rest of the script fails.  It fails quietly, and doesn't actually restore any tables.  So a die statement was added to cover this case.