### PR TITLE
tweaks affecting problems rendered in an iframe with iFrameResizer

### DIFF
--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -28,7 +28,7 @@
 				send_pg_flags: 1,
 				extra_header_text:
 					'<style>' +
-					'html{overflow-y:auto;}body{padding:1px;background:#f5f5f5;}.container-fluid{padding:0px;}' +
+					'html{overflow-y:hidden;}body{padding:1px;background:#f5f5f5;}.container-fluid{padding:0px;}' +
 					'</style>',
 				...renderOptions
 			};
@@ -76,7 +76,15 @@
 							container.innerHTML = data.pg_flags.comment;
 							iframe.after(container);
 						}
-						iFrameResize({ checkOrigin: false, warningTimeout: 20000, scrolling: 'omit' }, iframe);
+						iFrameResize(
+							{
+								checkOrigin: false,
+								warningTimeout: 20000,
+								scrolling: 'omit',
+								heightCalculationMethod: 'taggedElement'
+							},
+							iframe
+						);
 						iframe.addEventListener('load', () => resolve());
 					}
 					iframe.srcdoc = data.html;

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -34,7 +34,7 @@
 	%== $extra_header_text
 </head>
 <body>
-	<div class="container-fluid">
+	<div class="container-fluid" data-iframe-height="1">
 		<div class="row g-0">
 			<div class="col-12 problem">
 				%== $resultSummary
@@ -180,7 +180,7 @@
 	</div>
 	% # Show the footer unless it is explicity disabled.
 	% if ($showFooter ne '0') {
-		<div id="footer">
+		<div id="footer" data-iframe-height="1">
 			WeBWorK &copy; 2000-2023 |
 			host: <%= $SITE_URL %> |
 			course: <%= $courseID %> |


### PR DESCRIPTION
This will pair with a PR to `pg`. This affects how problems behave when they are in an iframe that uses iFrameResizer. With this PR and the one in `pg`, the feedback popover should trigger the iframe resizing, but the MathQuill editor should not. And the MQ editor should never have a horizontal scrollbar. And when there is a vertical scrollbar, it should not obscure the buttons too much.