### PR TITLE
Fix the instructor_rpc endpoint usage for the library browser.

### DIFF
--- a/htdocs/js/SetMaker/setmaker.js
+++ b/htdocs/js/SetMaker/setmaker.js
@@ -51,7 +51,7 @@
 		const authenParams = {};
 		const user = document.getElementsByName('user')[0];
 		if (user) authenParams.user = user.value;
-		const sessionKey = document.getElementsByName('key')[0]?.value;
+		const sessionKey = document.getElementsByName('key')[0];
 		if (sessionKey) authenParams.key = sessionKey.value;
 
 		return {


### PR DESCRIPTION
The value attribute of the hidden key input does not have a value attribute.  Need to stop at the element in the first step.

This fixes the first issue observed by @Alex-Jordan in issue #2381.