### PR TITLE
Fix `listCourses` for the model course.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -114,7 +114,8 @@ sub listCourses {
 
 	# Collect directories which may be course directories
 	my @cdirs =
-		@{ path($coursesDir)->list({ dir => 1 })->grep(sub { -d $_ && $_ !~ /modelCourse$/ })->map('basename') };
+		@{ path($coursesDir)->list({ dir => 1 })->grep(sub { -d $_ && $_->basename ne 'modelCourse' })->map('basename')
+		};
 	if ($stmt_bad) {
 		# Fall back to old method listing all directories.
 		return @cdirs;


### PR DESCRIPTION
Make `listCourses` skip only the `modelCourse`, and not all courses ending in `modelCourse`.

This fixes issue #2384.