### PR TITLE
Fix cross listed OPL problems in the library browser.

### DIFF
--- a/htdocs/js/SetMaker/setmaker.js
+++ b/htdocs/js/SetMaker/setmaker.js
@@ -66,33 +66,37 @@
 
 	// Content request handling
 
-	const libSubjects = document.querySelector('select[name="library_subjects"]');
-	const libChapters = document.querySelector('select[name="library_chapters"]');
-	const libSections = document.querySelector('select[name="library_sections"]');
+	const librarySubject = document.querySelector('select[name="library_subject"]');
+	const libraryChapter = document.querySelector('select[name="library_chapter"]');
+	const librarySection = document.querySelector('select[name="library_section"]');
 	const libraryTextbook = document.querySelector('select[name="library_textbook"]');
-	const libraryChapter = document.querySelector('select[name="library_textchapter"]');
-	const librarySection = document.querySelector('select[name="library_textsection"]');
+	const libraryTextChapter = document.querySelector('select[name="library_textchapter"]');
+	const libraryTextSection = document.querySelector('select[name="library_textsection"]');
 	const includeOPL = document.querySelector('[name="includeOPL"]');
 	const includeContrib = document.querySelector('[name="includeContrib"]');
+	const levels = Array.from(document.getElementsByName('level'));
+	const libraryKeywords = document.getElementsByName('library_keywords')[0];
 
 	const countLine = document.getElementById('library_count_line');
 
 	const lib_update = async (who, what) => {
-		const child = { subjects: 'chapters', chapters: 'sections', sections: 'count' };
+		const child = { subject: 'chapter', chapter: 'section', section: 'count' };
 
 		const requestObject = init_webservice('searchLib');
-		requestObject.library_subjects = libSubjects?.value ?? '';
-		requestObject.library_chapters = libChapters?.value ?? '';
-		requestObject.library_sections = libSections?.value ?? '';
+		requestObject.library_subject = librarySubject?.value ?? '';
+		requestObject.library_chapter = libraryChapter?.value ?? '';
+		requestObject.library_section = librarySection?.value ?? '';
 		requestObject.library_textbook = libraryTextbook?.value ?? '';
-		requestObject.library_textchapter = libraryChapter?.value ?? '';
-		requestObject.library_textsection = librarySection?.value ?? '';
+		requestObject.library_textchapter = libraryTextChapter?.value ?? '';
+		requestObject.library_textsection = libraryTextSection?.value ?? '';
 		requestObject.includeOPL =
 			(includeOPL.type === 'checkbox' && includeOPL?.checked) ||
 			(includeOPL.type === 'hidden' && includeOPL.value)
 				? 1
 				: 0;
 		requestObject.includeContrib = includeContrib?.checked ? 1 : 0;
+		requestObject.level = levels.filter((level) => level.checked).map((level) => level.value);
+		requestObject.library_keywords = libraryKeywords?.value ?? '';
 
 		if (who == 'count') {
 			// Don't perform a count if there is no count line to update.
@@ -139,16 +143,16 @@
 			return;
 		}
 
-		if (who == 'chapters' && requestObject.library_subjects == '') {
+		if (who == 'chapter' && requestObject.library_subject == '') {
 			lib_update(who, 'clear');
 			return;
 		}
-		if (who == 'sections' && requestObject.library_chapters == '') {
+		if (who == 'section' && requestObject.library_chapter == '') {
 			lib_update(who, 'clear');
 			return;
 		}
 
-		requestObject.command = who == 'sections' ? 'getSectionListings' : 'getAllDBchapters';
+		requestObject.command = who == 'section' ? 'getSectionListings' : 'getAllDBchapters';
 
 		const controller = new AbortController();
 		const timeoutId = setTimeout(() => controller.abort(), 10000);
@@ -185,29 +189,28 @@
 		const select_all_option = sel.firstChild;
 		while (sel.firstChild) sel.lastChild.remove();
 		sel.append(select_all_option);
-		newarray.forEach((val) => {
+		newarray.forEach(([name, id]) => {
 			const option = document.createElement('option');
-			option.value = val;
-			option.textContent = val;
+			option.value = id;
+			option.textContent = name;
 			sel.append(option);
 		});
 	};
 
-	libChapters?.addEventListener('change', () => lib_update('sections', 'get'));
-	libSubjects?.addEventListener('change', () => lib_update('chapters', 'get'));
-	libSections?.addEventListener('change', () => lib_update('count', 'clear'));
+	libraryChapter?.addEventListener('change', () => lib_update('section', 'get'));
+	librarySubject?.addEventListener('change', () => lib_update('chapter', 'get'));
+	librarySection?.addEventListener('change', () => lib_update('count', 'clear'));
 	includeOPL?.addEventListener('change', () => lib_update('count', 'clear'));
 	includeContrib?.addEventListener('change', () => lib_update('count', 'clear'));
-	document
-		.querySelectorAll('input[name="level"]')
-		.forEach((level) => level.addEventListener('change', () => lib_update('count', 'clear')));
+	levels.forEach((level) => level.addEventListener('change', () => lib_update('count', 'clear')));
+	libraryKeywords?.addEventListener('change', () => lib_update('count', 'clear'));
 
 	// Set up the advanced view selects to submit the form when changed.
 	const libraryBrowserForm = document.forms['library_browser_form'];
 	if (libraryBrowserForm) {
 		libraryTextbook?.addEventListener('change', () => libraryBrowserForm.submit());
-		libraryChapter?.addEventListener('change', () => libraryBrowserForm.submit());
-		librarySection?.addEventListener('change', () => libraryBrowserForm.submit());
+		libraryTextChapter?.addEventListener('change', () => libraryBrowserForm.submit());
+		libraryTextSection?.addEventListener('change', () => libraryBrowserForm.submit());
 	}
 
 	// Add problems to target set

--- a/htdocs/js/TagWidget/tagwidget.js
+++ b/htdocs/js/TagWidget/tagwidget.js
@@ -309,9 +309,9 @@
 				mode: 'same-origin',
 				body: new URLSearchParams(
 					createWebServiceObject('setProblemTags', {
-						library_subjects: this.subjectSelect.value,
-						library_chapters: this.chapterSelect.value,
-						library_sections: this.sectionSelect.value,
+						library_subject: this.subjectSelect.value,
+						library_chapter: this.chapterSelect.value,
+						library_section: this.sectionSelect.value,
 						library_levels: this.levelSelect.value,
 						library_status: this.statusSelect?.value ?? '0',
 						command: this.filePath

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -29,7 +29,7 @@ use WeBWorK::Utils qw(sortByName x);
 use WeBWorK::Utils::DateTime qw(getDefaultSetDueDate);
 use WeBWorK::Utils::Instructor qw(assignSetToUser assignProblemToAllSetUsers addProblemToSet);
 use WeBWorK::Utils::LibraryStats;
-use WeBWorK::Utils::ListingDB qw(getSectionListings);
+use WeBWorK::Utils::ListingDB qw(getDBListings);
 use WeBWorK::Utils::Sets qw(format_set_name_internal);
 use WeBWorK::Utils::Tags;
 
@@ -320,11 +320,8 @@ sub process_search ($c, @dbsearch) {
 	my %mlt = ();
 	my $mltind;
 	for my $indx (0 .. $#dbsearch) {
-		$dbsearch[$indx]->{filepath} =
-			$dbsearch[$indx]->{libraryroot} . "/" . $dbsearch[$indx]->{path} . "/" . $dbsearch[$indx]->{filename};
-		# For debugging
-		$dbsearch[$indx]->{oindex} = $indx;
-		if ($mltind = $dbsearch[$indx]->{morelt}) {
+		$dbsearch[$indx]{oindex} = $indx;
+		if ($mltind = $dbsearch[$indx]{morelt}) {
 			if (defined($mlt{$mltind})) {
 				push @{ $mlt{$mltind} }, $indx;
 			} else {
@@ -332,7 +329,7 @@ sub process_search ($c, @dbsearch) {
 			}
 		}
 	}
-	# Now filepath is set and we have a hash of mlt entries
+	# Now we have a hash of mlt entries.
 
 	# Find MLT leaders, mark entries for no show,
 	# set up children array for leaders
@@ -548,10 +545,7 @@ sub pre_header_initialize ($c) {
 		}
 	} elsif ($c->param('lib_view')) {
 		# View from the library database
-		@pg_files = ();
-		# TODO: deprecate OPLv1 -- replace getSectionListings with getDBListings($c,0)
-		my @dbsearch = getSectionListings($c);
-		@pg_files              = process_search($c, @dbsearch);
+		@pg_files              = process_search($c, getDBListings($c, 0));
 		$use_previous_problems = 0;
 	} elsif ($c->param('view_setdef_set')) {
 		# View a set from a set*.def
@@ -638,7 +632,7 @@ sub pre_header_initialize ($c) {
 	} elsif ($c->param('library_advanced')) {
 		$library_basic = 2;
 	} elsif ($c->param('library_reset')) {
-		for my $jj (qw(chapters sections subjects textbook textchapter textsection keywords)) {
+		for my $jj (qw(chapter section subject textbook textchapter textsection keywords)) {
 			$c->param('library_' . $jj, undef);
 		}
 		$c->param('level', undef);

--- a/lib/WebworkWebservice/LibraryActions.pm
+++ b/lib/WebworkWebservice/LibraryActions.pm
@@ -146,50 +146,31 @@ sub searchLib {
 		$self->{level} = [ split(//, $rh->{library_levels}) ];
 	}
 	'getDBTextbooks' eq $subcommand && do {
-		$self->{library_subjects}    = $rh->{library_subjects};
-		$self->{library_chapters}    = $rh->{library_chapters};
-		$self->{library_sections}    = $rh->{library_sections};
-		$self->{library_textchapter} = $rh->{library_textchapter};
-		my @textbooks = WeBWorK::Utils::ListingDB::getDBTextbooks($self);
+		my @textbooks = WeBWorK::Utils::ListingDB::getDBTextbooks($self->c);
 		$out->{ra_out} = \@textbooks;
 		return $out;
 	};
 	'getAllDBsubjects' eq $subcommand && do {
-		my @subjects = WeBWorK::Utils::ListingDB::getAllDBsubjects($self);
+		my @subjects = WeBWorK::Utils::ListingDB::getAllDBsubjects($self->c);
 		$out->{ra_out} = \@subjects;
 		$out->{text}   = 'Subjects loaded.';
 		return $out;
 	};
 	'getAllDBchapters' eq $subcommand && do {
-		$self->{library_subjects} = $rh->{library_subjects};
-		my @chaps = WeBWorK::Utils::ListingDB::getAllDBchapters($self);
+		my @chaps = WeBWorK::Utils::ListingDB::getAllDBchapters($self->c);
 		$out->{ra_out} = \@chaps;
 		$out->{text}   = 'Chapters loaded.';
 
 		return $out;
 	};
 	'getDBListings' eq $subcommand && do {
-
-		my $templateDir = $self->ce->{courseDirs}->{templates};
-		$self->{library_subjects}    = $rh->{library_subjects};
-		$self->{library_chapters}    = $rh->{library_chapters};
-		$self->{library_sections}    = $rh->{library_sections};
-		$self->{library_keywords}    = $rh->{library_keywords};
-		$self->{library_textbook}    = $rh->{library_textbook};
-		$self->{library_textchapter} = $rh->{library_textchapter};
-		$self->{library_textsection} = $rh->{library_textsection};
-		my @listings = WeBWorK::Utils::ListingDB::getDBListings($self);
-		my @output =
-			map { "$templateDir/" . $_->{libraryroot} . '/' . $_->{path} . '/' . $_->{filename} } @listings;
+		my @listings = WeBWorK::Utils::ListingDB::getDBListings($self->c);
+		my @output   = map {"$self->ce->{courseDirs}{templates}/$_->{filepath}"} @listings;
 		$out->{ra_out} = \@output;
 		return $out;
 	};
 	'getSectionListings' eq $subcommand && do {
-		$self->{library_subjects} = $rh->{library_subjects};
-		$self->{library_chapters} = $rh->{library_chapters};
-		$self->{library_sections} = $rh->{library_sections};
-
-		my @section_listings = WeBWorK::Utils::ListingDB::getAllDBsections($self);
+		my @section_listings = WeBWorK::Utils::ListingDB::getAllDBsections($self->c);
 		$out->{ra_out} = \@section_listings;
 		$out->{text}   = 'Sections loaded.';
 
@@ -197,16 +178,7 @@ sub searchLib {
 	};
 
 	'countDBListings' eq $subcommand && do {
-		$self->{library_subjects}    = $rh->{library_subjects};
-		$self->{library_chapters}    = $rh->{library_chapters};
-		$self->{library_sections}    = $rh->{library_sections};
-		$self->{library_keywords}    = $rh->{library_keywords};
-		$self->{library_textbook}    = $rh->{library_textbook};
-		$self->{library_textchapter} = $rh->{library_textchapter};
-		$self->{library_textsection} = $rh->{library_textsection};
-		$self->{includeOPL}          = $rh->{includeOPL};
-		$self->{includeContrib}      = $rh->{includeContrib};
-		my $count = WeBWorK::Utils::ListingDB::countDBListings($self);
+		my $count = WeBWorK::Utils::ListingDB::countDBListings($self->c);
 		$out->{text}   = 'Count done.';
 		$out->{ra_out} = [$count];
 		return $out;
@@ -221,26 +193,21 @@ sub getProblemTags {
 	my $out  = {};
 	my $path = $rh->{command};
 	# Get a pointer to a hash of DBchapter, ..., DBsection
-	my $tags = WeBWorK::Utils::ListingDB::getProblemTags($path);
+	my $tags = WeBWorK::Utils::ListingDB::getProblemTags($path->c);
 	$out->{ra_out} = $tags;
 	$out->{text}   = 'Tags loaded.';
 
 	return $out;
 }
 
-# FIXME: Why are library_subjects, library_chapters, library_sections plural?  Each has a value that is a single
-# subject, chapter, or section.  This is also done in many places above.
 sub setProblemTags {
 	my ($invocant, $self, $rh) = @_;
-	my $path   = $rh->{command};
-	my $dbsubj = $rh->{library_subjects};
-	my $dbchap = $rh->{library_chapters};
-	my $dbsect = $rh->{library_sections};
-	my $level  = $rh->{library_levels};
-	my $stat   = $rh->{library_status};
 	# result is [success, message] with success = 0 or 1
-	my $result = WeBWorK::Utils::ListingDB::setProblemTags($path, $dbsubj, $dbchap, $dbsect, $level, $stat);
-	my $out    = {};
+	my $result = WeBWorK::Utils::ListingDB::setProblemTags(
+		$rh->{command},         $rh->{library_subject}, $rh->{library_chapter},
+		$rh->{library_section}, $rh->{library_levels},  $rh->{library_status}
+	);
+	my $out = {};
 	$out->{text} = $result->[1];
 	return $out;
 }

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel.html.ep
@@ -17,16 +17,8 @@
 	% $c->addbadmessage($msg->());
 % }
 %
-% # Now check which version to use.
-% my $libraryVersion = $ce->{problemLibrary}{version} || 2;
-% if ($libraryVersion == 1) {
-	<div class="alert alert-danger p-1 mb-2 text-center">Problem library version 1 is no longer supported.</div>
-% } elsif ($libraryVersion >= 2) {
-	% if ($c->{library_basic} == 1) {
-		<%= include 'ContentGenerator/Instructor/SetMaker/browse_library_panel_simple' =%>
-	% } else {
-		<%= include 'ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced' =%>
-	% }
+% if ($c->{library_basic} == 1) {
+	<%= include 'ContentGenerator/Instructor/SetMaker/browse_library_panel_simple' =%>
 % } else {
-	<div class="alert alert-danger p-1 mb-2 text-center">The problem library version is set to an illegal value.</div>
+	<%= include 'ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced' =%>
 % }

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced.html.ep
@@ -8,36 +8,36 @@
 	<div class="row mb-1">
 		<div class="col-md-6 col-sm-8 mb-1 offset-md-3">
 			<div class="row mb-1">
-				<%= label_for library_subjects => maketext('Subject:'),
+				<%= label_for library_subject => maketext('Subject:'),
 					class => 'col-3 col-form-label col-form-label-sm' =%>
 				<div class="col-9">
-					<%= select_field library_subjects => [
+					<%= select_field library_subject => [
 							[ maketext('All Subjects') => '', selected => undef ],
 							getAllDBsubjects($c)
 						],
-						id => 'library_subjects', class => 'form-select form-select-sm' =%>
+						id => 'library_subject', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 			<div class="row mb-1">
-				<%= label_for library_chapters => maketext('Chapter:'),
+				<%= label_for library_chapter => maketext('Chapter:'),
 					class => 'col-3 col-form-label col-form-label-sm' =%>
 				<div class="col-9">
-					<%= select_field library_chapters => [
+					<%= select_field library_chapter => [
 							[ maketext('All Chapters') => '', selected => undef ],
 							getAllDBchapters($c)
 						],
-						id => 'library_chapters', class => 'form-select form-select-sm' =%>
+						id => 'library_chapter', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 			<div class="row mb-1">
-				<%= label_for library_sections => maketext('Section:'),
+				<%= label_for library_section => maketext('Section:'),
 					class => 'col-3 col-form-label col-form-label-sm' =%>
 				<div class="col-9">
-					<%= select_field library_sections => [
+					<%= select_field library_section => [
 							[ maketext('All Sections') => '', selected => undef ],
 							getAllDBsections($c)
 						],
-						id => 'library_sections', class => 'form-select form-select-sm' =%>
+						id => 'library_section', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 			<div class="row mb-1">
@@ -57,7 +57,7 @@
 				<div class="col-9">
 					<%= select_field library_textchapter => [
 							[ maketext('All Chapters') => '', selected => undef ],
-							map { $_->[0] } @{ getDBTextbooks($c, 'textchapter') }
+							map { [ "$_->[1]. $_->[2]" => $_->[0] ] } @{ getDBTextbooks($c, 'textchapter') }
 						],
 						id => 'library_textchapter', class => 'form-select form-select-sm' =%>
 				</div>
@@ -68,7 +68,7 @@
 				<div class="col-9">
 					<%= select_field library_textsection => [
 							[ maketext('All Sections') => '', selected => undef ],
-							map { $_->[0] } @{ getDBTextbooks($c, 'textsection') }
+							map { [ "$_->[1]. $_->[2]" => $_->[0] ] } @{ getDBTextbooks($c, 'textsection') }
 						],
 						id => 'library_textsection', class => 'form-select form-select-sm' =%>
 				</div>

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_simple.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_simple.html.ep
@@ -5,36 +5,36 @@
 	<div class="row mb-2">
 		<div class="col-md-6 col-sm-8 offset-md-3">
 			<div class="row mb-1">
-				<%= label_for library_subjects => maketext('Subject:'),
+				<%= label_for library_subject => maketext('Subject:'),
 					class => 'col-2 col-form-label col-form-label-sm' =%>
 				<div class="col-10">
-					<%= select_field library_subjects => [
+					<%= select_field library_subject => [
 							[ maketext('All Subjects') => '', selected => undef ],
 							getAllDBsubjects($c)
 						],
-						id => 'library_subjects', class => 'form-select form-select-sm' =%>
+						id => 'library_subject', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 			<div class="row mb-1">
-				<%= label_for library_chapters => maketext('Chapter:'),
+				<%= label_for library_chapter => maketext('Chapter:'),
 					class => 'col-2 col-form-label col-form-label-sm' =%>
 				<div class="col-10">
-					<%= select_field library_chapters => [
+					<%= select_field library_chapter => [
 							[ maketext('All Chapters') => '', selected => undef ],
 							getAllDBchapters($c)
 						],
-						id => 'library_chapters', class => 'form-select form-select-sm' =%>
+						id => 'library_chapter', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 			<div class="row mb-1">
-				<%= label_for library_sections => maketext('Section:'),
+				<%= label_for library_section => maketext('Section:'),
 					class => 'col-2 col-form-label col-form-label-sm' =%>
 				<div class="col-10">
-					<%= select_field library_sections => [
+					<%= select_field library_section => [
 							[ maketext('All Sections') => '', selected => undef ],
 							getAllDBsections($c)
 						],
-						id => 'library_sections', class => 'form-select form-select-sm' =%>
+						id => 'library_section', class => 'form-select form-select-sm' =%>
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
The database query used to count and list OPL and Contrib problems was not good enough to narrow down to a single cross listed problem listing in the OPL database. As a result a single problem would be listed multiple times if a datbaase subject is not selected.  For example, if a textbook, text chapter, and text section are selected but not a database chapter.  This fixes issue #2387.  See that issue for details. Note that this could be improved upon by changing the OPL database.  The structure of the OPL database is not good. There is absolutely no reason that the libraryroot, pg file path, and pg file basename should be stored in separate columns, much less in separate tables.

To make that work well the values of the select options needed to be switched from being the human readable texts that are shown to being the database ids of the things the select represent.  This also fixes another issue that I have known about for a while now.  If you are on the "Basic Search" page (the initial page) of the library browser, select the subject "Calculus - single variable", chapter "Limits and continuity", and section "Motivational applications (estimation)", and then click on the "Advanced Search" button, this results in a heavy spike in CPU usage and a long delay before the page actually loads. That happens with other selections as well, but how bad it is varies with what is selected.

Also remove the plurals from the select names that don't make sense since they represenet a singular quantity.

This also removes support for OPLv1 (as the TODO in SetMaker.pm suggests). There is no reason to support that anymore. Not all of the scripts have the version check removed yet though.

Generally clean up the ListingDB.pm file.