### PR TITLE
Restructure the problem sets page (the course home page).

### DIFF
--- a/htdocs/js/ProblemSets/problemsets.js
+++ b/htdocs/js/ProblemSets/problemsets.js
@@ -65,7 +65,8 @@
 
 		for (const [type, fallbackTitle] of [
 			['open', 'Open Assignments'],
-			['not-open', 'Unopen Assignments'],
+			['reduced', 'Reduced Scoring Assignments'],
+			['not-open', 'Future Assignments'],
 			['past-due', 'Past Due Assignments']
 		]) {
 			const section = addSection(

--- a/htdocs/js/ProblemSets/problemsets.js
+++ b/htdocs/js/ProblemSets/problemsets.js
@@ -1,0 +1,112 @@
+(() => {
+	const setListContainer = document.getElementById('set-list-container');
+
+	if (!setListContainer) return;
+
+	const addSection = (type, title, contents) => {
+		const isCollapsed = localStorage.getItem(`${settingStoreID}.collapsed.${type}`) === 'true';
+
+		const accordion = document.createElement('div');
+		accordion.classList.add('accordion', 'mb-3');
+
+		const item = document.createElement('div');
+		item.classList.add('accordion-item');
+
+		const header = document.createElement('h2');
+		header.classList.add('accordion-header');
+
+		const button = document.createElement('button');
+		button.classList.add('accordion-button', 'fs-5', 'fw-bold');
+		if (isCollapsed) button.classList.add('collapsed');
+		button.type = 'button';
+		button.dataset.bsToggle = 'collapse';
+		button.dataset.bsTarget = `#${type}-collapse`;
+		button.setAttribute('aria-expanded', isCollapsed ? 'false' : 'true');
+		button.setAttribute('aria-controls', `${type}-collapse`);
+		button.textContent = title;
+		header.append(button);
+
+		const collapse = document.createElement('div');
+		collapse.classList.add('accordion-collapse', 'collapse');
+		if (!isCollapsed) collapse.classList.add('show');
+		collapse.id = `${type}-collapse`;
+
+		const body = document.createElement('div');
+		body.classList.add('accordion-body', 'p-0');
+		collapse.append(body);
+
+		const list = document.createElement('ol');
+		list.classList.add('list-group', 'list-group-flush', 'rounded-bottom');
+		list.append(...contents);
+		body.append(list);
+
+		item.append(header, collapse);
+		accordion.append(item);
+
+		setListContainer.append(accordion);
+
+		collapse.addEventListener('shown.bs.collapse', () =>
+			localStorage.setItem(`${settingStoreID}.collapsed.${type}`, 'false')
+		);
+		collapse.addEventListener('hidden.bs.collapse', () =>
+			localStorage.setItem(`${settingStoreID}.collapsed.${type}`, 'true')
+		);
+	};
+
+	const setList = Array.from(setListContainer.querySelectorAll('.list-group-item'));
+	const showByDateBtn = document.getElementById('show-by-date-btn');
+	const showByTypeBtn = document.getElementById('show-by-type-btn');
+	const settingStoreID = `WW.${document.getElementsByName('courseID')[0]?.value ?? 'unknownCourse'}.${
+		document.getElementsByName('userName')[0]?.value ?? 'unknownUser'
+	}.problem_list`;
+
+	const displayByDate = () => {
+		while (setListContainer.firstChild) setListContainer.firstChild.remove();
+
+		for (const [type, fallbackTitle] of [
+			['open', 'Open Assignments'],
+			['not-open', 'Unopen Assignments'],
+			['past-due', 'Past Due Assignments']
+		]) {
+			const section = addSection(
+				type,
+				showByDateBtn?.dataset[`${type}Title`] ?? fallbackTitle,
+				setList
+					.filter((set) => set.dataset.setStatus === type)
+					.sort((a, b) => parseInt(a.dataset.urgencySortOrder) - parseInt(b.dataset.urgencySortOrder))
+			);
+		}
+
+		localStorage.setItem(`${settingStoreID}.sort_method`, 'date');
+		showByDateBtn.classList.add('active');
+		showByTypeBtn.classList.remove('active');
+	};
+
+	const displayByType = () => {
+		while (setListContainer.firstChild) setListContainer.firstChild.remove();
+
+		for (const [type, fallbackTitle] of [
+			['default', 'Regular Assignments'],
+			['test', 'Tests/Quizzes']
+		]) {
+			addSection(
+				type,
+				showByTypeBtn?.dataset[`${type}Title`] ?? fallbackTitle,
+				setList
+					.filter((set) => set.dataset.setType === type)
+					.sort((a, b) => parseInt(a.dataset.nameSortOrder) - parseInt(b.dataset.nameSortOrder))
+			);
+		}
+
+		localStorage.setItem(`${settingStoreID}.sort_method`, 'type');
+		showByTypeBtn.classList.add('active');
+		showByDateBtn.classList.remove('active');
+	};
+
+	showByDateBtn?.addEventListener('click', displayByDate);
+	showByTypeBtn?.addEventListener('click', displayByType);
+
+	const sortMethod = localStorage.getItem(`${settingStoreID}.sort_method`);
+	if (sortMethod === 'type') displayByType();
+	else displayByDate();
+})();

--- a/htdocs/js/ProblemSets/problemsets.js
+++ b/htdocs/js/ProblemSets/problemsets.js
@@ -69,12 +69,17 @@
 			['not-open', 'Future Assignments'],
 			['past-due', 'Past Due Assignments']
 		]) {
+			const reverseSort = type === 'past-due';
 			const section = addSection(
 				type,
 				showByDateBtn?.dataset[`${type}Title`] ?? fallbackTitle,
 				setList
 					.filter((set) => set.dataset.setStatus === type)
-					.sort((a, b) => parseInt(a.dataset.urgencySortOrder) - parseInt(b.dataset.urgencySortOrder))
+					.sort(
+						(a, b) =>
+							(reverseSort ? -1 : 1) *
+							(parseInt(a.dataset.urgencySortOrder) - parseInt(b.dataset.urgencySortOrder))
+					)
 			);
 		}
 

--- a/htdocs/js/ProblemSets/problemsets.js
+++ b/htdocs/js/ProblemSets/problemsets.js
@@ -4,6 +4,8 @@
 	if (!setListContainer) return;
 
 	const addSection = (type, title, contents) => {
+		if (!contents.length) return;
+
 		const isCollapsed = localStorage.getItem(`${settingStoreID}.collapsed.${type}`) === 'true';
 
 		const accordion = document.createElement('div');

--- a/htdocs/js/System/system.js
+++ b/htdocs/js/System/system.js
@@ -120,11 +120,11 @@
 	// Accessibility
 	// Present the contents of the data-alt attribute as alternative content for screen reader users.
 	// The icon should be formatted as <i class="icon fas fa-close" data-alt="close"></i>
-	// FIXME:  Don't add these by javascript.  Make a content generator method that adds these instead.
+	// FIXME:  Don't add these by javascript.  Just add these in place instead.
 	document.querySelectorAll('i.icon').forEach((icon) => {
 		if (typeof icon.dataset.alt !== 'undefined') {
 			const glyph = document.createElement('span');
-			glyph.classList.add('sr-only-glyphicon');
+			glyph.classList.add('visually-hidden');
 			glyph.style.fontSize = icon.style.fontSize;
 			glyph.textContent = icon.dataset.alt;
 			icon.after(glyph);

--- a/htdocs/js/System/system.scss
+++ b/htdocs/js/System/system.scss
@@ -36,19 +36,6 @@ table caption {
 	color: #dc3545;
 }
 
-/* Screen Reader */
-.sr-only-glyphicon {
-	position: absolute;
-	width: 1em;
-	height: 1em;
-	padding: 0;
-	margin: 0;
-	margin-left: -1em;
-	overflow: hidden;
-	clip: rect(0, 0, 0, 0);
-	border: 0 none;
-}
-
 .visually-hidden-focusable:active,
 .visually-hidden-focusable:focus {
 	z-index: 21;
@@ -534,7 +521,7 @@ ul.courses-list {
 	}
 }
 
-/* Assignments page */
+/* Problem list and version list pages */
 .problem_set_table {
 	td a {
 		font-weight: bold;

--- a/htdocs/themes/math4-yellow/_theme-overrides.scss
+++ b/htdocs/themes/math4-yellow/_theme-overrides.scss
@@ -29,6 +29,11 @@
 	);
 }
 
+.btn-outline-primary {
+	--#{$prefix}btn-color: #{shade_color($primary, 60%)};
+	--#{$prefix}btn-border-color: #{shade_color($primary, 20%)};
+}
+
 .text-primary {
 	color: $link-color !important;
 }

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/format_code_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/format_code_form.html.ep
@@ -10,8 +10,8 @@
 			. 'function that attempts to format code in a standard way.  It does not change '
 			. 'the functionality of the code and in general is desired to have a common problem layout.') =%>"
 			data-bs-placement="top" data-bs-toggle="popover" role="button">
-			<i aria-hidden="true" class="icon fas fa-question-circle" data-alt="Help Icon"></i>
-			<span class="sr-only-glyphicon">Help Icon</span>
+			<i aria-hidden="true" class="fas fa-question-circle"></i>
+			<span class="visually-hidden"><%= maketext('Help Icon') %></span>
 		</a>
 	</div>
 	<div class="form-check">
@@ -26,8 +26,8 @@
 			. 'to ensure the problem functions.  One area of attention should be the answer blanks, '
 			. 'which may not be converted correctly.') =%>"
 		data-bs-placement="top" data-bs-toggle="popover" role="button">
-			<i aria-hidden="true" class="icon fas fa-question-circle" data-alt="Help Icon"></i>
-			<span class="sr-only-glyphicon">Help Icon</span>
+			<i aria-hidden="true" class="fas fa-question-circle"></i>
+			<span class="visually-hidden"><%= maketext('Help Icon') %></span>
 		</a>
 	</div>
 </div>

--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -26,7 +26,7 @@
 	<%= hidden_field courseID => $ce->{courseName} =%>
 	<%= hidden_field userName => param('user') =%>
 	<div class="btn-group" role="group" aria-label="<%= maketext('Display choice') %>">
-		<button id="show-by-date-btn" type="button" class="btn btn-primary"
+		<button id="show-by-date-btn" type="button" class="btn btn-outline-primary"
 			data-open-title="<%= maketext('Open Assignments') %>"
 			data-reduced-title="<%= maketext('Reduced Scoring Assignments') %>"
 			data-not-open-title="<%= maketext('Future Assignments') %>"
@@ -34,7 +34,7 @@
 		   	>
 			<%= maketext('Show By Date') =%>
 		</button>
-		<button id="show-by-type-btn" type="button" class="btn btn-primary"
+		<button id="show-by-type-btn" type="button" class="btn btn-outline-primary"
 			data-default-title="<%= maketext('Regular Assignments') %>"
 			data-test-title="<%= maketext('Tests/Quizzes') %>"
 			>

--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -1,3 +1,5 @@
+% use WeBWorK::Utils qw(getAssetURL);
+%
 % # If navigation is restricted, then don't show the body and instead display a
 % # message informing the user to access assignments via an LMS.
 % unless ($authz->hasPermissions(param('user'), 'navigation_allowed')) {
@@ -12,71 +14,41 @@
 	% last;
 % }
 %
-% content_for set_table => begin
-	% # Create the set table.
-	<div class="table-responsive">
-		<table class="problem_set_table table table-sm caption-top font-sm">
-			<caption><%= maketext('Assignments') %></caption>
-			%
-			% # Setlist table headers
-			% my $sort = param('sort') || 'status';
-			<thead class="table-group-divider">
-				<tr>
-					<th scope="col">
-						% if ($sort eq 'name') {
-							<span><%= maketext('Name') %></span>
-						% } else {
-							<%= link_to maketext('Name') => $c->systemLink(url_for, params => { sort => 'name' }) =%>
-						% }
-					</th>
-					<th scope="col">
-						% if ($sort eq 'status') {
-							<span><%= maketext('Status') %></span>
-						% } else {
-							<%= link_to maketext('Status') =>
-								$c->systemLink(url_for, params => { sort => 'status' }) =%>
-						% }
-					</th>
-					<th scope="col" class="hardcopy">
-						<i class ="icon far fa-arrow-alt-circle-down fa-lg" aria-hidden="true"
-						   title="<%= maketext('Generate Hardcopy') %>"
-						   data-alt="<%= maketext('Generate Hardcopy') %>">
-						</i>
-					</th>
-				</tr>
-			</thead>
-			%
-			<tbody class="table-group-divider">
-				% my $sets = stash('sets') // [];
-				%
-				% # Regular sets and gateway template sets are merged, but sorted either by name or urgency.
-				% # Versions are not shown here. Instead they are on the ProblemSet page for the gateway quiz.
-				% for my $set (@$sets) {
-					% if ($set->visible || $authz->hasPermissions(param('user'), 'view_hidden_sets')) {
-						<%= $c->setListRow($set) =%>
-					% }
-				% }
-			</tbody>
-		</table>
-	</div>
+% content_for js => begin
+	<%= javascript getAssetURL($ce, 'js/ProblemSets/problemsets.js'), defer => undef =%>
 % end
 %
-% if ($authz->hasPermissions(param('user'), 'view_multiple_sets')) {
-	<%= form_for 'hardcopy', name => 'problem-sets-form', id => 'problem-sets-form', method => 'POST', begin =%>
-		<%= $c->hidden_authen_fields =%>
-		<%= content 'set_table' =%>
-		<div class="mb-3">
-			<%= input_tag reset => maketext('Deselect All Sets'),
-				id => 'clear', type => 'reset', class => 'btn btn-info' =%>
-		</div>
-		<div class="mb-3">
-			<%= submit_button maketext('Generate Hardcopy for Selected Sets'),
-				id => 'hardcopy', name => 'hardcopy', class => 'btn btn-info' =%>
-		</div>
-	<% end =%>
-% } else {
-	<%= content 'set_table' =%>
-% }
+% # Create the set list.
+% # Regular sets and gateway template sets are merged, but sorted either by name or urgency.
+% # Versions are not shown here. Instead they are on the ProblemSet page for the gateway quiz.
+%
+<div class="d-flex justify-content-end gap-2 mb-3">
+	<%= hidden_field courseID => $ce->{courseName} =%>
+	<%= hidden_field userName => param('user') =%>
+	<div class="btn-group" role="group" aria-label="<%= maketext('Display choice') %>">
+		<button id="show-by-date-btn" type="button" class="btn btn-primary"
+			data-open-title="<%= maketext('Open Assignments') %>"
+			data-not-open-title="<%= maketext('Unopen Assignments') %>"
+			data-past-due-title="<%= maketext('Past Due Assignments') %>"
+		   	>
+			<%= maketext('Show By Date') =%>
+		</button>
+		<button id="show-by-type-btn" type="button" class="btn btn-primary"
+			data-default-title="<%= maketext('Regular Assignments') %>"
+			data-test-title="<%= maketext('Tests/Quizzes') %>"
+			>
+			<%= maketext('Show By Type') =%>
+		</button>
+	</div>
+</div>
+%
+<div id="set-list-container">
+	<ol class="list-group mb-3 invisible">
+		% for (@{ stash('sets') // [] }) {
+			<%= include('ContentGenerator/ProblemSets/set_list_row', set => $_, $c->getSetStatus($_)) =%>
+		% }
+	</ol>
+</div>
 %
 <%= $c->feedbackMacro(
 	route              => current_route,

--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -28,7 +28,8 @@
 	<div class="btn-group" role="group" aria-label="<%= maketext('Display choice') %>">
 		<button id="show-by-date-btn" type="button" class="btn btn-primary"
 			data-open-title="<%= maketext('Open Assignments') %>"
-			data-not-open-title="<%= maketext('Unopen Assignments') %>"
+			data-reduced-title="<%= maketext('Reduced Scoring Assignments') %>"
+			data-not-open-title="<%= maketext('Future Assignments') %>"
 			data-past-due-title="<%= maketext('Past Due Assignments') %>"
 		   	>
 			<%= maketext('Show By Date') =%>

--- a/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
+++ b/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
@@ -1,0 +1,62 @@
+% use WeBWorK::Utils::DateTime qw(after);
+% use WeBWorK::Utils::Sets qw(format_set_name_display);
+%
+% my $display_name = format_set_name_display($set->set_id);
+%
+<li class="list-group-item d-flex align-items-center justify-content-between" data-set-status="<%= $status %>"
+	data-set-type="<%= $set->assignment_type =~ /gateway/ ? 'test' : 'default' %>"
+	data-urgency-sort-order="<%= $set->{urgency_sort_order} %>" data-name-sort-order="<%= $set->{name_sort_order} %>">
+	<div>
+		% my $icon_title = $set->assignment_type =~ /gateway/ ? maketext('Test/Quiz') : maketext('Regular Assignment');
+		<i class="set-id-tooltip fa-solid <%= $set->assignment_type =~ /gateway/ ? 'fa-list-check' : 'fa-book-open' %>"
+			data-bs-title="<%= $icon_title %>" data-bs-toggle="tooltip" data-bs-placement="right"
+			aria-hidden="true" tabindex="-1">
+		</i>
+		<span class="visually-hidden"><%= $icon_title %></span>
+	</div>
+	<div class="ms-3 me-auto">
+		<div dir="ltr">
+			% if ($link_is_active) {
+				<%= link_to $display_name => $c->systemLink(url_for('problem_list', setID => $set->set_id)),
+					class => 'fw-bold set-id-tooltip',
+					data  => { bs_toggle => 'tooltip', bs_placement => 'right', bs_title => $set->description }
+				=%>
+			% } else {
+				<span class="set-id-tooltip" data-bs-toggle="tooltip" data-bs-placement="right"
+					data-bs-title="<%= $set->description %>">
+					<%= $display_name =%>
+				</span>
+				<span class="visually-hidden"><%= $set->description %></span>
+			% }
+		</div>
+		<div class="font-sm"><%= $status_msg %></div>
+		% if (!$set->visible && $authz->hasPermissions(param('user'), 'view_unopened_sets')) {
+			<div class="font-sm"><em><%= maketext('(This set is hidden from students.)') %></em></div>
+		% }
+		<div class="font-sm">
+			% for (@$other_messages) {
+				<div><%== $_ %></div>
+			% }
+		</div>
+	</div>
+	% if (
+		% $set->assignment_type !~ /gateway/
+		% && ($authz->hasPermissions(param('user'), 'view_multiple_sets')
+		% || (after($set->open_date) && (!$is_restricted || after($set->due_date))))
+	% )
+	% {
+		% my $hardcopyTitle = maketext('Download [_1]', tag('span', dir => 'ltr', $display_name));
+		<div class="hardcopy">
+			<%= link_to $c->systemLink(
+				url_for('hardcopy', setID => $set->set_id),
+				params => { selected_sets => $set->set_id }
+			),
+			class => 'hardcopy-link', begin =%>
+				<i class="hardcopy-tooltip far fa-arrow-alt-circle-down fa-lg" aria-hidden="true"
+					title="<%= $hardcopyTitle =%>" data-bs-toggle="tooltip"
+					data-bs-placement="left"></i>
+				<span class="visually-hidden"><%== $hardcopyTitle %></span>
+			<% end =%>
+		</div>
+	% }
+</li>

--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -112,8 +112,8 @@
 							bs_toggle    => 'popover'
 						},
 						begin =%>
-						<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="Help Icon"></i>
-						<span class="sr-only-glyphicon">Help Icon</span>
+						<i class="fas fa-question-circle" aria-hidden="true"></i>
+						<span class="visually-hidden"><%= maketext('Help Icon') %></span>
 					<% end =%>
 				<% end =%>
 				<div class="col-sm">
@@ -158,8 +158,8 @@
 							bs_toggle    => 'popover'
 						},
 						begin =%>
-						<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="Help Icon"></i>
-						<span class="sr-only-glyphicon">Help Icon</span>
+						<i class="fas fa-question-circle" aria-hidden="true"></i>
+						<span class="visually-hidden"><%= maketext('Help Icon') %></span>
 					<% end =%>
 				<% end =%>
 				<div class="col-sm">

--- a/templates/HelpFiles/ProblemSets.html.ep
+++ b/templates/HelpFiles/ProblemSets.html.ep
@@ -17,15 +17,16 @@
 % title maketext('Course Home Help');
 %
 <p><%= maketext('This is the standard entry point for the course.') %></p>
-<p><%= maketext('It lists the homework problem sets available for the students.') %></p>
+<p><%= maketext('It lists the assignments available for the students.') %></p>
 <p>
 	<%= maketext('The information box on the right displays information about the course. This is useful for leaving '
 		. 'course wide messages for students. It contains text from the file templates/course_info.txt. Instructors '
 		. 'can edit this file from the web (click on the "Edit" link).') =%>
 </p>
 <p class="mb-0">
-	<%= maketext('You can check the boxes to the right of the sets and click "Generate Hardcopy for Selected Sets" to '
-		. 'generate a PDF hardcopy of the selected sets. You can generate hardcopies for multiple users including '
-		. 'their answers as well. Note that students will only be able to generate hardcopies of a single set at a '
-		. 'time. Students will only be able to include answers in the hardcopy after the answer date.') =%>
+	<%= maketext('You can click the download icon to the right of each set to generate a PDF hardcopy of the set. '
+		. 'You can generate hardcopies for multiple sets and students including their answers as well by selecting '
+		. 'sets and students on the page that opens when that icon is clicked. Note that students will only be able '
+		. 'to generate hardcopies of a single set at a time. Students will only be able to include answers in '
+		. 'the hardcopy after the answer date.') =%>
 </p>


### PR DESCRIPTION
The table is replaced with list groups.  There are two or three list groups, depending on which view you select.  There are two options, "Show By Date" and "Show By Type".

If "Show By Date" is chosen (this is the default), then sets are grouped into the three categories "Open Assignments", "Unopen Assigments", and "Past Due Assignments".  Within the categories the sets are sorted by urgency (the previous status sort).

If "Show By Type" is chosen, then sets are grouped into the two categories "Regular Assignments" and "Tests/Quizzes".  Within each group the sets are ordered by name (the previous name sort).  Note that JITAR sets are grouped with "Regular Assignments".

Now all sets have an icon before them.  For tests that is the same icon that was used before.  For other assignments an open book icon is used. After the icon, the set name is shown with the status below it, and then other messages (reduced scoring and restricted release messages) below that.  The download set icon is to the right as before.

Instructors and students now see the same thing regarding the download set options.  There are no check boxes for an instructor to select and print multiple sets.  There are still numerous ways that an instructor can do that.  It is not needed here.  That can be done from the "Instructor Tools" page or even technically from here by clicking on any download icon, and then selecting the desired sets on the "Hardcopy Generator" page.

Several settings are saved in local storage that make it so that when you return to this page it is the same as it was the last time you visited it in the same browser.  The last chosen sort method will be what you see the next time you open the page, and collapsed sections will still be collapsed.

This is the result of a discussion in our meeting on Wednesday, April 3. As discussed, some wording may need to be ironed out.

For example, a past due set no longer says "Closed, answers available". Instead it says "Available for review. Answers available."  There are too many "availables" in that statement.

Also, is "Regular Assignments" good?  I was going to use "Homework Assigments", but we are trying to get away from the "homework" name.