### PR TITLE
Use an unpadded session.

### DIFF
--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -24,6 +24,8 @@ Mojolicious::WeBWorK - Mojolicious app for WeBWorK 2.
 
 use Env qw(WEBWORK_SERVER_ADMIN);
 
+use Mojo::JSON qw(encode_json);
+
 use WeBWorK;
 use WeBWorK::CourseEnvironment;
 use WeBWorK::Utils::Logs qw(writeTimingLogEntry);
@@ -40,6 +42,8 @@ sub startup ($app) {
 
 	# Configure the application
 	$app->secrets($config->{secrets});
+
+	$app->sessions->serialize(sub { return encode_json($_[0]) });
 
 	# Set constants from the configuration.
 	$WeBWorK::Debug::Enabled                                = $config->{debug}{enabled} // 0;


### PR DESCRIPTION
This changes the serialization method used by `Mojo::Sessions` to merely JSON encode the session without padding.  The default serialization method JSON encodes the session and then pads it with the letter `Z` to a length of 1025 characaters.

This results in much smaller session cookies (roughly one fifth the previous size).  Thus it is possible to be signed in to more courses at a time without hitting the cookie size limit.

This should perhaps only be considered if the limit on the number of courses that can be signed into at one time is deemed to be a big enough problem that something needs to be done.