### PR TITLE
Make the LMS Context ID configurable via the course configuration page.

### DIFF
--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -915,10 +915,10 @@ sub getConfigValues ($ce) {
 			var  => 'lms_context_id',
 			doc  => x('LMS Context ID'),
 			doc2 => x(
-				'This must be set in order to utilize LTI content selection. This must be configured in the LMS '
-					. 'first. If content selection from the LMS is attempted once the LMS is configured to use it, '
-					. 'then you will be shown the LMS context ID. Enter the context ID shown here, and then you '
-					. 'will be able to select assignments from this course, and import them into the LMS.'
+				'This must be set in order to utilize LTI content selection. The WeBWorK content item URL must be '
+					. 'set for the external tool in the LMS first. Then if content selection from the LMS is '
+					. 'attempted, you will be shown the LMS context ID. Enter the context ID shown here, and then '
+					. 'you will be able to select assignments from this course, and import them into the LMS.'
 			),
 			type => 'lms_context_id'
 		}


### PR DESCRIPTION
This setting requires its own special `ConfigObject` submodule.  To make this work well, the `ConfigObject` setup needed to be changed a bit. Settings from the course settings table also now have their own `ConfigObject` submodule (the `courseTitle` is the only setting that uses this though).

A new series of permissions controls all configuration settings.  Each setting has its own permission.  Each of these permissions have the form `change_config_[var]`. Note that the user must also have the permission `modify_problem_sets` to change configuration settings. If a configuration option is not specifically set for a setting, then the `modify_problem_sets` permission alone is sufficient to change a configuration setting. The only one of these permissions that is set by default is `change_config_lms_context_id`, and that is set to `admin`.

So the previous `setting_table_courseTitle` would now be `change_config_courseTitle`.  That is not set by default since that is the same as `modify_problem_sets`, and so there is no point in it being set.  However, there is an example of it in `defaults.config`.