### PR TITLE
Make the "Show Problem Grader" checkbox a button instead.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -704,6 +704,9 @@ async sub pre_header_initialize ($c) {
 		return;
 	}
 
+	# Unset the showProblemGrader parameter if the "Hide Problem Grader" button was clicked.
+	$c->param(showProblemGrader => undef) if $c->param('hideProblemGrader');
+
 	# What does the user want to do?
 	my %want = (
 		showOldAnswers     => $user->showOldAnswers ne '' ? $user->showOldAnswers : $ce->{pg}{options}{showOldAnswers},

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -454,6 +454,9 @@ async sub pre_header_initialize ($c) {
 	# (this hash is updated and re-stored after the can and will hashes)
 	$c->{showMeAnother} = \%showMeAnother;
 
+	# Unset the showProblemGrader parameter if the "Hide Problem Grader" button was clicked.
+	$c->param(showProblemGrader => undef) if $c->param('hideProblemGrader');
+
 	# Permissions
 
 	# What does the user want to do?
@@ -986,8 +989,8 @@ sub nav ($c, $args) {
 
 	my %tail;
 	$tail{displayMode}       = $c->{displayMode}             if defined $c->{displayMode};
-	$tail{showOldAnswers}    = $c->{will}{showOldAnswers}    if defined $c->{will}{showOldAnswers};
-	$tail{showProblemGrader} = $c->{will}{showProblemGrader} if defined $c->{will}{showProblemGrader};
+	$tail{showOldAnswers}    = 1                             if $c->{will}{showOldAnswers};
+	$tail{showProblemGrader} = 1                             if $c->{will}{showProblemGrader};
 	$tail{studentNavFilter}  = $c->param('studentNavFilter') if $c->param('studentNavFilter');
 
 	return $c->tag(

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -634,18 +634,6 @@
 		<%= $jumpLinks->() =%>
 		<div class="gwDivider"></div>
 		%
-		<div class="checkboxes-container col-12 my-2">
-			% if ($c->{can}{showProblemGrader}) {
-				<div class="form-check">
-					<label class="form-check-label">
-						<input name="showProblemGrader" type="checkbox" class="form-check-input"
-							<%= $c->{want}{showProblemGrader} ? 'checked' : '' %>>
-						<%= maketext('Show problem graders') %>
-					</label>
-				</div>
-			% }
-		</div>
-		%
 		<div class="submit-buttons-container col-12 mb-2">
 			<%= submit_button maketext('Preview Test'), name => 'previewAnswers', class => 'btn btn-primary mb-1' =%>
 			% if ($c->{can}{recordAnswersNextTime}) {
@@ -689,6 +677,20 @@
 		% if ($numProbPerPage && $numPages > 1 && $c->{can}{recordAnswersNextTime}) {
 			<p><em><%= maketext('Note: grading the test grades all problems, not just those on this page.') %></em></p>
 		% }
+		%
+		% if ($c->{can}{showProblemGrader}) {
+			<div class="col-12 my-2">
+				% if ($c->{will}{showProblemGrader}) {
+					<%= submit_button maketext('Hide Problem Graders'), name => 'hideProblemGrader',
+						class => 'btn btn-primary mb-1' =%>
+					<%= hidden_field showProblemGrader => 1 =%>
+				% } else {
+					<%= submit_button maketext('Show Problem Graders'), name => 'showProblemGrader',
+						class => 'btn btn-primary mb-1' =%>
+				% }
+			</div>
+		% }
+		%
 		% if (defined param('sourceFilePath')) {
 			<%= hidden_field sourceFilePath => param('sourceFilePath') =%>
 		% }

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -93,8 +93,9 @@
 				</div>
 				<%= $c->output_message =%>
 			</div>
-			<div class="checkboxes-container col-12 my-2"><%= $c->output_checkboxes %></div>
+			<%= $c->output_checkboxes %>
 			<div class="submit-buttons-container col-12 my-2"><%= $c->output_submit_buttons %></div>
+			<%= include 'ContentGenerator/Problem/instructor_buttons' %>
 			<div id="score_summary" class="scoreSummary"><%= $c->output_score_summary %></div>
 			<%= $c->output_misc =%>
 		<% end =%>

--- a/templates/ContentGenerator/Problem/checkboxes.html.ep
+++ b/templates/ContentGenerator/Problem/checkboxes.html.ep
@@ -1,61 +1,40 @@
-% my %can  = %{ $c->{can} };
-% my %will = %{ $c->{will} };
+% last unless $c->{can}{showAnsGroupInfo}
+	% || $c->{can}{showAnsHashInfo}
+	% || $c->{can}{showPGInfo}
+	% || $c->{can}{showResourceInfo};
 %
-% if ($can{showProblemGrader}
-	% || $can{showAnsGroupInfo}
-	% || $can{showAnsHashInfo}
-	% || $can{showPGInfo}
-	% || $can{showResourceInfo})
-% {
+<div class="col-12 my-2">
 	<span class="me-2"><%= maketext('Show:') %></span>
-% }
-%
-% if ($can{showProblemGrader} && !$will{showMeAnother}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showProblemGrader => 1, id => 'showProblemGrader_id', class => 'form-check-input',
-				$will{showProblemGrader} ? (checked => undef) : () =%>
-			<%= maketext('Problem Grader') =%>
-		</label>
-	</div>
-% }
-%
-% if ($can{showAnsGroupInfo}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showAnsGroupInfo => 1, id => 'showAnsGroupInfo_id', class => 'form-check-input',
-				$will{showAnsGroupInfo} ? (checked => undef) : () =%>
-			<%= maketext('Answer Group Info') =%>
-		</label>
-	</div>
-% }
-%
-% if ($can{showResourceInfo}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showResourceInfo => 1, id => 'showResourceInfo_id', class => 'form-check-input',
-				$will{showResourceInfo} ? (checked => undef) : () =%>
-			<%= maketext('Auxiliary Resources') =%>
-		</label>
-	</div>
-% }
-%
-% if ($can{showAnsHashInfo}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showAnsHashInfo => 1, id => 'showAnsHashInfo_id', class => 'form-check-input',
-				$will{showAnsHashInfo} ? (checked => undef) : () =%>
-			<%= maketext('Answer Hash Info') =%>
-		</label>
-	</div>
-% }
-%
-% if ($can{showPGInfo}) {
-	<div class="form-check form-check-inline">
-		<label class="form-check-label">
-			<%= check_box showPGInfo => 1, id => 'showPGInfo_id', class => 'form-check-input',
-				$will{showPGInfo} ? (checked => undef) : () =%>
-			<%= maketext('PG Info') =%>
-		</label>
-	</div>
-% }
+	%
+	% if ($c->{can}{showAnsGroupInfo}) {
+		<div class="form-check form-check-inline">
+			<%= check_box showAnsGroupInfo => 1, id => 'showAnsGroupInfo', class => 'form-check-input',
+				$c->{will}{showAnsGroupInfo} ? (checked => undef) : () =%>
+			<%= label_for showAnsGroupInfo => maketext('Answer Group Info'), class => "form-check-label" =%>
+		</div>
+	% }
+	%
+	% if ($c->{can}{showResourceInfo}) {
+		<div class="form-check form-check-inline">
+			<%= check_box showResourceInfo => 1, id => 'showResourceInfo', class => 'form-check-input',
+				$c->{will}{showResourceInfo} ? (checked => undef) : () =%>
+			<%= label_for showResourceInfo => maketext('Auxiliary Resources'), class => 'form-check-label' =%>
+		</div>
+	% }
+	%
+	% if ($c->{can}{showAnsHashInfo}) {
+		<div class="form-check form-check-inline">
+			<%= check_box showAnsHashInfo => 1, id => 'showAnsHashInfo', class => 'form-check-input',
+				$c->{will}{showAnsHashInfo} ? (checked => undef) : () =%>
+			<%= label_for showAnsHashInfo => maketext('Answer Hash Info'), class => 'form-check-label' =%>
+		</div>
+	% }
+	%
+	% if ($c->{can}{showPGInfo}) {
+		<div class="form-check form-check-inline">
+			<%= check_box showPGInfo => 1, id => 'showPGInfo', class => 'form-check-input',
+				$c->{will}{showPGInfo} ? (checked => undef) : () =%>
+			<%= label_for showPGInfo => maketext('PG Info'), class =>  'form-check-label' =%>
+		</div>
+	% }
+</div>

--- a/templates/ContentGenerator/Problem/instructor_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/instructor_buttons.html.ep
@@ -1,0 +1,14 @@
+% last unless $authz->hasPermissions(param('user'), 'access_instructor_tools');
+%
+<div class="submit-buttons-container col-12 my-2">
+	% if ($c->{can}{showProblemGrader} && !$c->{will}{showMeAnother}) {
+		% if ($c->{will}{showProblemGrader}) {
+			<%= submit_button maketext('Hide Problem Grader'), name => 'hideProblemGrader',
+				class => 'btn btn-primary mb-1' =%>
+			<%= hidden_field showProblemGrader => 1 =%>
+		% } else {
+			<%= submit_button maketext('Show Problem Grader'), name => 'showProblemGrader',
+				class => 'btn btn-primary mb-1' =%>
+		% }
+	% }
+</div>


### PR DESCRIPTION
The button is below the other usual problem/test submit buttons.  When clicked problem graders are shown, and the button becomes the "Hide Problem Grader" button.  Obviously when that is clicked the problem graders are hidden.

For now nothing is done with the check boxes for showing the various PG debugging information elements.  In thinking about this further, there really isn't a better way of handling those with the current structure.  Those are only shown for admin users (by default) so I don't think this is something that will be changed for this release.  I think that these should be removed from the problem page entirely, and instead only shown (for those with the permission to see them) on the PG editor page.  The PG code for handling these things should be completely revised and cleaned up.  It really is a hack for them to work with these check boxes to begin with.  On the PG editor page a modal dialog could be made available to view this data.

As to showing correct answers in a list after the problem (or at the bottom inside the probem?), I am not sure that is the best idea either.  We can talk about this more in a meeting, but I think it will end up being a rather ugly addition to the page.  We might as well go back to the results table.  This needs more thought.