### PR TITLE
Wait for render completion before saving tmp file when clicking "Check Answers" in the PG editor.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -312,7 +312,7 @@
 		if (!problemForm) return;
 
 		for (const button of problemForm.querySelectorAll('input[type="submit"]')) {
-			button.addEventListener('click', (e) => {
+			button.addEventListener('click', async (e) => {
 				e.preventDefault();
 
 				// FormData does not support the characters in raw problem source.  URLSearchParams does.
@@ -327,7 +327,7 @@
 				requestData.set(button.name, button.value);
 				requestData.set('set_id', document.getElementsByName('hidden_set_id')[0]?.value ?? 'Unknown Set');
 
-				renderProblem(requestData);
+				await renderProblem(requestData);
 
 				saveTempFile();
 			});

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -68,6 +68,14 @@
 					% }
 					%== $LTIGradeMessage
 					%
+					% if (stash->{disable_cookies}) {
+						%= hidden_field disableCookies => $disableCookies
+						%= hidden_field passwd         => $passwd
+					% }
+					% if (stash->{disable_cookies} || $ce->{session_management_via} ne 'session_cookie') {
+						%= hidden_field key => $key
+					% }
+					%= hidden_field user                     => $user
 					%= hidden_field sourceFilePath           => $sourceFilePath
 					%= hidden_field problemSource            => $problemSource
 					%= hidden_field rawProblemSource         => $rawProblemSource
@@ -77,11 +85,7 @@
 					%= hidden_field psvn                     => $psvn
 					%= hidden_field fileName                 => $fileName
 					%= hidden_field courseID                 => $courseID
-					%= hidden_field user                     => $user
-					%= hidden_field passwd                   => $passwd
-					%= hidden_field disableCookies           => $disableCookies
 					%= hidden_field displayMode              => $displayMode
-					%= hidden_field key                      => $key
 					%= hidden_field outputformat             => $formatName
 					%= hidden_field theme                    => $theme
 					%= hidden_field language                 => $formLanguage


### PR DESCRIPTION
It seems that if the problem rendering request does not complete before the request to save the temporary file is sent, the streams can get crossed.  We all know how bad that is!

This seems to only occur when proxying hypnotoad in some way or another. Somehow hypnotoad manages to keep the streams straight when proxying is not involved.

This is really not specific to the "Check Answers" button, but could occur with any of the submit buttons in the problem.

Also, don't add the `passwd` and `key` to the form when rendering via the `render_rpc` endpoint unless cookies are disabled for the request, and in the case that `session_management_via` is "session_cookie" don't add the key to the form.

This fixes issue #2394.