### PR TITLE
Fix an overzealous `->c` addition from #2388.

### DIFF
--- a/lib/WebworkWebservice/LibraryActions.pm
+++ b/lib/WebworkWebservice/LibraryActions.pm
@@ -193,7 +193,7 @@ sub getProblemTags {
 	my $out  = {};
 	my $path = $rh->{command};
 	# Get a pointer to a hash of DBchapter, ..., DBsection
-	my $tags = WeBWorK::Utils::ListingDB::getProblemTags($path->c);
+	my $tags = WeBWorK::Utils::ListingDB::getProblemTags($path);
 	$out->{ra_out} = $tags;
 	$out->{text}   = 'Tags loaded.';
 


### PR DESCRIPTION
That pull request changed to passing the controller object to the ListingDB methods directly instead of using the WebworkWebservice's pass through methods that make it look like a controller object.  Thus `$self` needed to be change to `$self->c` in those calls.  However `$path` was not supposed to be changed to `$path->c`.

Just try to open the tags from any problem or in the library browser with the develop branch to see what this broke.  Oops.