### PR TITLE
define set_to_display as empty string when undefined

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -534,9 +534,9 @@ sub pre_header_initialize ($c) {
 		}
 	} elsif ($c->param('view_course_set')) {
 		# View problems selected from the a set in this course
-		my $set_to_display = $c->{current_library_set};
+		my $set_to_display = $c->{current_library_set} // '';
 		debug("set_to_display is $set_to_display");
-		if (!defined $set_to_display || $set_to_display eq '') {
+		if ($set_to_display eq '') {
 			$c->addbadmessage($c->maketext("You need to select a set from this course to view."));
 		} else {
 			@pg_files = map { { 'filepath' => $_->source_file, 'morelt' => 0 } }
@@ -549,9 +549,9 @@ sub pre_header_initialize ($c) {
 		$use_previous_problems = 0;
 	} elsif ($c->param('view_setdef_set')) {
 		# View a set from a set*.def
-		my $set_to_display = $c->{current_library_set};
+		my $set_to_display = $c->{current_library_set} // '';
 		debug("set_to_display is $set_to_display");
-		if (!defined $set_to_display || $set_to_display eq '') {
+		if ($set_to_display eq '') {
 			$c->addbadmessage($c->maketext("You need to select a set definition file to view."));
 		} else {
 			@pg_files = $c->read_set_def($set_to_display);


### PR DESCRIPTION
Without this, if you go to the Library Browser, Set Definition Files button, and just click to view problems with no set selected, you get a perl error because of line 553 (the debug line) using an undefined string. It seems like if the string is undefined, it's OK to define it as `''` in the previous line to avoid this. And likewise with viewing problems from "Course Sets".