### PR TITLE
Fix focusing the "name" input in the file manager.

### DIFF
--- a/htdocs/js/FileManager/filemanager.js
+++ b/htdocs/js/FileManager/filemanager.js
@@ -55,7 +55,7 @@
 		});
 
 		// If on the confirmation page (and not the edit page), then focus the "name" input.
-		if (!form.getElementsByName('data')[0]) form.getElementsByName('name')[0]?.focus();
+		if (!document.getElementsByName('data')[0]) document.getElementsByName('name')[0]?.focus();
 	}
 
 	// The bits for types from least to most significant digit are set in the directoryListing method of


### PR DESCRIPTION
The form element does not have a `getElementsByName` method.  The `document` needs to be used for that.

This causes a console log error when the file manager page loads, and the "name" element is never focused.