### PR TITLE
Force scaffolds open when checking for a show me another variant.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -23,7 +23,6 @@ WeBWorK::ContentGenerator::ShowMeAnother - Show students alternate versions of c
 =cut
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound);
 use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
 use WeBWorK::Utils::Rendering qw(getTranslatorDebuggingOptions renderPG);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
@@ -131,6 +130,7 @@ async sub pre_header_initialize ($c) {
 			displayMode              => 'plainText',
 			showHints                => 0,
 			showSolutions            => 0,
+			forceScaffoldsOpen       => 1,
 			refreshMath2img          => 0,
 			processAnswers           => 1,
 			permissionLevel          => $db->getPermissionLevel($userName)->permission,
@@ -167,6 +167,7 @@ async sub pre_header_initialize ($c) {
 					displayMode              => 'plainText',
 					showHints                => 0,
 					showSolutions            => 0,
+					forceScaffoldsOpen       => 1,
 					refreshMath2img          => 0,
 					processAnswers           => 1,
 					permissionLevel          => $db->getPermissionLevel($userName)->permission,
@@ -228,6 +229,7 @@ async sub pre_header_initialize ($c) {
 				displayMode              => 'plainText',
 				showHints                => 0,
 				showSolutions            => 0,
+				forceScaffoldsOpen       => 1,
 				refreshMath2img          => 0,
 				processAnswers           => 1,
 				permissionLevel          => $db->getPermissionLevel($userName)->permission,
@@ -237,7 +239,15 @@ async sub pre_header_initialize ($c) {
 			},
 		);
 
-		if ($showMeAnotherNewPG->{body_text} eq $showMeAnotherOriginalPG->{body_text}) {
+		my $new_body_text = $showMeAnotherNewPG->{body_text};
+		for (keys %{ $showMeAnotherNewPG->{resource_list} }) {
+			$new_body_text =~ s/$showMeAnotherNewPG->{resource_list}{$_}//g
+				if defined $showMeAnotherNewPG->{resource_list}{$_};
+		}
+
+		if ($new_body_text eq $orig_body_text
+			&& !have_different_answers($showMeAnotherNewPG, $showMeAnotherOriginalPG))
+		{
 			$showMeAnother{IsPossible}   = 0;
 			$showMeAnother{CheckAnswers} = 0;
 			$showMeAnother{Preview}      = 0;


### PR DESCRIPTION
Currently when show me another checks for a new problem variant it does not force scaffolds to be open.  As such, if the first scaffold is static, later scaffolds are not, and the later scaffolds happen to have the same answers as the original problem, then show me another will claim that a new variant is not possible.

Here is a minimal test case:

```
DOCUMENT();
loadMacros('PGstandard.pl', 'PGML.pl', 'scaffold.pl', 'PGcourse.pl');

$a = Compute(random(1, 5));

Scaffold::Begin();
Section::Begin('Static Scaffold');
BEGIN_PGML
Enter [`5`]: [_____]{5}
END_PGML
Section::End();

Section::Begin('Dynamic Scaffold');
BEGIN_PGML
Enter [`[$a] + [@ 5 - $a @]`]: [_____]{5}
END_PGML
Section::End();
Scaffold::End();

ENDDOCUMENT();
```

With the develop branch (or any previous version of webwork2) this will fail to generate a new version.  With this pull request a new version will be generated.

Also update the comparison when checking answers or previewing from the show me another page to match the prior comparison.