### PR TITLE
Deleting numeric setting in course config can reset entire simple.conf file.

### DIFF
--- a/lib/WeBWorK/ConfigObject/number.pm
+++ b/lib/WeBWorK/ConfigObject/number.pm
@@ -18,7 +18,7 @@ use Mojo::Base 'WeBWorK::ConfigObject', -signatures;
 
 sub save_string ($self, $oldval, $use_current = 0) {
 	my $newval = $self->convert_newval_source($use_current) =~ s/['"`]//gr;
-	if ($newval !~ m/^[+-]?\d*(\.\d*)?$/) {
+	if ($newval !~ m/^[-+]?(\d+(\.\d*)?|\.\d+)$/) {
 		$self->{c}->addbadmessage(qq{Invalid numeric value "$newval" for variable \$$self->{var}.  }
 				. 'Reverting to the system default value.');
 		return '';


### PR DESCRIPTION
The regular expression in the WeBWorK::ConfigObject::number::save_string method that checks to see if a value is numeric allows the empty string. As a result if the contents of an input for a numeric setting are deleted, and then "Save Changes" is clicked on the course configuration page, `$varName = ;` is saved to the `simple.conf` file.  Since that is not valid perl, the next time that the course configuration page is loaded you will see that all settings are now shown to be the default site wide settings (because the simple.conf file fails to evaluate). Now if you click "Save Changes" again, the simple.conf file is saved with no settings at all, and so all customized settings are lost.

This fixes the regular expression so that the empty string is not allowed.  So if a value is deleted, then the system default will be reverted to, and a message will be displayed stating this (as was intended).

This bug is also present in WeBWorK 2.18.