### PR TITLE
Fix a useless defined check when searching for email recipients.

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -273,8 +273,7 @@ sub fetchEmailRecipients ($c, $permissionType, $sender = undef) {
 			user_id       => $user_ids,
 			email_address => { '!=', undef },
 			$ce->{feedback_by_section}
-				&& defined $sender
-				&& defined $sender->section ? (section => $sender->section) : (),
+				&& defined $sender ? (section => ($sender->section eq '' ? undef : $sender->section)) : ()
 		})
 	);
 


### PR DESCRIPTION
Checking that the `$sender->section` is defined does not work.  That method always returns something that is defined.  Even if the value of the `section` is NULL in the database the `$sender->section` method returns the empty string. Furthermore, testing for `section = ''` does not work to return those for which the `section` is NULL in the database.  As a result if `feedback_by_section` is enabled and the `$sender` does not have a section set, then the returned list will always be empty.

This is a minor issue since typically when `feedback_by_section` is enabled, the users sending emails will have sections (since that is the whole point).  But the `defined` check is useless.