### PR TITLE
Change the $CookieLifeTime default to 30 minutes to match $sessionKeyTimeout.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -955,8 +955,10 @@ $CookieSecure = 0;
 # The CookieLifeTime value should be numeric and in seconds, or should be set to
 # "session", in which case the cookie will expire when the browser session ends
 # (a "session cookie"). Note that a value of 0 also means the cookie will expire
-# when the browser session ends. The default value is 7 days.
-$CookieLifeTime = 604800;
+# when the browser session ends. The default value is 30 minutes (the same as
+# the $sessionKeyTimout default). It is recommended that this be the same as the
+# $sessionKeyTimeout setting.
+$CookieLifeTime = 60*30;
 
 ################################################################################
 # Two Factor Authentication

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -551,12 +551,12 @@ $mail{feedbackRecipients}    = [
 # Set the value of the samesite attribute of the session cookie:
 # See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
 # Notes about the $CookieSameSite options:
-# The CookieLifeTime setting determines how long the browser should retain the
-# cookie. See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie.
-# The CookieLifeTime value should be numeric and in seconds, or should be set to
-# "session", in which case the cookie will expire when the browser session ends
-# (a "session cookie"). Note that a value of 0 also means the cookie will expire
-# when the browser session ends. The default value is 7 days.
+# The "None" setting should only be used with HTTPS and when $CookieSecure is
+# set to 1 below. The "None" setting is also less secure and can allow certain
+# types of cross-site attacks.  The "Strict" setting can break the links in the
+# system generated feedback emails when read in a web mail client.  Due to those
+# factors, the "Lax" setting is probably the optimal choice for typical webwork2
+# servers.
 #$CookieSameSite = "None";
 #$CookieSameSite = "Strict";
 #$CookieSameSite = "Lax";
@@ -570,8 +570,10 @@ $mail{feedbackRecipients}    = [
 # The CookieLifeTime value should be numeric and in seconds, or should be set to
 # "session", in which case the cookie will expire when the browser session ends
 # (a "session cookie"). Note that a value of 0 also means the cookie will expire
-# when the browser session ends. The default value is 7 days.
-#$CookieLifeTime = 604800;
+# when the browser session ends. The default value is 30 minutes (the same as
+# the $sessionKeyTimout default). It is recommended that this be the same as the
+# $sessionKeyTimeout setting.
+#$CookieLifeTime = 60*30;
 #$CookieLifeTime = "session";
 
 ################################################################################


### PR DESCRIPTION
The cookie lifetime should be the same as the session timeout. It doesn't make sense to keep the cookie any longer than the session is valid for.  That only results in stale cookies sitting unusable in the browser cache.

Should we consider increasing both of these settings to 1 hour instead of 30 minutes? I don't think it would be a good idea to increase the default any more than that.  Note that the time limit is extended each time that a request is sent to the server.  So a 30 minute cookie and session lifetime means that if there must be no communication between the client and server for a full 30 minutes before the session expires.

Also correct the $CookieSameSite documentation in localOverrides.conf. I think this was a copy and paste issue.