### PR TITLE
Update dependencies again.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,79 +7,79 @@
             "name": "webwork.javascript_package_manager",
             "license": "GPL-2.0+",
             "dependencies": {
-                "@fortawesome/fontawesome-free": "^6.4.2",
-                "bootstrap": "~5.3.2",
+                "@fortawesome/fontawesome-free": "^6.5.2",
+                "bootstrap": "~5.3.3",
                 "codemirror": "^5.65.15",
                 "flatpickr": "^4.6.13",
-                "iframe-resizer": "^4.3.7",
+                "iframe-resizer": "^4.3.11",
                 "jquery": "^3.7.1",
                 "jquery-ui-dist": "^1.13.2",
-                "luxon": "^3.4.3",
+                "luxon": "^3.4.4",
                 "mathjax": "^3.2.2",
                 "shortcut-buttons-flatpickr": "^0.4.0",
-                "sortablejs": "^1.15.0"
+                "sortablejs": "^1.15.2"
             },
             "devDependencies": {
-                "autoprefixer": "^10.4.16",
-                "chokidar": "^3.5.3",
-                "cssnano": "^6.0.1",
-                "postcss": "^8.4.31",
-                "prettier": "^3.1.1",
+                "autoprefixer": "^10.4.19",
+                "chokidar": "^3.6.0",
+                "cssnano": "^6.1.2",
+                "postcss": "^8.4.38",
+                "prettier": "^3.2.5",
                 "rtlcss": "^4.1.1",
-                "sass": "^1.69.5",
-                "terser": "^5.24.0",
+                "sass": "^1.75.0",
+                "terser": "^5.30.4",
                 "yargs": "^17.7.2"
             }
         },
         "node_modules/@fortawesome/fontawesome-free": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
-            "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+            "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q==",
             "hasInstallScript": true,
             "engines": {
                 "node": ">=6"
             }
         },
         "node_modules/@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             },
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true,
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/source-map": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "dependencies": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
@@ -89,9 +89,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -118,9 +118,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -167,9 +167,9 @@
             }
         },
         "node_modules/autoprefixer": {
-            "version": "10.4.16",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-            "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+            "version": "10.4.19",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+            "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
             "dev": true,
             "funding": [
                 {
@@ -186,9 +186,9 @@
                 }
             ],
             "dependencies": {
-                "browserslist": "^4.21.10",
-                "caniuse-lite": "^1.0.30001538",
-                "fraction.js": "^4.3.6",
+                "browserslist": "^4.23.0",
+                "caniuse-lite": "^1.0.30001599",
+                "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -219,9 +219,9 @@
             "dev": true
         },
         "node_modules/bootstrap": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
-            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "funding": [
                 {
                     "type": "github",
@@ -249,9 +249,9 @@
             }
         },
         "node_modules/browserslist": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
             "funding": [
                 {
@@ -268,9 +268,9 @@
                 }
             ],
             "dependencies": {
-                "caniuse-lite": "^1.0.30001541",
-                "electron-to-chromium": "^1.4.535",
-                "node-releases": "^2.0.13",
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
+                "node-releases": "^2.0.14",
                 "update-browserslist-db": "^1.0.13"
             },
             "bin": {
@@ -299,9 +299,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001565",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-            "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+            "version": "1.0.30001612",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+            "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
             "dev": true,
             "funding": [
                 {
@@ -319,16 +319,10 @@
             ]
         },
         "node_modules/chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
-            "funding": [
-                {
-                    "type": "individual",
-                    "url": "https://paulmillr.com/funding/"
-                }
-            ],
             "dependencies": {
                 "anymatch": "~3.1.2",
                 "braces": "~3.0.2",
@@ -340,6 +334,9 @@
             },
             "engines": {
                 "node": ">= 8.10.0"
+            },
+            "funding": {
+                "url": "https://paulmillr.com/funding/"
             },
             "optionalDependencies": {
                 "fsevents": "~2.3.2"
@@ -360,9 +357,9 @@
             }
         },
         "node_modules/codemirror": {
-            "version": "5.65.15",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
-            "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
+            "version": "5.65.16",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+            "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
         },
         "node_modules/color-convert": {
             "version": "2.0.1",
@@ -398,12 +395,12 @@
             }
         },
         "node_modules/css-declaration-sorter": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-            "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+            "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
             "dev": true,
             "engines": {
-                "node": "^10 || ^12 || >=14"
+                "node": "^14 || ^16 || >=18"
             },
             "peerDependencies": {
                 "postcss": "^8.0.9"
@@ -463,13 +460,13 @@
             }
         },
         "node_modules/cssnano": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
-            "integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
+            "integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
             "dev": true,
             "dependencies": {
-                "cssnano-preset-default": "^6.0.1",
-                "lilconfig": "^2.1.0"
+                "cssnano-preset-default": "^6.1.2",
+                "lilconfig": "^3.1.1"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
@@ -479,62 +476,63 @@
                 "url": "https://opencollective.com/cssnano"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/cssnano-preset-default": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
-            "integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
+            "integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
             "dev": true,
             "dependencies": {
-                "css-declaration-sorter": "^6.3.1",
-                "cssnano-utils": "^4.0.0",
-                "postcss-calc": "^9.0.0",
-                "postcss-colormin": "^6.0.0",
-                "postcss-convert-values": "^6.0.0",
-                "postcss-discard-comments": "^6.0.0",
-                "postcss-discard-duplicates": "^6.0.0",
-                "postcss-discard-empty": "^6.0.0",
-                "postcss-discard-overridden": "^6.0.0",
-                "postcss-merge-longhand": "^6.0.0",
-                "postcss-merge-rules": "^6.0.1",
-                "postcss-minify-font-values": "^6.0.0",
-                "postcss-minify-gradients": "^6.0.0",
-                "postcss-minify-params": "^6.0.0",
-                "postcss-minify-selectors": "^6.0.0",
-                "postcss-normalize-charset": "^6.0.0",
-                "postcss-normalize-display-values": "^6.0.0",
-                "postcss-normalize-positions": "^6.0.0",
-                "postcss-normalize-repeat-style": "^6.0.0",
-                "postcss-normalize-string": "^6.0.0",
-                "postcss-normalize-timing-functions": "^6.0.0",
-                "postcss-normalize-unicode": "^6.0.0",
-                "postcss-normalize-url": "^6.0.0",
-                "postcss-normalize-whitespace": "^6.0.0",
-                "postcss-ordered-values": "^6.0.0",
-                "postcss-reduce-initial": "^6.0.0",
-                "postcss-reduce-transforms": "^6.0.0",
-                "postcss-svgo": "^6.0.0",
-                "postcss-unique-selectors": "^6.0.0"
+                "browserslist": "^4.23.0",
+                "css-declaration-sorter": "^7.2.0",
+                "cssnano-utils": "^4.0.2",
+                "postcss-calc": "^9.0.1",
+                "postcss-colormin": "^6.1.0",
+                "postcss-convert-values": "^6.1.0",
+                "postcss-discard-comments": "^6.0.2",
+                "postcss-discard-duplicates": "^6.0.3",
+                "postcss-discard-empty": "^6.0.3",
+                "postcss-discard-overridden": "^6.0.2",
+                "postcss-merge-longhand": "^6.0.5",
+                "postcss-merge-rules": "^6.1.1",
+                "postcss-minify-font-values": "^6.1.0",
+                "postcss-minify-gradients": "^6.0.3",
+                "postcss-minify-params": "^6.1.0",
+                "postcss-minify-selectors": "^6.0.4",
+                "postcss-normalize-charset": "^6.0.2",
+                "postcss-normalize-display-values": "^6.0.2",
+                "postcss-normalize-positions": "^6.0.2",
+                "postcss-normalize-repeat-style": "^6.0.2",
+                "postcss-normalize-string": "^6.0.2",
+                "postcss-normalize-timing-functions": "^6.0.2",
+                "postcss-normalize-unicode": "^6.1.0",
+                "postcss-normalize-url": "^6.0.2",
+                "postcss-normalize-whitespace": "^6.0.2",
+                "postcss-ordered-values": "^6.0.2",
+                "postcss-reduce-initial": "^6.1.0",
+                "postcss-reduce-transforms": "^6.0.2",
+                "postcss-svgo": "^6.0.3",
+                "postcss-unique-selectors": "^6.0.4"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/cssnano-utils": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
-            "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
+            "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/csso": {
@@ -626,9 +624,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.574",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
-            "integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
+            "version": "1.4.747",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.747.tgz",
+            "integrity": "sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -724,9 +722,9 @@
             }
         },
         "node_modules/iframe-resizer": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.7.tgz",
-            "integrity": "sha512-a3EGVScU9NtUpj6lWvGhVw3EfOw5AopRs5xGsQU385kWdgQt++OsD6PCnTV+8YkgBu/g28rLIh0EztFg9UQr1Q==",
+            "version": "4.3.11",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.11.tgz",
+            "integrity": "sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A==",
             "engines": {
                 "node": ">=0.8.0"
             },
@@ -736,9 +734,9 @@
             }
         },
         "node_modules/immutable": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+            "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
             "dev": true
         },
         "node_modules/is-binary-path": {
@@ -806,12 +804,15 @@
             }
         },
         "node_modules/lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+            "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
             "dev": true,
             "engines": {
-                "node": ">=10"
+                "node": ">=14"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/antonk52"
             }
         },
         "node_modules/lodash.memoize": {
@@ -827,9 +828,9 @@
             "dev": true
         },
         "node_modules/luxon": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
-            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg==",
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
             "engines": {
                 "node": ">=12"
             }
@@ -846,9 +847,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "dev": true,
             "funding": [
                 {
@@ -864,9 +865,9 @@
             }
         },
         "node_modules/node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
             "dev": true
         },
         "node_modules/normalize-path": {
@@ -918,9 +919,9 @@
             }
         },
         "node_modules/postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "dev": true,
             "funding": [
                 {
@@ -937,9 +938,9 @@
                 }
             ],
             "dependencies": {
-                "nanoid": "^3.3.6",
+                "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             },
             "engines": {
                 "node": "^10 || ^12 || >=14"
@@ -962,125 +963,125 @@
             }
         },
         "node_modules/postcss-colormin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
-            "integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
+            "integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0",
-                "colord": "^2.9.1",
+                "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-convert-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
-            "integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
+            "integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-discard-comments": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
-            "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
+            "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-discard-duplicates": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
-            "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+            "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-discard-empty": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
-            "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
+            "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-discard-overridden": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
-            "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
+            "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-merge-longhand": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
-            "integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
+            "integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^6.0.0"
+                "stylehacks": "^6.1.1"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-merge-rules": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
-            "integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
+            "integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^4.0.0",
-                "postcss-selector-parser": "^6.0.5"
+                "cssnano-utils": "^4.0.2",
+                "postcss-selector-parser": "^6.0.16"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-minify-font-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
-            "integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
+            "integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1089,74 +1090,74 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-minify-gradients": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
-            "integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
+            "integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
             "dev": true,
             "dependencies": {
-                "colord": "^2.9.1",
-                "cssnano-utils": "^4.0.0",
+                "colord": "^2.9.3",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-minify-params": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
-            "integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
+            "integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
-                "cssnano-utils": "^4.0.0",
+                "browserslist": "^4.23.0",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-minify-selectors": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
-            "integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
+            "integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.0.5"
+                "postcss-selector-parser": "^6.0.16"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-charset": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
-            "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
+            "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
             "dev": true,
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-display-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
-            "integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
+            "integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1165,13 +1166,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-positions": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
-            "integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
+            "integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1180,13 +1181,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-repeat-style": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
-            "integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
+            "integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1195,13 +1196,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-string": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
-            "integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
+            "integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1210,13 +1211,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-timing-functions": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
-            "integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
+            "integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1225,29 +1226,29 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-unicode": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
-            "integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
+            "integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-url": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
-            "integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
+            "integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1256,13 +1257,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-normalize-whitespace": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
-            "integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
+            "integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1271,45 +1272,45 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-ordered-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
-            "integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
+            "integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
             "dev": true,
             "dependencies": {
-                "cssnano-utils": "^4.0.0",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-reduce-initial": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
-            "integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
+            "integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-reduce-transforms": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
-            "integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
+            "integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0"
@@ -1318,13 +1319,13 @@
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.13",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+            "version": "6.0.16",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+            "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -1335,34 +1336,34 @@
             }
         },
         "node_modules/postcss-svgo": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
-            "integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
+            "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
             "dev": true,
             "dependencies": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^3.0.2"
+                "svgo": "^3.2.0"
             },
             "engines": {
                 "node": "^14 || ^16 || >= 18"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-unique-selectors": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
-            "integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
+            "integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
             "dev": true,
             "dependencies": {
-                "postcss-selector-parser": "^6.0.5"
+                "postcss-selector-parser": "^6.0.16"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/postcss-value-parser": {
@@ -1372,9 +1373,9 @@
             "dev": true
         },
         "node_modules/prettier": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
@@ -1426,9 +1427,9 @@
             }
         },
         "node_modules/sass": {
-            "version": "1.69.5",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.75.0.tgz",
+            "integrity": "sha512-ShMYi3WkrDWxExyxSZPst4/okE9ts46xZmJDSawJQrnte7M1V9fScVB+uNXOVKRBt0PggHOwoZcn8mYX4trnBw==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -1448,9 +1449,9 @@
             "integrity": "sha512-JKmT4my3Hm1e18OvG4Q6RcFhN4WRqqpTMkHrvZ7fup/dp6aTIWGVCHdRYtASkp/FCzDlJh6iCLQ/VcwwNpAMoQ=="
         },
         "node_modules/sortablejs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+            "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
         },
         "node_modules/source-map": {
             "version": "0.6.1",
@@ -1462,9 +1463,9 @@
             }
         },
         "node_modules/source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "dev": true,
             "engines": {
                 "node": ">=0.10.0"
@@ -1519,31 +1520,32 @@
             }
         },
         "node_modules/stylehacks": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
-            "integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
+            "integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
             "dev": true,
             "dependencies": {
-                "browserslist": "^4.21.4",
-                "postcss-selector-parser": "^6.0.4"
+                "browserslist": "^4.23.0",
+                "postcss-selector-parser": "^6.0.16"
             },
             "engines": {
                 "node": "^14 || ^16 || >=18.0"
             },
             "peerDependencies": {
-                "postcss": "^8.2.15"
+                "postcss": "^8.4.31"
             }
         },
         "node_modules/svgo": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+            "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
             "dev": true,
             "dependencies": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
-                "css-tree": "^2.2.1",
+                "css-tree": "^2.3.1",
+                "css-what": "^6.1.0",
                 "csso": "^5.0.5",
                 "picocolors": "^1.0.0"
             },
@@ -1559,9 +1561,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.24.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-            "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
+            "version": "5.30.4",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+            "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -1686,41 +1688,41 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": {
-            "version": "6.4.2",
-            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.4.2.tgz",
-            "integrity": "sha512-m5cPn3e2+FDCOgi1mz0RexTUvvQibBebOUlUlW0+YrMjDTPkiJ6VTKukA1GRsvRw+12KyJndNjj0O4AgTxm2Pg=="
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-6.5.2.tgz",
+            "integrity": "sha512-hRILoInAx8GNT5IMkrtIt9blOdrqHOnPBH+k70aWUAqPZPgopb9G5EQJFpaBx/S8zp2fC+mPW349Bziuk1o28Q=="
         },
         "@jridgewell/gen-mapping": {
-            "version": "0.3.3",
-            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
-            "integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.5.tgz",
+            "integrity": "sha512-IzL8ZoEDIBRWEzlCcRhOaCupYyN5gdIK+Q6fbFdPDg6HqX6jpkItn7DFIpW9LQzXG6Df9sA7+OKnq0qlz/GaQg==",
             "dev": true,
             "requires": {
-                "@jridgewell/set-array": "^1.0.1",
+                "@jridgewell/set-array": "^1.2.1",
                 "@jridgewell/sourcemap-codec": "^1.4.10",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/trace-mapping": "^0.3.24"
             }
         },
         "@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true
         },
         "@jridgewell/set-array": {
-            "version": "1.1.2",
-            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
-            "integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+            "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
             "dev": true
         },
         "@jridgewell/source-map": {
-            "version": "0.3.5",
-            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
-            "integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
+            "version": "0.3.6",
+            "resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.6.tgz",
+            "integrity": "sha512-1ZJTZebgqllO79ue2bm3rIGud/bOe0pP5BjSRCRxxYkEZS8STV7zN84UBbiYu7jy+eCKSnVIUgoWWE/tt+shMQ==",
             "dev": true,
             "requires": {
-                "@jridgewell/gen-mapping": "^0.3.0",
-                "@jridgewell/trace-mapping": "^0.3.9"
+                "@jridgewell/gen-mapping": "^0.3.5",
+                "@jridgewell/trace-mapping": "^0.3.25"
             }
         },
         "@jridgewell/sourcemap-codec": {
@@ -1730,9 +1732,9 @@
             "dev": true
         },
         "@jridgewell/trace-mapping": {
-            "version": "0.3.20",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
-            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
+            "version": "0.3.25",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+            "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -1752,9 +1754,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.11.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
+            "integrity": "sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==",
             "dev": true
         },
         "ansi-regex": {
@@ -1783,14 +1785,14 @@
             }
         },
         "autoprefixer": {
-            "version": "10.4.16",
-            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.16.tgz",
-            "integrity": "sha512-7vd3UC6xKp0HLfua5IjZlcXvGAGy7cBAXTg2lyQ/8WpNhd6SiZ8Be+xm3FyBSYJx5GKcpRCzBh7RH4/0dnY+uQ==",
+            "version": "10.4.19",
+            "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.19.tgz",
+            "integrity": "sha512-BaENR2+zBZ8xXhM4pUaKUxlVdxZ0EZhjvbopwnXmxRUfqDmwSpC2lAi/QXvx7NRdPCo1WKEcEF6mV64si1z4Ew==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.10",
-                "caniuse-lite": "^1.0.30001538",
-                "fraction.js": "^4.3.6",
+                "browserslist": "^4.23.0",
+                "caniuse-lite": "^1.0.30001599",
+                "fraction.js": "^4.3.7",
                 "normalize-range": "^0.1.2",
                 "picocolors": "^1.0.0",
                 "postcss-value-parser": "^4.2.0"
@@ -1809,9 +1811,9 @@
             "dev": true
         },
         "bootstrap": {
-            "version": "5.3.2",
-            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
-            "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
+            "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
             "requires": {}
         },
         "braces": {
@@ -1824,14 +1826,14 @@
             }
         },
         "browserslist": {
-            "version": "4.22.1",
-            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-            "integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+            "version": "4.23.0",
+            "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.0.tgz",
+            "integrity": "sha512-QW8HiM1shhT2GuzkvklfjcKDiWFXHOeFCIA/huJPwHsslwcydgk7X+z2zXpEijP98UCY7HbubZt5J2Zgvf0CaQ==",
             "dev": true,
             "requires": {
-                "caniuse-lite": "^1.0.30001541",
-                "electron-to-chromium": "^1.4.535",
-                "node-releases": "^2.0.13",
+                "caniuse-lite": "^1.0.30001587",
+                "electron-to-chromium": "^1.4.668",
+                "node-releases": "^2.0.14",
                 "update-browserslist-db": "^1.0.13"
             }
         },
@@ -1854,15 +1856,15 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001565",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-            "integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+            "version": "1.0.30001612",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001612.tgz",
+            "integrity": "sha512-lFgnZ07UhaCcsSZgWW0K5j4e69dK1u/ltrL9lTUiFOwNHs12S3UMIEYgBV0Z6C6hRDev7iRnMzzYmKabYdXF9g==",
             "dev": true
         },
         "chokidar": {
-            "version": "3.5.3",
-            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
-            "integrity": "sha512-Dr3sfKRP6oTcjf2JmUmFJfeVMvXBdegxB0iVQ5eb2V10uFJUCAS8OByZdVAyVb8xXNz3GjjTgj9kLWsZTqE6kw==",
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+            "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
             "dev": true,
             "requires": {
                 "anymatch": "~3.1.2",
@@ -1887,9 +1889,9 @@
             }
         },
         "codemirror": {
-            "version": "5.65.15",
-            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.15.tgz",
-            "integrity": "sha512-YC4EHbbwQeubZzxLl5G4nlbLc1T21QTrKGaOal/Pkm9dVDMZXMH7+ieSPEOZCtO9I68i8/oteJKOxzHC2zR+0g=="
+            "version": "5.65.16",
+            "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.16.tgz",
+            "integrity": "sha512-br21LjYmSlVL0vFCPWPfhzUCT34FM/pAdK7rRIZwa0rrtrIdotvP4Oh4GUHsu2E3IrQMCfRkL/fN3ytMNxVQvg=="
         },
         "color-convert": {
             "version": "2.0.1",
@@ -1919,9 +1921,9 @@
             "dev": true
         },
         "css-declaration-sorter": {
-            "version": "6.4.1",
-            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-6.4.1.tgz",
-            "integrity": "sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==",
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz",
+            "integrity": "sha512-h70rUM+3PNFuaBDTLe8wF/cdWu+dOZmb7pJt8Z2sedYbAcQVQV/tEchueg3GWxwqS0cxtbxmaHEdkNACqcvsow==",
             "dev": true,
             "requires": {}
         },
@@ -1961,56 +1963,57 @@
             "dev": true
         },
         "cssnano": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.0.1.tgz",
-            "integrity": "sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-6.1.2.tgz",
+            "integrity": "sha512-rYk5UeX7VAM/u0lNqewCdasdtPK81CgX8wJFLEIXHbV2oldWRgJAsZrdhRXkV1NJzA2g850KiFm9mMU2HxNxMA==",
             "dev": true,
             "requires": {
-                "cssnano-preset-default": "^6.0.1",
-                "lilconfig": "^2.1.0"
+                "cssnano-preset-default": "^6.1.2",
+                "lilconfig": "^3.1.1"
             }
         },
         "cssnano-preset-default": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.0.1.tgz",
-            "integrity": "sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==",
+            "version": "6.1.2",
+            "resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-6.1.2.tgz",
+            "integrity": "sha512-1C0C+eNaeN8OcHQa193aRgYexyJtU8XwbdieEjClw+J9d94E41LwT6ivKH0WT+fYwYWB0Zp3I3IZ7tI/BbUbrg==",
             "dev": true,
             "requires": {
-                "css-declaration-sorter": "^6.3.1",
-                "cssnano-utils": "^4.0.0",
-                "postcss-calc": "^9.0.0",
-                "postcss-colormin": "^6.0.0",
-                "postcss-convert-values": "^6.0.0",
-                "postcss-discard-comments": "^6.0.0",
-                "postcss-discard-duplicates": "^6.0.0",
-                "postcss-discard-empty": "^6.0.0",
-                "postcss-discard-overridden": "^6.0.0",
-                "postcss-merge-longhand": "^6.0.0",
-                "postcss-merge-rules": "^6.0.1",
-                "postcss-minify-font-values": "^6.0.0",
-                "postcss-minify-gradients": "^6.0.0",
-                "postcss-minify-params": "^6.0.0",
-                "postcss-minify-selectors": "^6.0.0",
-                "postcss-normalize-charset": "^6.0.0",
-                "postcss-normalize-display-values": "^6.0.0",
-                "postcss-normalize-positions": "^6.0.0",
-                "postcss-normalize-repeat-style": "^6.0.0",
-                "postcss-normalize-string": "^6.0.0",
-                "postcss-normalize-timing-functions": "^6.0.0",
-                "postcss-normalize-unicode": "^6.0.0",
-                "postcss-normalize-url": "^6.0.0",
-                "postcss-normalize-whitespace": "^6.0.0",
-                "postcss-ordered-values": "^6.0.0",
-                "postcss-reduce-initial": "^6.0.0",
-                "postcss-reduce-transforms": "^6.0.0",
-                "postcss-svgo": "^6.0.0",
-                "postcss-unique-selectors": "^6.0.0"
+                "browserslist": "^4.23.0",
+                "css-declaration-sorter": "^7.2.0",
+                "cssnano-utils": "^4.0.2",
+                "postcss-calc": "^9.0.1",
+                "postcss-colormin": "^6.1.0",
+                "postcss-convert-values": "^6.1.0",
+                "postcss-discard-comments": "^6.0.2",
+                "postcss-discard-duplicates": "^6.0.3",
+                "postcss-discard-empty": "^6.0.3",
+                "postcss-discard-overridden": "^6.0.2",
+                "postcss-merge-longhand": "^6.0.5",
+                "postcss-merge-rules": "^6.1.1",
+                "postcss-minify-font-values": "^6.1.0",
+                "postcss-minify-gradients": "^6.0.3",
+                "postcss-minify-params": "^6.1.0",
+                "postcss-minify-selectors": "^6.0.4",
+                "postcss-normalize-charset": "^6.0.2",
+                "postcss-normalize-display-values": "^6.0.2",
+                "postcss-normalize-positions": "^6.0.2",
+                "postcss-normalize-repeat-style": "^6.0.2",
+                "postcss-normalize-string": "^6.0.2",
+                "postcss-normalize-timing-functions": "^6.0.2",
+                "postcss-normalize-unicode": "^6.1.0",
+                "postcss-normalize-url": "^6.0.2",
+                "postcss-normalize-whitespace": "^6.0.2",
+                "postcss-ordered-values": "^6.0.2",
+                "postcss-reduce-initial": "^6.1.0",
+                "postcss-reduce-transforms": "^6.0.2",
+                "postcss-svgo": "^6.0.3",
+                "postcss-unique-selectors": "^6.0.4"
             }
         },
         "cssnano-utils": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.0.tgz",
-            "integrity": "sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==",
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-4.0.2.tgz",
+            "integrity": "sha512-ZR1jHg+wZ8o4c3zqf1SIUSTIvm/9mU343FMR6Obe/unskbvpGhZOo1J6d/r8D1pzkRQYuwbcH3hToOuoA2G7oQ==",
             "dev": true,
             "requires": {}
         },
@@ -2079,9 +2082,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.574",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.574.tgz",
-            "integrity": "sha512-bg1m8L0n02xRzx4LsTTMbBPiUd9yIR+74iPtS/Ao65CuXvhVZHP0ym1kSdDG3yHFDXqHQQBKujlN1AQ8qZnyFg==",
+            "version": "1.4.747",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.747.tgz",
+            "integrity": "sha512-+FnSWZIAvFHbsNVmUxhEqWiaOiPMcfum1GQzlWCg/wLigVtshOsjXHyEFfmt6cFK6+HkS3QOJBv6/3OPumbBfw==",
             "dev": true
         },
         "emoji-regex": {
@@ -2145,14 +2148,14 @@
             }
         },
         "iframe-resizer": {
-            "version": "4.3.7",
-            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.7.tgz",
-            "integrity": "sha512-a3EGVScU9NtUpj6lWvGhVw3EfOw5AopRs5xGsQU385kWdgQt++OsD6PCnTV+8YkgBu/g28rLIh0EztFg9UQr1Q=="
+            "version": "4.3.11",
+            "resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.3.11.tgz",
+            "integrity": "sha512-5QtnsmfH11GDsuC7Gxd/eNzojudX3346Gb0E+Ku8ln8AtfSq+cWCZtnhCrthrtE7f1CI2/kwHkZ9G4sFYzHP7A=="
         },
         "immutable": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.4.tgz",
-            "integrity": "sha512-fsXeu4J4i6WNWSikpI88v/PcVflZz+6kMhUfIwc5SY+poQRPnaf5V7qds6SUyUN3cVxEzuCab7QIoLOQ+DQ1wA==",
+            "version": "4.3.5",
+            "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.5.tgz",
+            "integrity": "sha512-8eabxkth9gZatlwl5TBuJnCsoTADlL6ftEr7A4qgdaTsPyreilDSnUk57SO+jfKcNtxPa22U5KK6DSeAYhpBJw==",
             "dev": true
         },
         "is-binary-path": {
@@ -2205,9 +2208,9 @@
             }
         },
         "lilconfig": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-2.1.0.tgz",
-            "integrity": "sha512-utWOt/GHzuUxnLKxB6dk81RoOeoNeHgbrXiuGk4yyF5qlRz+iIVWu56E2fqGHFrXz0QNUhLB/8nKqvRH66JKGQ==",
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.1.tgz",
+            "integrity": "sha512-O18pf7nyvHTckunPWCV1XUNXU1piu01y2b7ATJ0ppkUkk8ocqVWBrYjJBCwHDjD/ZWcfyrA0P4gKhzWGi5EINQ==",
             "dev": true
         },
         "lodash.memoize": {
@@ -2223,9 +2226,9 @@
             "dev": true
         },
         "luxon": {
-            "version": "3.4.3",
-            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.3.tgz",
-            "integrity": "sha512-tFWBiv3h7z+T/tDaoxA8rqTxy1CHV6gHS//QdaH4pulbq/JuBSGgQspQQqcgnwdAx6pNI7cmvz5Sv/addzHmUg=="
+            "version": "3.4.4",
+            "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
+            "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA=="
         },
         "mathjax": {
             "version": "3.2.2",
@@ -2239,15 +2242,15 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.6",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-            "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+            "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
             "dev": true
         },
         "node-releases": {
-            "version": "2.0.13",
-            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-            "integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+            "version": "2.0.14",
+            "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+            "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
             "dev": true
         },
         "normalize-path": {
@@ -2284,14 +2287,14 @@
             "dev": true
         },
         "postcss": {
-            "version": "8.4.31",
-            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-            "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+            "version": "8.4.38",
+            "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.38.tgz",
+            "integrity": "sha512-Wglpdk03BSfXkHoQa3b/oulrotAkwrlLDRSOb9D0bN86FdRyE9lppSp33aHNPgBa0JKCoB+drFLZkQoRRYae5A==",
             "dev": true,
             "requires": {
-                "nanoid": "^3.3.6",
+                "nanoid": "^3.3.7",
                 "picocolors": "^1.0.0",
-                "source-map-js": "^1.0.2"
+                "source-map-js": "^1.2.0"
             }
         },
         "postcss-calc": {
@@ -2305,230 +2308,230 @@
             }
         },
         "postcss-colormin": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.0.0.tgz",
-            "integrity": "sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-6.1.0.tgz",
+            "integrity": "sha512-x9yX7DOxeMAR+BgGVnNSAxmAj98NX/YxEMNFP+SDCEeNLb2r3i6Hh1ksMsnW8Ub5SLCpbescQqn9YEbE9554Sw==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0",
-                "colord": "^2.9.1",
+                "colord": "^2.9.3",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-convert-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.0.0.tgz",
-            "integrity": "sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-6.1.0.tgz",
+            "integrity": "sha512-zx8IwP/ts9WvUM6NkVSkiU902QZL1bwPhaVaLynPtCsOTqp+ZKbNi+s6XJg3rfqpKGA/oc7Oxk5t8pOQJcwl/w==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-discard-comments": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.0.tgz",
-            "integrity": "sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-6.0.2.tgz",
+            "integrity": "sha512-65w/uIqhSBBfQmYnG92FO1mWZjJ4GL5b8atm5Yw2UgrwD7HiNiSSNwJor1eCFGzUgYnN/iIknhNRVqjrrpuglw==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-duplicates": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.0.tgz",
-            "integrity": "sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-6.0.3.tgz",
+            "integrity": "sha512-+JA0DCvc5XvFAxwx6f/e68gQu/7Z9ud584VLmcgto28eB8FqSFZwtrLwB5Kcp70eIoWP/HXqz4wpo8rD8gpsTw==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-empty": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.0.tgz",
-            "integrity": "sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-6.0.3.tgz",
+            "integrity": "sha512-znyno9cHKQsK6PtxL5D19Fj9uwSzC2mB74cpT66fhgOadEUPyXFkbgwm5tvc3bt3NAy8ltE5MrghxovZRVnOjQ==",
             "dev": true,
             "requires": {}
         },
         "postcss-discard-overridden": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.0.tgz",
-            "integrity": "sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-6.0.2.tgz",
+            "integrity": "sha512-j87xzI4LUggC5zND7KdjsI25APtyMuynXZSujByMaav2roV6OZX+8AaCUcZSWqckZpjAjRyFDdpqybgjFO0HJQ==",
             "dev": true,
             "requires": {}
         },
         "postcss-merge-longhand": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.0.tgz",
-            "integrity": "sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==",
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-6.0.5.tgz",
+            "integrity": "sha512-5LOiordeTfi64QhICp07nzzuTDjNSO8g5Ksdibt44d+uvIIAE1oZdRn8y/W5ZtYgRH/lnLDlvi9F8btZcVzu3w==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0",
-                "stylehacks": "^6.0.0"
+                "stylehacks": "^6.1.1"
             }
         },
         "postcss-merge-rules": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.0.1.tgz",
-            "integrity": "sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-6.1.1.tgz",
+            "integrity": "sha512-KOdWF0gju31AQPZiD+2Ar9Qjowz1LTChSjFFbS+e2sFgc4uHOp3ZvVX4sNeTlk0w2O31ecFGgrFzhO0RSWbWwQ==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0",
-                "cssnano-utils": "^4.0.0",
-                "postcss-selector-parser": "^6.0.5"
+                "cssnano-utils": "^4.0.2",
+                "postcss-selector-parser": "^6.0.16"
             }
         },
         "postcss-minify-font-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.0.0.tgz",
-            "integrity": "sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-6.1.0.tgz",
+            "integrity": "sha512-gklfI/n+9rTh8nYaSJXlCo3nOKqMNkxuGpTn/Qm0gstL3ywTr9/WRKznE+oy6fvfolH6dF+QM4nCo8yPLdvGJg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-gradients": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.0.tgz",
-            "integrity": "sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-6.0.3.tgz",
+            "integrity": "sha512-4KXAHrYlzF0Rr7uc4VrfwDJ2ajrtNEpNEuLxFgwkhFZ56/7gaE4Nr49nLsQDZyUe+ds+kEhf+YAUolJiYXF8+Q==",
             "dev": true,
             "requires": {
-                "colord": "^2.9.1",
-                "cssnano-utils": "^4.0.0",
+                "colord": "^2.9.3",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-params": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.0.0.tgz",
-            "integrity": "sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-6.1.0.tgz",
+            "integrity": "sha512-bmSKnDtyyE8ujHQK0RQJDIKhQ20Jq1LYiez54WiaOoBtcSuflfK3Nm596LvbtlFcpipMjgClQGyGr7GAs+H1uA==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
-                "cssnano-utils": "^4.0.0",
+                "browserslist": "^4.23.0",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-minify-selectors": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.0.tgz",
-            "integrity": "sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-6.0.4.tgz",
+            "integrity": "sha512-L8dZSwNLgK7pjTto9PzWRoMbnLq5vsZSTu8+j1P/2GB8qdtGQfn+K1uSvFgYvgh83cbyxT5m43ZZhUMTJDSClQ==",
             "dev": true,
             "requires": {
-                "postcss-selector-parser": "^6.0.5"
+                "postcss-selector-parser": "^6.0.16"
             }
         },
         "postcss-normalize-charset": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.0.tgz",
-            "integrity": "sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-6.0.2.tgz",
+            "integrity": "sha512-a8N9czmdnrjPHa3DeFlwqst5eaL5W8jYu3EBbTTkI5FHkfMhFZh1EGbku6jhHhIzTA6tquI2P42NtZ59M/H/kQ==",
             "dev": true,
             "requires": {}
         },
         "postcss-normalize-display-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.0.tgz",
-            "integrity": "sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-6.0.2.tgz",
+            "integrity": "sha512-8H04Mxsb82ON/aAkPeq8kcBbAtI5Q2a64X/mnRRfPXBq7XeogoQvReqxEfc0B4WPq1KimjezNC8flUtC3Qz6jg==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-positions": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.0.tgz",
-            "integrity": "sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-6.0.2.tgz",
+            "integrity": "sha512-/JFzI441OAB9O7VnLA+RtSNZvQ0NCFZDOtp6QPFo1iIyawyXg0YI3CYM9HBy1WvwCRHnPep/BvI1+dGPKoXx/Q==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-repeat-style": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.0.tgz",
-            "integrity": "sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-6.0.2.tgz",
+            "integrity": "sha512-YdCgsfHkJ2jEXwR4RR3Tm/iOxSfdRt7jplS6XRh9Js9PyCR/aka/FCb6TuHT2U8gQubbm/mPmF6L7FY9d79VwQ==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-string": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.0.tgz",
-            "integrity": "sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-6.0.2.tgz",
+            "integrity": "sha512-vQZIivlxlfqqMp4L9PZsFE4YUkWniziKjQWUtsxUiVsSSPelQydwS8Wwcuw0+83ZjPWNTl02oxlIvXsmmG+CiQ==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-timing-functions": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.0.tgz",
-            "integrity": "sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-6.0.2.tgz",
+            "integrity": "sha512-a+YrtMox4TBtId/AEwbA03VcJgtyW4dGBizPl7e88cTFULYsprgHWTbfyjSLyHeBcK/Q9JhXkt2ZXiwaVHoMzA==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-unicode": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.0.0.tgz",
-            "integrity": "sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-6.1.0.tgz",
+            "integrity": "sha512-QVC5TQHsVj33otj8/JD869Ndr5Xcc/+fwRh4HAsFsAeygQQXm+0PySrKbr/8tkDKzW+EVT3QkqZMfFrGiossDg==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-url": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.0.tgz",
-            "integrity": "sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-6.0.2.tgz",
+            "integrity": "sha512-kVNcWhCeKAzZ8B4pv/DnrU1wNh458zBNp8dh4y5hhxih5RZQ12QWMuQrDgPRw3LRl8mN9vOVfHl7uhvHYMoXsQ==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-normalize-whitespace": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.0.tgz",
-            "integrity": "sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-6.0.2.tgz",
+            "integrity": "sha512-sXZ2Nj1icbJOKmdjXVT9pnyHQKiSAyuNQHSgRCUgThn2388Y9cGVDR+E9J9iAYbSbLHI+UUwLVl1Wzco/zgv0Q==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-ordered-values": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.0.tgz",
-            "integrity": "sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-6.0.2.tgz",
+            "integrity": "sha512-VRZSOB+JU32RsEAQrO94QPkClGPKJEL/Z9PCBImXMhIeK5KAYo6slP/hBYlLgrCjFxyqvn5VC81tycFEDBLG1Q==",
             "dev": true,
             "requires": {
-                "cssnano-utils": "^4.0.0",
+                "cssnano-utils": "^4.0.2",
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-reduce-initial": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.0.0.tgz",
-            "integrity": "sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==",
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-6.1.0.tgz",
+            "integrity": "sha512-RarLgBK/CrL1qZags04oKbVbrrVK2wcxhvta3GCxrZO4zveibqbRPmm2VI8sSgCXwoUHEliRSbOfpR0b/VIoiw==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
+                "browserslist": "^4.23.0",
                 "caniuse-api": "^3.0.0"
             }
         },
         "postcss-reduce-transforms": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.0.tgz",
-            "integrity": "sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==",
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-6.0.2.tgz",
+            "integrity": "sha512-sB+Ya++3Xj1WaT9+5LOOdirAxP7dJZms3GRcYheSPi1PiTMigsxHAdkrbItHxwYHr4kt1zL7mmcHstgMYT+aiA==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0"
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.13",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
-            "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+            "version": "6.0.16",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.16.tgz",
+            "integrity": "sha512-A0RVJrX+IUkVZbW3ClroRWurercFhieevHB38sr2+l9eUClMqome3LmEmnhlNy+5Mr2EYN6B2Kaw9wYdd+VHiw==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -2536,22 +2539,22 @@
             }
         },
         "postcss-svgo": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.0.tgz",
-            "integrity": "sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==",
+            "version": "6.0.3",
+            "resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-6.0.3.tgz",
+            "integrity": "sha512-dlrahRmxP22bX6iKEjOM+c8/1p+81asjKT+V5lrgOH944ryx/OHpclnIbGsKVd3uWOXFLYJwCVf0eEkJGvO96g==",
             "dev": true,
             "requires": {
                 "postcss-value-parser": "^4.2.0",
-                "svgo": "^3.0.2"
+                "svgo": "^3.2.0"
             }
         },
         "postcss-unique-selectors": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.0.tgz",
-            "integrity": "sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==",
+            "version": "6.0.4",
+            "resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-6.0.4.tgz",
+            "integrity": "sha512-K38OCaIrO8+PzpArzkLKB42dSARtC2tmG6PvD4b1o1Q2E9Os8jzfWFfSy/rixsHwohtsDdFtAWGjFVFUdwYaMg==",
             "dev": true,
             "requires": {
-                "postcss-selector-parser": "^6.0.5"
+                "postcss-selector-parser": "^6.0.16"
             }
         },
         "postcss-value-parser": {
@@ -2561,9 +2564,9 @@
             "dev": true
         },
         "prettier": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz",
-            "integrity": "sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==",
+            "version": "3.2.5",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+            "integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
             "dev": true
         },
         "readdirp": {
@@ -2594,9 +2597,9 @@
             }
         },
         "sass": {
-            "version": "1.69.5",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
-            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
+            "version": "1.75.0",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.75.0.tgz",
+            "integrity": "sha512-ShMYi3WkrDWxExyxSZPst4/okE9ts46xZmJDSawJQrnte7M1V9fScVB+uNXOVKRBt0PggHOwoZcn8mYX4trnBw==",
             "dev": true,
             "requires": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -2610,9 +2613,9 @@
             "integrity": "sha512-JKmT4my3Hm1e18OvG4Q6RcFhN4WRqqpTMkHrvZ7fup/dp6aTIWGVCHdRYtASkp/FCzDlJh6iCLQ/VcwwNpAMoQ=="
         },
         "sortablejs": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.0.tgz",
-            "integrity": "sha512-bv9qgVMjUMf89wAvM6AxVvS/4MX3sPeN0+agqShejLU5z5GX4C75ow1O2e5k4L6XItUyAK3gH6AxSbXrOM5e8w=="
+            "version": "1.15.2",
+            "resolved": "https://registry.npmjs.org/sortablejs/-/sortablejs-1.15.2.tgz",
+            "integrity": "sha512-FJF5jgdfvoKn1MAKSdGs33bIqLi3LmsgVTliuX6iITj834F+JRQZN90Z93yql8h0K2t0RwDPBmxwlbZfDcxNZA=="
         },
         "source-map": {
             "version": "0.6.1",
@@ -2621,9 +2624,9 @@
             "dev": true
         },
         "source-map-js": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-            "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.0.tgz",
+            "integrity": "sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==",
             "dev": true
         },
         "source-map-support": {
@@ -2663,33 +2666,34 @@
             "dev": true
         },
         "stylehacks": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.0.0.tgz",
-            "integrity": "sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-6.1.1.tgz",
+            "integrity": "sha512-gSTTEQ670cJNoaeIp9KX6lZmm8LJ3jPB5yJmX8Zq/wQxOsAFXV3qjWzHas3YYk1qesuVIyYWWUpZ0vSE/dTSGg==",
             "dev": true,
             "requires": {
-                "browserslist": "^4.21.4",
-                "postcss-selector-parser": "^6.0.4"
+                "browserslist": "^4.23.0",
+                "postcss-selector-parser": "^6.0.16"
             }
         },
         "svgo": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.0.2.tgz",
-            "integrity": "sha512-Z706C1U2pb1+JGP48fbazf3KxHrWOsLme6Rv7imFBn5EnuanDW1GPaA/P1/dvObE670JDePC3mnj0k0B7P0jjQ==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/svgo/-/svgo-3.2.0.tgz",
+            "integrity": "sha512-4PP6CMW/V7l/GmKRKzsLR8xxjdHTV4IMvhTnpuHwwBazSIlw5W/5SmPjN8Dwyt7lKbSJrRDgp4t9ph0HgChFBQ==",
             "dev": true,
             "requires": {
                 "@trysound/sax": "0.2.0",
                 "commander": "^7.2.0",
                 "css-select": "^5.1.0",
-                "css-tree": "^2.2.1",
+                "css-tree": "^2.3.1",
+                "css-what": "^6.1.0",
                 "csso": "^5.0.5",
                 "picocolors": "^1.0.0"
             }
         },
         "terser": {
-            "version": "5.24.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
-            "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
+            "version": "5.30.4",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.30.4.tgz",
+            "integrity": "sha512-xRdd0v64a8mFK9bnsKVdoNP9GQIKUAaJPTaqEQDL4w/J8WaW4sWXXoMZ+6SimPkfT5bElreXf8m9HnmPc3E1BQ==",
             "dev": true,
             "requires": {
                 "@jridgewell/source-map": "^0.3.3",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,27 +13,27 @@
         "url": "https://github.com/openwebwork/webwork2"
     },
     "dependencies": {
-        "@fortawesome/fontawesome-free": "^6.4.2",
-        "bootstrap": "~5.3.2",
+        "@fortawesome/fontawesome-free": "^6.5.2",
+        "bootstrap": "~5.3.3",
         "codemirror": "^5.65.15",
         "flatpickr": "^4.6.13",
-        "iframe-resizer": "^4.3.7",
+        "iframe-resizer": "^4.3.11",
         "jquery": "^3.7.1",
         "jquery-ui-dist": "^1.13.2",
-        "luxon": "^3.4.3",
+        "luxon": "^3.4.4",
         "mathjax": "^3.2.2",
         "shortcut-buttons-flatpickr": "^0.4.0",
-        "sortablejs": "^1.15.0"
+        "sortablejs": "^1.15.2"
     },
     "devDependencies": {
-        "autoprefixer": "^10.4.16",
-        "chokidar": "^3.5.3",
-        "cssnano": "^6.0.1",
-        "postcss": "^8.4.31",
-        "prettier": "^3.1.1",
+        "autoprefixer": "^10.4.19",
+        "chokidar": "^3.6.0",
+        "cssnano": "^6.1.2",
+        "postcss": "^8.4.38",
+        "prettier": "^3.2.5",
         "rtlcss": "^4.1.1",
-        "sass": "^1.69.5",
-        "terser": "^5.24.0",
+        "sass": "^1.75.0",
+        "terser": "^5.30.4",
         "yargs": "^17.7.2"
     },
     "browserslist": [


### PR DESCRIPTION
All dependencies are now at their latest versions.  The changes are:

* @fortawesome/fontawesome-free: 6.4.2 to 6.5.2
* bootstrap: 5.3.2 to 5.3.3
* iframe-resizer: 4.3.7 to 4.2.11
* luxon: 3.4.3 to 3.4.4
* sortablejs: 1.15.0 to 1.15.2
* autoprefixer: 10.4.16 to 10.4.19
* chokidar: 3.5.3 to 3.6.0
* cssnano: 6.0.1 to 6.1.2
* postcss: 8.4.31 to 8.4.38
* prettier: 3.1.1 to 3.2.5
* sass: 1.69.5 to 1.75.0
* terser: 5.24.0 to 5.30.0

No code changes are needed for this update.

Note that new version of @fortawesome/fontawesome-free has finally fixed the "incorrect glyph bbox in a downloadable font" console warning.