### PR TITLE
The fallback original_student_ans can not be in math mode text in hardcopy.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1317,7 +1317,10 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 			} elsif (defined $pg->{answers}{$ansName}{original_student_ans}
 				&& $pg->{answers}{$ansName}{original_student_ans} ne '')
 			{
-				$stuAns = "\\begin{verbatim}$pg->{answers}{$ansName}{original_student_ans}\\end{verbatim}";
+				$stuAns =
+					"\\begin{verbatim}"
+					. ($pg->{answers}{$ansName}{original_student_ans} =~ s/\\end\{verbatim\}//gr)
+					. "\\end{verbatim}";
 			} else {
 				$stuAns = "no response";
 			}

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1313,15 +1313,15 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 			if (defined $pg->{answers}{$ansName}{preview_latex_string}
 				&& $pg->{answers}{$ansName}{preview_latex_string} ne '')
 			{
-				$stuAns = $pg->{answers}{$ansName}{preview_latex_string};
+				$stuAns = "\$\\displaystyle $pg->{answers}{$ansName}{preview_latex_string}\$";
 			} elsif (defined $pg->{answers}{$ansName}{original_student_ans}
 				&& $pg->{answers}{$ansName}{original_student_ans} ne '')
 			{
-				$stuAns = "\\text{" . $pg->{answers}{$ansName}{original_student_ans} . "}";
+				$stuAns = "\\begin{verbatim}$pg->{answers}{$ansName}{original_student_ans}\\end{verbatim}";
 			} else {
-				$stuAns = "\\text{no response}";
+				$stuAns = "no response";
 			}
-			$stuAnswers .= "\\item\n\$\\displaystyle $stuAns\$\n";
+			$stuAnswers .= "\\item\n$stuAns\n";
 		}
 		$stuAnswers .= "\\end{itemize}}$corrMsg\\par\n";
 		print $FH $stuAnswers;


### PR DESCRIPTION
There are many answers for which the `original_student_ans` does not work inside `$\displaystyle \text{...}$` which is what is currently used for student answers if `preview_latex_string` is not defined or is empty.

For example, consider the following MWE.

```
DOCUMENT();
loadMacros('PGstandard.pl', 'PGML.pl', 'contextFraction.pl', 'PGcourse.pl');
$b   = random(2, 4);
$ans = Compute("3^($b)");
Context()->operators->undefine('+', '-', '*', ' *', '* ', '^', '**');
BEGIN_PGML
Simplify [`3^[$b]`]: [_]{$ans}
END_PGML
ENDDOCUMENT();
```

Add that problem to a set and submit the answer `3^$b` (whatever `$b` is for you) without actually simplifying.  Since exponents are disabled for this problem, that answer does not parse into a MathObject value, and so `preview_latex_string` is undefined.  Now if you generate a hardcopy for this set including "Student answers" hardcopy will fail since the `^` character must be in math mode and not inside `\text`.

So I see no alternative, but to go back to using verbatim in this case.