### PR TITLE
Don't show last answers when a new ShowMeAnother problem is shown.

### DIFF
--- a/templates/ContentGenerator/Problem/submit_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/submit_buttons.html.ep
@@ -52,10 +52,9 @@
 		% && $c->{showMeAnother}{MaxReps} > -1
 		% && $c->{showMeAnother}{Count} >= $c->{showMeAnother}{MaxReps};
 	% if ($can{showMeAnother} && !$exhausted) {
-		<%= submit_button maketext('Show Me Another'),
-			formaction => url_for('show_me_another'),
-			formtarget => 'WW_Show_Me_Another',
+	<%= link_to maketext('Show Me Another') => $c->systemLink(url_for('show_me_another')),
 			class      => 'set-id-tooltip btn btn-primary mb-1',
+			target     => 'WW_Show_Me_Another',
 			data       => {
 				bs_toggle    => 'tooltip',
 				bs_placement => 'right',


### PR DESCRIPTION
When I made the "Show Me Another" button an actual submit button in #2405, and unintended consequence is that the answers from the original problem or previous show me another problem persist when show me another is initialized with a new problem. I don't know why I thought that would work.  So that will need to be a link again.