### PR TITLE
Fix unintentional versioned set deletion on the user detail page.

### DIFF
--- a/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
@@ -17,9 +17,6 @@
 						params => { editForUser => $userID }
 					) =%>
 			</span>
-			% if ($version) {
-				<%= hidden_field "set.$setID,v$version.assignment" => 'delete' =%>
-			% }
 		% } else {
 			<span dir="ltr">
 				% if ($isGateway) {
@@ -34,6 +31,9 @@
 		<label class="form-check-label">
 			<%= check_box $version ? "set.$setID,v$version.assignment" : "set.$setID.assignment" => 'assigned',
 				class => 'form-check-input', defined $mergedSet ? (checked => undef) : () =%>
+			% if (defined $mergedSet && $version) {
+				<%= hidden_field "set.$setID,v$version.assignment" => 'delete' =%>
+			% }
 		</label>
 	</td>
 	<td class="text-center">


### PR DESCRIPTION
The issue is that with the restructuring of the page the hidden input corresponding to the "assigned" checkbox for a versioned set was not moved with the checkbox.  As a result it now comes earlier in the DOM. This means that the order of the values for the hidden input and checkbox by the same name are now reversed in the submitted form.  Since the WeBWorK::Controller param method returns the first one the code now gets the hidden input value of "delete" instead of the check box value of "assigned" even when the check box is checked.

The fix is simply to move the hidden input back to after the checkbox.

This fixes issue #2419.