### PR TITLE
In LTI Advantage, pass actual scores back (with total possible)

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -232,7 +232,7 @@ async sub submit_set_grade ($self, $userID, $setID) {
 }
 
 # Submits scoreGiven and scoreMaximum to the lms with $sourcedid as the identifier.
-async sub submit_grade ($self, $LMSuserID, $lineitem, $scoreiGiven, $scoreMaximum) {
+async sub submit_grade ($self, $LMSuserID, $lineitem, $scoreGiven, $scoreMaximum) {
 	my $c  = $self->{c};
 	my $ce = $c->{ce};
 


### PR DESCRIPTION
So...I've done zero testing with this. Because I'm not set up to test on Canvas or Moodle, and I can't really test with D2L without just diving in and trying things in production.

But my intent here is to stop sending the LMS decimal/percentage scores. For example if a student has 1/12 on an assignment, WeBWorK sends back 0.08 as the score (rounded down from 0.8333....) If the LMS grade item is set to also be out of 12 points, then the student sees they have  0.96/12, since 0.96 is 8% of 12.

So the intent here is that we send the LMS the 1 and the 12. Although I have not tested, this seemed surprisingly easy to do. The scoring utilities are already set up to return arrays with things like the 1 and the 12. @drgrice1 can I impose on you to critique this and if it's workable, try it out on Canvas and Moodle?

Related to this, I'd like to change content item selection to not use a scoreMaximum of 100 by default. Or at least make that configurable to use either 100 or the item's actual total. But that would be a separate PR and is perhaps controversial if you prefer it to be out of 100. But we are finding in practice that step #1 when connecting a WW course to a D2L course is to go change all the 100's to the actual assignment totals. I mention it now since it is somewhat related.