### PR TITLE
Fix hidden sets being shown to students.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -72,6 +72,10 @@ sub initialize ($c) {
 		@sets = grep { $_->assignment_type !~ /proctored/ } @sets
 			unless $authz->hasPermissions($user, 'view_proctored_tests');
 
+		# Remove hidden sets unless the user has permission to view hidden sets.
+		@sets = grep { $_->visible } @sets
+			unless $authz->hasPermissions($user, 'view_hidden_sets');
+
 		debug('Begin sorting merged sets');
 
 		# Cache sort orders.  Javascript uses these to display sets in the correct order.


### PR DESCRIPTION
Currently hidden sets are still listed for students.  I am not sure when this regression was added, but this fixes it.