### PR TITLE
Don't have Mojolicious UTF-8 decode files. Instead do it ourself.

### DIFF
--- a/lib/WeBWorK/Utils/Files.pm
+++ b/lib/WeBWorK/Utils/Files.pm
@@ -19,6 +19,7 @@ use Mojo::Base 'Exporter', -signatures;
 use File::Spec::Functions qw(canonpath);
 use File::Find;
 use Mojo::File qw(path);
+use Mojo::Util qw(decode);
 
 our @EXPORT_OK = qw(
 	surePathToFile
@@ -45,7 +46,7 @@ sub readFile ($fileName) {
 	my $result = '';
 
 	if (-r $fileName) {
-		eval { $result = path($fileName)->slurp('UTF-8') };
+		eval { $result = path($fileName)->slurp; $result = decode('UTF-8', $result); };
 		warn "$@\n" if $@;
 	}
 


### PR DESCRIPTION
In the `WeBWorK::Utils::Files::readFile` method UTF-8 decode the file contents after calling the `Mojo::File::slurp` without passing the UTF-8 decode parameter.

This is an alternate approach to #2432 that makes it so that version 9.22 of Mojolicious (the version in the Ubuntu 22.04 repositories) can still be used.