### PR TITLE
Allow access to the instructor_rpc route without revoking proctor authorization.

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -219,9 +219,12 @@ async sub dispatch ($c) {
 					await WeBWorK::ContentGenerator::LoginProctor->new($c)->go;
 					return 0;
 				}
-			} else {
+			} elsif ($c->current_route ne 'instructor_rpc') {
 				# If any other page is opened, then revoke proctor authorization if it has been granted.
 				# Otherwise the student will be able to re-enter the test without again obtaining proctor authorization.
+				# Do NOT do this for the instructor_rpc route.  The only student usage of this route is to get the
+				# current server time during a gateway quiz, and that definitely should not revoke proctor
+				# authorization.
 				delete $c->authen->session->{proctor_authorization_granted};
 			}
 			return 1;


### PR DESCRIPTION
This fixes a (rather serious) bug in which proctor authorization is revoked when the instructor_rpc endpoint is used by students during a test to get the server time.  This means that every single time that a student changes pages or hits preview during a proctored test, the student needs to re-renter the proctor username and password.

The only command that the instructor_rpc allows for student users is this command that gets the server time.  All other commands are instructor only, and should be fine to allow without revoking proctor authorization.