### PR TITLE
Synchronize the "add user" page with the "edit user" page.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -32,6 +32,10 @@ sub initialize ($c) {
 
 	my $user = $c->param('user');
 
+	# Make sure these are defined for the template.
+	$c->stash->{statusValues}     = [];
+	$c->stash->{permissionValues} = [];
+
 	# Check permissions
 	return unless $authz->hasPermissions($user, 'access_instructor_tools');
 	return unless $authz->hasPermissions($user, 'modify_student_data');
@@ -45,8 +49,7 @@ sub initialize ($c) {
 		# FIXME: Handle errors if user already exists as well as all other errors that could occur (including errors
 		# when adding the permission, adding the password, and assigning sets to the users).
 		for my $i (1 .. $numberOfStudents) {
-			my $new_user_id  = trim_spaces($c->param("new_user_id_$i"));
-			my $new_password = cryptPassword($c->param("student_id_$i"));
+			my $new_user_id = trim_spaces($c->param("new_user_id_$i"));
 			next unless $new_user_id;
 
 			my $newUser = $db->newUser;
@@ -58,7 +61,7 @@ sub initialize ($c) {
 			$newUser->section(trim_spaces($c->param("section_$i")));
 			$newUser->recitation(trim_spaces($c->param("recitation_$i")));
 			$newUser->comment(trim_spaces($c->param("comment_$i")));
-			$newUser->status($ce->status_name_to_abbrevs($ce->{default_status}));
+			$newUser->status($c->param("status_$i"));
 
 			eval { $db->addUser($newUser) };
 			if ($@) {
@@ -75,12 +78,12 @@ sub initialize ($c) {
 
 				my $newPermissionLevel = $db->newPermissionLevel;
 				$newPermissionLevel->user_id($new_user_id);
-				$newPermissionLevel->permission(0);
+				$newPermissionLevel->permission($c->param("permission_$i"));
 				$db->addPermissionLevel($newPermissionLevel);
 
 				my $newPassword = $db->newPassword;
 				$newPassword->user_id($new_user_id);
-				$newPassword->password($new_password);
+				$newPassword->password(cryptPassword($c->param("student_id_$i")));
 				$db->addPassword($newPassword);
 
 				push(
@@ -97,6 +100,29 @@ sub initialize ($c) {
 			my @setIDs = $c->param('assignSets');
 			assignSetsToUsers($db, $ce, \@setIDs, \@userIDs);
 		}
+	}
+
+	# Create the array of statuses for the status selects.
+	$c->stash->{statusValues} = [
+		map { [
+			$c->maketext($_) => $ce->{statuses}{$_}{abbrevs}[0],
+			$ce->{statuses}{$_}{abbrevs}[0] eq ($ce->status_name_to_abbrevs($ce->{default_status}))[0]
+			? (selected => undef)
+			: ()
+		] } sort(keys %{ $ce->{statuses} })
+	];
+
+	# Create the array of permission values for the permission selects.
+	for my $role (sort { $ce->{userRoles}{$a} <=> $ce->{userRoles}{$b} } keys %{ $ce->{userRoles} }) {
+		next
+			unless $ce->{userRoles}{$role} <= $db->getPermissionLevel($c->param('user'))->permission;
+		push(
+			@{ $c->stash->{permissionValues} },
+			[
+				$c->maketext($role) => $ce->{userRoles}{$role},
+				$ce->{userRoles}{$role} eq $ce->{default_permission_level} ? (selected => undef) : ()
+			]
+		);
 	}
 
 	return;

--- a/templates/ContentGenerator/Instructor/AddUsers.html.ep
+++ b/templates/ContentGenerator/Instructor/AddUsers.html.ep
@@ -12,7 +12,6 @@
 	% last;
 % }
 %
-<hr>
 <p><%= defined $c->{studentEntryReport} ? $c->{studentEntryReport}->join('') : '' %></p>
 <p>
 	<%= maketext(
@@ -25,70 +24,91 @@
 %
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields('create_') =%>
-	<div class="input-group d-inline-flex w-auto">
+	<div class="input-group d-inline-flex w-auto mb-3">
 		<%= submit_button maketext('Create'), class => 'btn btn-primary' =%>
-		<%= number_field number_of_students => $numberOfStudents, size => 5, min => 1, class => 'form-control' =%>
+		<%= number_field number_of_students => $numberOfStudents, min => 1,
+			class => 'form-control', style => 'width: 6em' =%>
 		<span class="input-group-text"><%= maketext('entry rows.') %></span>
 	</div>
 <% end =%>
-<hr>
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	<%= hidden_field number_of_students => $numberOfStudents =%>
 	<div class="table-responsive">
 		<table class="table table-sm table-bordered">
-			<tr>
-				<th><%= maketext('Last Name') %></th>
-				<th><%= maketext('First Name') %></th>
-				<th><%= maketext('Student ID') %></th>
-				<th><%= maketext('Login Name') %><span class="required-field">*</span></th>
-				<th><%= maketext('Email Address') %></th>
-				<th><%= maketext('Section') %></th>
-				<th><%= maketext('Recitation') %></th>
-				<th><%= maketext('Comment') %></th>
-			</tr>
-			% for (1 .. $numberOfStudents) {
+			<thead class="table-group-divider">
 				<tr>
-					<td>
-						% param("last_name_$_", undef);
-						<%= text_field "last_name_$_" => '', size => '10',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("first_name_$_", undef);
-						<%= text_field "first_name_$_" => '', size => '10',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("student_id_$_", undef);
-						<%= text_field "student_id_$_" => '', size => '16',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("new_user_id_$_", undef);
-						<%= text_field "new_user_id_$_" => '', size => '10',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("email_address_$_", undef);
-						<%= text_field "email_address_$_" => '', class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("section_$_", undef);
-						<%= text_field "section_$_" => '', size => '4',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("recitation_$_", undef);
-						<%= text_field "recitation_$_" => '', size => '4',
-							class => 'form-control form-control-sm w-auto' =%>
-					</td>
-					<td>
-						% param("comment_$_", undef);
-						<%= text_field "comment_$_" => '', class => 'form-control form-control-sm w-auto' =%>
-					</td>
+					<th id="user_id_header"><%= maketext('Login Name') %><span class="required-field">*</span></th>
+					<th id="first_name_header"><%= maketext('First Name') %></th>
+					<th id="last_name_header"><%= maketext('Last Name') %></th>
+					<th id="email_address_header"><%= maketext('Email Address') %></th>
+					<th id="student_id_header"><%= maketext('Student ID') %></th>
+					<th id="status_header"><%= maketext('Enrollment Status') %></th>
+					<th id="section_header"><%= maketext('Section') %></th>
+					<th id="recitation_header"><%= maketext('Recitation') %></th>
+					<th id="comment_header"><%= maketext('Comment') %></th>
+					<th id="permission_header"><%= maketext('Permission Level') %></th>
 				</tr>
-			% }
+			</thead>
+			<tbody class="table-group-divider">
+				% for (1 .. $numberOfStudents) {
+					<tr>
+						<td>
+							% param("new_user_id_$_", undef);
+							<%= text_field "new_user_id_$_" => '', size => '10', 'aria-labelledby' => 'user_id_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("first_name_$_", undef);
+							<%= text_field "first_name_$_" => '', size => '10',
+								'aria-labelledby' => 'first_name_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("last_name_$_", undef);
+							<%= text_field "last_name_$_" => '', size => '10', 'aria-labelledby' => 'last_name_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("email_address_$_", undef);
+							<%= text_field "email_address_$_" => '', 'aria-labelledby' => 'email_address_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("student_id_$_", undef);
+							<%= text_field "student_id_$_" => '', size => '16',
+								'aria-labelledby' => 'student_id_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("status_$_", undef);
+							<%= select_field "status_$_" => $statusValues, 'aria-labelledby' => 'status_header',
+							class => 'form-select form-select-sm w-auto flex-grow-0' =%>
+						</td>
+						<td>
+							% param("section_$_", undef);
+							<%= text_field "section_$_" => '', size => '4', 'aria-labelledby' => 'section_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("recitation_$_", undef);
+							<%= text_field "recitation_$_" => '', size => '4', 'aria-labelledby' => 'recitation_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("comment_$_", undef);
+							<%= text_field "comment_$_" => '', 'aria-labelledby' => 'comment_header',
+								class => 'form-control form-control-sm w-auto' =%>
+						</td>
+						<td>
+							% param("permission_$_", undef);
+							<%= select_field "permission_$_" => $permissionValues,
+							'aria-labelledby' => 'permission_header',
+							class => 'form-select form-select-sm w-auto flex-grow-0' =%>
+						</td>
+					</tr>
+				% }
+			</tbody>
 		</table>
 	</div>
 	<p class="my-2"><%= maketext('Select sets below to assign them to the newly-created users.') %></p>


### PR DESCRIPTION
That is the same fields are shown in the same order on the "add user" page as on the "edit user" page.  This means that "status" and "permission" can now be set when a user is created, instead of needing to first create a user, and then edit the user to set those.

The defaults in the status and permission dropdowns that are selected are the defaults from the course environment.  This means that if those are not changed, the behavior will be the same as before.

The order being different on this page than on the "add user" page and the general user list page has always annoyed me, and is in my opinion quite confusing to new webwork users.  Old webwork users will need to adapt to the new order of course.

Note that this is related to (and part of) discussion #1785.  I want to also deal with the password which is the main point of that discussion.  What I would like to do is have the password be another field that is shown on both the add user and edit user(s) pages, and remove the "Password" tab from the main "Accounts Manager" page.  This is not hard to do, but to do it easily in this way would mean dropping the behavior of setting the default password to being the student id.