### PR TITLE
Remove instructions about moving the admin course after creation.

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -68,14 +68,9 @@ $server_root_url   = '';
 # Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
 $webwork_server_admin_email = '';
 
-# The following is the name of the admin course where admin level users can  create
+# The following is the name of the admin course where admin level users can create
 # courses, delete courses, and more. It is named 'admin' by default but for security,
-# you may want to change to something that cannot be guessed. While installing WeBWorK,
-# leave this as 'admin'. Once everything is running well, use the 'admin' course to
-# create a new course to serve as the admin course. You may need to copy all archives
-# from the 'admin' course into this new course. Then change $admin_course_id to the ID
-# of the new course and restart webwork2. You may then also want to archive and delete
-# the original 'admin' course.
+# you may want to change to something that cannot be guessed.
 $admin_course_id = 'admin';
 
 # When new courses are created using the admin course, this setting controls


### PR DESCRIPTION
It seems easier to just create the admin course with the desired name.  The 2.19 installation instructions on the wiki now say to do it this way as well.