### PR TITLE
Make the current tab on the course config page remain active when saving.

### DIFF
--- a/htdocs/js/Config/config.js
+++ b/htdocs/js/Config/config.js
@@ -4,6 +4,7 @@
 
 	const elementInitialValues = [];
 	for (const element of configForm.elements) {
+		if (element.name === 'current_tab') continue;
 		elementInitialValues.push([element, element.type === 'checkbox' ? element.checked : element.value]);
 	}
 
@@ -18,4 +19,10 @@
 	};
 
 	configForm.addEventListener('submit', () => (window.onbeforeunload = null));
+
+	if (configForm.current_tab) {
+		document.querySelectorAll('.tab-link').forEach((tabLink) => {
+			tabLink.addEventListener('show.bs.tab', () => (configForm.current_tab.value = tabLink.dataset.tab));
+		});
+	}
 })();

--- a/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Config.pm
@@ -105,7 +105,7 @@ sub pre_header_initialize ($c) {
 			# Redirect back to the instructor config page after saving settings.  After the redirect the now saved
 			# changes will take effect.  This gives the appearance that settings take effect immediately after saving.
 			$c->authen->flash(status_message => $c->{status_message}->join(''));
-			$c->reply_with_redirect($c->systemLink($c->url_for('instructor_config')));
+			$c->reply_with_redirect($c->systemLink($c->url_for('instructor_config'), params => ['current_tab']));
 		} else {
 			$c->addbadmessage(
 				$c->c(

--- a/templates/ContentGenerator/Instructor/Config.html.ep
+++ b/templates/ContentGenerator/Instructor/Config.html.ep
@@ -21,21 +21,27 @@
 <%= form_for current_route, method => 'POST', id => 'config-form', name => 'config-form', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	%
+	% param('current_tab', 'General') unless param('current_tab');
+	<%= hidden_field current_tab => param('current_tab') =%>
 	% for my $configSection (@$configValues) {
 		% my $sectionName = shift @$configSection;
 		% my $id          = lc($sectionName =~ s|[/ ]|-|gr);
 		%
 		% content_for config_tabs => begin
-			<button type="button" class="nav-link<%= $sectionName eq 'General' ? ' active' : '' %>" id="<%= $id %>-tab"
-				data-bs-toggle="tab" data-bs-target="#<%= $id %>" role="tab" aria-controls="<%= $id %>"
-				aria-selected="<%= $sectionName eq 'General' ? 'true' : 'false' %>">
-				<%= maketext($sectionName) =%>
-			</button>
+			<%= tag 'button',
+				type            => 'button',
+				id              => "$id-tab",
+				class           => 'tab-link nav-link' . ($sectionName eq param('current_tab') ? ' active' : ''),
+				role            => 'tab',
+				'aria-controls' => $id,
+				'aria-selected' => $sectionName eq param('current_tab') ? 'true' : 'false',
+				data            => { bs_toggle => 'tab', bs_target => "#$id", tab => $sectionName },
+				maketext($sectionName) =%>
 		% end
 		%
 		% content_for config_tabs_content => begin
-			<div class="tab-pane fade show<%= $sectionName eq 'General' ? ' active' : '' %>" id="<%= $id %>"
-				role="tabpanel" aria-labelledby="<%= $id %>-tab" tabindex="0">
+			<div class="tab-pane fade show<%= $sectionName eq param('current_tab') ? ' active' : '' %>"
+				id="<%= $id %>" role="tabpanel" aria-labelledby="<%= $id %>-tab" tabindex="0">
 				<h2><b><%= maketext($sectionName) %></b></h2>
 				<div class="table-responsive">
 					<table class="table table-bordered align-middle">


### PR DESCRIPTION
This was requested by @Alex-Jordan in https://github.com/openwebwork/webwork2/pull/2393#issuecomment-2184166316.