### PR TITLE
Make the "Assignments (Course Home)" link always available for LTI content item selection.

### DIFF
--- a/templates/ContentGenerator/LTI/content_item_selection.html.ep
+++ b/templates/ContentGenerator/LTI/content_item_selection.html.ep
@@ -21,13 +21,11 @@
 			% for (keys %$forwardParams) {
 				<%= hidden_field $_ => $forwardParams->{$_} =%>
 			% }
-			% if ($c->ce->{LTIGradeMode} ne 'homework') {
-				<div class="form-check mb-3">
-					<%= check_box course_home_link => 1, id => 'course_home_link', class => 'form-check-input' =%>
-					<%= label_for course_home_link => maketext('Assignments (Course Home)'),
-						class => 'form-check-label' =%>
-				</div>
-			% }
+			<div class="form-check mb-3">
+				<%= check_box course_home_link => 1, id => 'course_home_link', class => 'form-check-input' =%>
+				<%= label_for course_home_link => maketext('Assignments (Course Home)'),
+					class => 'form-check-label' =%>
+			</div>
 			<fieldset class="mb-3">
 				<legend><%= maketext('Visible Sets') %></legend>
 				% if ($acceptMultiple) {


### PR DESCRIPTION
Leave the decision to the instructor regardless of the LTIGradeMode setting.