### PR TITLE
Update the docker build to Ubuntu 24.04.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # We need to change FROM before setting the ENV variables.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 ENV WEBWORK_URL=/webwork2 \
 	WEBWORK_ROOT_URL=http://localhost::8080 \
@@ -110,8 +110,6 @@ RUN apt-get update \
 	libjson-perl \
 	libjson-xs-perl \
 	liblocale-maketext-lexicon-perl \
-	libmail-sender-perl \
-	libmail-sender-perl \
 	libmariadb-dev \
 	libmath-random-secure-perl \
 	libmime-base32-perl \
@@ -120,6 +118,7 @@ RUN apt-get update \
 	libminion-perl \
 	libmodule-build-perl \
 	libmodule-pluggable-perl \
+	libmojolicious-perl \
 	libmojolicious-plugin-renderfile-perl \
 	libnet-https-nb-perl \
 	libnet-ip-perl \
@@ -189,8 +188,6 @@ RUN apt-get update \
 RUN cpanm install -n \
 	Statistics::R::IO \
 	DBD::MariaDB \
-	Mojolicious \
-	Mojo::SQLite@3.002 \
 	Perl::Tidy@20220613 \
 	Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*
@@ -219,7 +216,6 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 # 7. Apply patches
 
 # Patch files that are applied below
-COPY docker-config/imagemagick-allow-pdf-read.patch /tmp
 COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
 
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
@@ -237,8 +233,6 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 		&& npm install \
 	&& cd $PG_ROOT/htdocs \
 		&& npm install \
-	&& patch -p1 -d / < /tmp/imagemagick-allow-pdf-read.patch \
-	&& rm /tmp/imagemagick-allow-pdf-read.patch \
 	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
 	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
 

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -1,7 +1,7 @@
 # This is the Stage 1 Dockerfile, which builds a base OS image (webwork-base)
 # on top of which the WeBWorK parts will be installed by the Stage 2 Dockerfile.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.04
 
 # ==================================================================
 # Phase 1 - Set base OS image install stage ENV variables
@@ -72,8 +72,6 @@ RUN apt-get update \
 	libjson-perl \
 	libjson-xs-perl \
 	liblocale-maketext-lexicon-perl \
-	libmail-sender-perl \
-	libmail-sender-perl \
 	libmariadb-dev \
 	libmath-random-secure-perl \
 	libmime-base32-perl \
@@ -82,6 +80,7 @@ RUN apt-get update \
 	libminion-perl \
 	libmodule-build-perl \
 	libmodule-pluggable-perl \
+	libmojolicious-perl \
 	libmojolicious-plugin-renderfile-perl \
 	libnet-https-nb-perl \
 	libnet-ip-perl \
@@ -151,8 +150,6 @@ RUN apt-get update \
 RUN cpanm install -n \
 	Statistics::R::IO \
 	DBD::MariaDB \
-	Mojolicious \
-	Mojo::SQLite@3.002 \
 	Perl::Tidy@20220613 \
 	Archive::Zip::SimpleZip \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -33,7 +33,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # We need to change FROM before setting the ENV variables.
 
-FROM webwork-base:forWW218
+FROM webwork-base:forWW219
 
 ENV WEBWORK_URL=/webwork2 \
 	WEBWORK_ROOT_URL=http://localhost::8080 \
@@ -74,7 +74,6 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 # 7. Apply patches
 
 # Patch files that are applied below
-COPY docker-config/imagemagick-allow-pdf-read.patch /tmp
 COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
 
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
@@ -92,8 +91,6 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 		&& npm install \
 	&& cd $PG_ROOT/htdocs \
 		&& npm install \
-	&& patch -p1 -d / < /tmp/imagemagick-allow-pdf-read.patch \
-	&& rm /tmp/imagemagick-allow-pdf-read.patch \
 	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
 	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
 

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -97,7 +97,7 @@ services:
       # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
       dockerfile: DockerfileStage2
       # For the 2 stage build process run
-      #     docker build --tag webwork-base:forWW218 -f DockerfileStage1 .
+      #     docker build --tag webwork-base:forWW219 -f DockerfileStage1 .
       # and then
       #     docker-compose build
       # When rebuilding to get updated images add the "--no-cache" option to both commands.


### PR DESCRIPTION
Note that the imagemagick-allow-pdf-read.patch is no longer needed. Ubuntu 24.04 allows PDF read rights by default.  The reason this restriction was previously applied was due to a security vulnerability in ghostscript.  That vulnerability has long been fixed (even for Ubuntu 22.04 although the policy was not updated).  The patch is left in the repository for Ubuntu 22.04 users.

Also, the Mojo::SQLite version downgrade is not needed anymore with the version of Mojo::SQLite in Ubuntu 24.04.