### PR TITLE
Delete an LTI course map entry for a course if that course is deleted.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -762,6 +762,9 @@ sub deleteCourse {
 	my $create_db_result = $db->delete_tables;
 	die "$courseID: course database deletion failed.\n" unless $create_db_result;
 
+	# If this course has an entry in the LTI course map, then delete it also.
+	$db->deleteLTICourseMapWhere({ course_id => $courseID });
+
 	##### step 2: delete course directory structure #####
 
 	my @courseDirNames = sort { $courseDirs{$a} cmp $courseDirs{$b} } keys %courseDirs;


### PR DESCRIPTION
Currently if a course is deleted the entry in the lti_course_map table for that course is left in the database, and the course is still listed on the "Manage LTI Course Map" page in the admin course.  Furthermore, you can no longer change the context id for that course on that page due to the protections of the form that only allow working with an actual course.  This can cause issues with LTI authentication if an LMS course with that context id tries to use content selection.