### PR TITLE
Add username and password option for SMTP authentication

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -42,6 +42,16 @@ include("VERSION");  # get WW version
 # Mail Settings
 ################################################################################
 
+# $generic_sender_name will be used as the "From:" name on all feedback emails
+# sent without a defined user.
+$generic_sender_name = '';
+
+# The following variables will override the "From:" address in messages sent by
+# the named feature.
+$feedback_sender_email = ''; # For student feedback
+$instructor_sender_email = ''; # For instructors emailing students
+$jitar_sender_email = ''; # For notifications of incomplete JiTaR sets
+
 # By default, feedback is sent to all users who have permission to
 # receive_feedback in a course. If this list is non-empty, feedback is also sent
 # to the addresses specified here.

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -38,6 +38,24 @@
 # Additional mail settings in defaults.config can be overridden here
 ################################################################################
 
+# $generic_sender_name will be used as the "From:" name on all feedback emails
+# sent without a defined user.
+
+$generic_sender_name = '';
+
+# The following variables will override the "From:" address in messages sent by
+# the named feature.
+# When one of these is set, all messages sent by that feature will use the
+# supplied email address as the "From:" address, and the address of the relevant
+# user will be set as the "Reply-to:" address for the message.
+# These may be required if you have provided an SMTP username and password in
+# site.conf.  They can also be used to improve email verification and avoid
+# messages getting filtered as spam.
+
+$feedback_sender_email = ''; # For student feedback
+$instructor_sender_email = ''; # For instructors emailing students
+$jitar_sender_email = ''; # For notifications of incomplete JiTaR sets
+
 # By default, feedback is sent to all users who have permission to
 # receive_feedback in a course. If this list is non-empty, feedback is also sent
 # to the addresses specified here.

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -242,17 +242,9 @@ $webwork_courses_dir = "/opt/webwork/courses"; # a typical place to put course d
 # otherwise type the name of your School's outgoing email server.
 $mail{smtpServer} = '';  # e.g. 'mail.yourschool.edu' or 'localhost'
 
-# When connecting to the above server, WeBWorK will send this address in the
-# MAIL FROM command. This has nothing to do with the "From" address on the mail
-# message. It can really be anything, but some mail servers require it contain
-# a valid mail domain, or at least be well-formed.
-$mail{smtpSender} = '';  # e.g.  'webwork@yourserver.yourschool.edu'
-# Be sure to use single quotes for the address or the @ sign will be interpreted as an array.
-
 $mail{set_return_path} = ''; #sets the return_path to the From: field (sender's email address)
 # The return path is used to send error messages about bounced emails
 # "noreply\@$mail{smtpServer}" discards error messages,
-# using $mail{smtpSender} would deliver error messages to that address.
 # The default setting should be adjusted for local domain
 # Leaving the return path blank triggers the default which results in Return-Path  being set to the email of the sender.
 
@@ -262,7 +254,6 @@ $mail{set_return_path} = ''; #sets the return_path to the From: field (sender's 
 # set it to 5 for testing, 30 or larger for production
 
 $mail{smtpTimeout}           = 30;
-
 
 # TLS is a method for providing secure connections to the smtp server.
 # https://en.wikipedia.org/wiki/Transport_Layer_Security

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -237,10 +237,9 @@ $webwork_courses_dir = "/opt/webwork/courses"; # a typical place to put course d
 # The following directives need to be configured in order for your webwork
 # server to be able to send mail.
 
-# Mail sent by the PG system and the mail merge and feedback modules will be
-# sent via this SMTP server.  localhost may work if your server is capable
-# of sending email, otherwise type the name of your School's outgoing email
-# server.
+# Mail sent by the mail merge and feedback modules will be sent via this SMTP
+# server.  localhost may work if your server is capable of sending email,
+# otherwise type the name of your School's outgoing email server.
 $mail{smtpServer} = '';  # e.g. 'mail.yourschool.edu' or 'localhost'
 
 # When connecting to the above server, WeBWorK will send this address in the

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -256,7 +256,6 @@ $mail{set_return_path} = ''; #sets the return_path to the From: field (sender's 
 # using $mail{smtpSender} would deliver error messages to that address.
 # The default setting should be adjusted for local domain
 # Leaving the return path blank triggers the default which results in Return-Path  being set to the email of the sender.
-#
 
 # Seconds to wait before timing out when connecting to the SMTP server.
 #  the default is 120 seconds.
@@ -268,28 +267,40 @@ $mail{smtpTimeout}           = 30;
 
 # TLS is a method for providing secure connections to the smtp server.
 # https://en.wikipedia.org/wiki/Transport_Layer_Security
-# At some sites coordinating the certificates properly is tricky
-# Set this value to 0 to avoid checking certificates.
-# Set it to 0 to trouble shoot an inability to verify certificates with the smtp server
+# Allowed values: 'starttls', 'ssl', 'maybestarttls', 0
+# Values of 'maybestarttls' and 0 are insecure and are not recommended for
+# production environments, except where the smtp server is localhost.
 
 $mail{tls_allowed} = 0;
 
-#$tls_allowed=0;  #old method -- this variable no longer works.
+# Extra settings for SSL/TLS
+# You may need to use this setting if your SMTP server uses a self-signed certificate.
+# SSL_verify_mode => 0 is not recommended for production environments for security
+# reasons.  See https://metacpan.org/pod/IO::Socket::SSL#Common-Usage-Errors
 
+#$mail{smtpSSLOptions} = {SSL_verify_mode => 0};
 
 # errors of the form
-#  unable to establish SMTP connection to smtp-gw.rochester.edu port 465
-# indicate that there is a mismatch between the port number and the use of ssl
-# use port 25 when ssl is off and use port 465 when ssl is on (tls_allowed=1)
+# "unable to establish SMTP connection to smtp-gw.rochester.edu port 465"
+# indicate that there may be a mismatch between the port number and the use of ssl.
+# Many mail servers use port 25 when ssl is off, use port 465 when ssl is on (tls_allowed='ssl'),
+# and use port 587 when starttls is used (tls_allowed='starttls').
 
 
-# Set the SMTP port manually.  Typically this does not need to be done it will use
-# port 25 if no SSL is on and 465 if ssl is on
+# Set the SMTP port manually.  Typically this does not need to be done. It will use
+# port 25 if insecure, and 465 if ssl is on
 
 #$mail{smtpPort} = 25;
 
 # Debugging tutorial for sending email using ssl/tls
 # https://maulwuff.de/research/ssl-debugging.html
+
+# SMTP Authentication
+# If your SMTP server requires authentication you can provide the username and password
+# for the account on the mail server
+
+#$mail{smtpUsername} = '';
+#$mail{smtpPassword} = '';
 
 # Set maxAttachmentSize to the maximum number of megabytes to allow for the size of
 # files attached to feedback emails.  Note that this should be set to match the

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -287,7 +287,11 @@ $mail{tls_allowed} = 0;
 
 # SMTP Authentication
 # If your SMTP server requires authentication you can provide the username and password
-# for the account on the mail server
+# for the account on the mail server.
+# If you set these credentials, you may need to define the variables $feedback_sender_email,
+# $instructor_sender_email and $jitar_sender_email in localOverrides.conf, as some SMTP
+# servers require the "From:" address of outgoing emails to match this username.  Setting
+# those sender variables will then put the user's email address in the "Reply-to:" field.
 
 #$mail{smtpUsername} = '';
 #$mail{smtpPassword} = '';

--- a/courses.dist/modelCourse/templates/email/welcome.msg
+++ b/courses.dist/modelCourse/templates/email/welcome.msg
@@ -1,6 +1,7 @@
 ##  template for a Welcome message to be emailed to class (delete this line)
+## Note that the From: address will be replaced by the email address of the account
+## from which the message is sent.
 From: teacher@somewhere.edu (Jan Teacher)
-Reply-To: teacher@somewhere.edu
 Subject: online homework for Math 123
 Message:
     Hi $FN,

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -79,17 +79,13 @@ sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
 			$mail_data->{merge_data}
 		);
 
-		my $email;
+		my $email = Email::Stuffer->to($user_record->email_address)->subject($mail_data->{subject})->text_body($msg)
+			->header('X-Remote-Host' => $mail_data->{remote_host});
 		if ($ce->{instructor_sender_email}) {
-			$email =
-				Email::Stuffer->to($user_record->email_address)
-				->from($mail_data->{from_name} . ' <' . $ce->{instructor_sender_email} . '>')
-				->reply_to($mail_data->{from})->subject($mail_data->{subject})->text_body($msg)
-				->header('X-Remote-Host' => $mail_data->{remote_host});
+			$email->from($mail_data->{from_name} . ' <' . $ce->{instructor_sender_email} . '>')
+				->reply_to($mail_data->{from});
 		} else {
-			$email =
-				Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})
-				->subject($mail_data->{subject})->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+			$email->from($mail_data->{from});
 		}
 
 		eval {

--- a/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/SendInstructorEmail.pm
@@ -79,9 +79,18 @@ sub mail_message_to_recipients ($job, $ce, $db, $mail_data) {
 			$mail_data->{merge_data}
 		);
 
-		my $email =
-			Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})->subject($mail_data->{subject})
-			->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+		my $email;
+		if ($ce->{instructor_sender_email}) {
+			$email =
+				Email::Stuffer->to($user_record->email_address)
+				->from($mail_data->{from_name} . ' <' . $ce->{instructor_sender_email} . '>')
+				->reply_to($mail_data->{from})->subject($mail_data->{subject})->text_body($msg)
+				->header('X-Remote-Host' => $mail_data->{remote_host});
+		} else {
+			$email =
+				Email::Stuffer->to($user_record->email_address)->from($mail_data->{from})
+				->subject($mail_data->{subject})->text_body($msg)->header('X-Remote-Host' => $mail_data->{remote_host});
+		}
 
 		eval {
 			$email->send_or_die({

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -185,10 +185,17 @@ $emailableURL
 			$msg .= "***** Data about the environment: *****\n\n" . Dumper($ce) . "\n\n";
 		}
 
-		my $email =
-			Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg)
-			->header('X-Remote-Host' => $remote_host);
-
+		my $from_name = $user ? $user->full_name : $ce->{generic_sender_name};
+		my $email;
+		if ($ce->{feedback_sender_email}) {
+			$email =
+				Email::Stuffer->to(join(',', @recipients))->from("$from_name <$ce->{feedback_sender_email}>")
+				->reply_to($sender)->subject($subject)->text_body($msg)->header('X-Remote-Host' => $remote_host);
+		} else {
+			$email =
+				Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg)
+				->header('X-Remote-Host' => $remote_host);
+		}
 		# Extra headers
 		$email->header('X-WeBWorK-Route',  $route)    if defined $route;
 		$email->header('X-WeBWorK-Course', $courseID) if defined $courseID;

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -186,15 +186,12 @@ $emailableURL
 		}
 
 		my $from_name = $user ? $user->full_name : $ce->{generic_sender_name};
-		my $email;
+		my $email     = Email::Stuffer->to(join(',', @recipients))->subject($subject)->text_body($msg)
+			->header('X-Remote-Host' => $remote_host);
 		if ($ce->{feedback_sender_email}) {
-			$email =
-				Email::Stuffer->to(join(',', @recipients))->from("$from_name <$ce->{feedback_sender_email}>")
-				->reply_to($sender)->subject($subject)->text_body($msg)->header('X-Remote-Host' => $remote_host);
+			$email->from("$from_name <$ce->{feedback_sender_email}>")->reply_to($sender);
 		} else {
-			$email =
-				Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg)
-				->header('X-Remote-Host' => $remote_host);
+			$email->from($sender);
 		}
 		# Extra headers
 		$email->header('X-WeBWorK-Route',  $route)    if defined $route;

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -329,7 +329,10 @@ sub createEmailSenderTransportSMTP ($ce) {
 	return Email::Sender::Transport::SMTP->new({
 		host => $ce->{mail}{smtpServer},
 		ssl  => $ce->{mail}{tls_allowed} // 0,
-		defined $ce->{mail}->{smtpPort} ? (port => $ce->{mail}{smtpPort}) : (),
+		defined $ce->{mail}->{smtpPort}       ? (port          => $ce->{mail}{smtpPort})       : (),
+		defined $ce->{mail}->{smtpUsername}   ? (sasl_username => $ce->{mail}{smtpUsername})   : (),
+		defined $ce->{mail}->{smtpPassword}   ? (sasl_password => $ce->{mail}{smtpPassword})   : (),
+		defined $ce->{mail}->{smtpSSLOptions} ? (ssl_options   => $ce->{mail}{smtpSSLOptions}) : (),
 		timeout => $ce->{mail}{smtpTimeout},
 	});
 }

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -464,7 +464,13 @@ Recitation: $recitation
 Comment:    $comment
 /;
 
-	my $email = Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg);
+	my $email;
+	if ($ce->{jitar_sender_email}) {
+		$email = Email::Stuffer->to(join(',', @recipients))->from("$full_name <$ce->{jitar_sender_email}>")
+			->reply_to($sender)->subject($subject)->text_body($msg);
+	} else {
+		$email = Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg);
+	}
 
 	# Extra headers
 	$email->header('X-WeBWorK-Course: ', $courseID) if defined $courseID;

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -464,12 +464,11 @@ Recitation: $recitation
 Comment:    $comment
 /;
 
-	my $email;
+	my $email = Email::Stuffer->to(join(',', @recipients))->subject($subject)->text_body($msg);
 	if ($ce->{jitar_sender_email}) {
-		$email = Email::Stuffer->to(join(',', @recipients))->from("$full_name <$ce->{jitar_sender_email}>")
-			->reply_to($sender)->subject($subject)->text_body($msg);
+		$email->from("$full_name <$ce->{jitar_sender_email}>")->reply_to($sender);
 	} else {
-		$email = Email::Stuffer->to(join(',', @recipients))->from($sender)->subject($subject)->text_body($msg);
+		$email->from($sender);
 	}
 
 	# Extra headers

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -34,15 +34,7 @@
 						<%= label_for from => maketext('From:'),
 							class => 'col-sm-3 col-form-label col-form-label-sm' =%>
 						<div class="col-sm-9">
-							<%= text_field from => $c->{from}, id => 'from',
-								class => 'form-control form-control-sm' =%>
-						</div>
-					</div>
-					<div class="row mb-1">
-						<%= label_for replyTo => maketext('Reply-To:'),
-							class => 'col-sm-3 col-form-label col-form-label-sm' =%>
-						<div class="col-sm-9">
-							<%= text_field replyTo => $c->{replyTo}, id => 'replyTo',
+							<%= text_field from => $c->{from}, id => 'from', readonly => undef, disabled => undef,
 								class => 'form-control form-control-sm' =%>
 						</div>
 					</div>


### PR DESCRIPTION
This adds the ability to set a username and password for authentication with the SMTP server.

It also adds the ability to set `ssl_options` when creating the `Email::Sender::Transport::SMTP` object, which is necessary if the SMTP server uses a self-signed certificate.

I have tested this with our institutional SMTP server, and with smtp.gmail.com.  The only way I was able to authenticate to smtp.gmail.com was to create an app password for a gmail account that has 2FA enabled.

The gmail smtp server overwrites the "from" address in the message with the address of the user that authenticated.  My smtp server will only accept messages where the "from" address in the message matches the user that authenticated, so this PR won't be very useful without some implementation of setting "reply-to" addresses on messages, as discussed in #2383.  I can either add that to this PR or start a new PR for that.