### PR TITLE
when grade passback only happens on mass update intervals, let studen…

### DIFF
--- a/conf/authen_LTI_1_1.conf.dist
+++ b/conf/authen_LTI_1_1.conf.dist
@@ -7,8 +7,11 @@
 
 # This is a string that is used to name the LMS for end users, for example in a message telling
 # users to sign in through their LMS.
-$LTI{v1p1}{LMS_name} = 'e.g., Blackboard, Canvas, Moodle, etc.';
-#$LTI{v1p1}{LMS_name} = 'Desire2Learn';
+$LTI{v1p1}{LMS_name} = 'the LMS';
+#$LTI{v1p1}{LMS_name} = 'Blackboard';
+#$LTI{v1p1}{LMS_name} = 'Canvas';
+#$LTI{v1p1}{LMS_name} = 'D2L Brightspace';
+#$LTI{v1p1}{LMS_name} = 'Moodle';
 
 # This is a URL that should take users to a place they can log in to their LMS.  It will use the
 # text from LMS_name, but use LMS_url as the href.  If LMS_url is empty or undefined, the

--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -7,8 +7,11 @@
 
 # This is a string that is used to name the LMS for end users, for example in a message telling
 # users to sign in through their LMS.
-$LTI{v1p3}{LMS_name} = 'e.g., Blackboard, Canvas, Moodle, etc.';
-#$LTI{v1p3}{LMS_name} = 'Desire2Learn';
+$LTI{v1p3}{LMS_name} = 'the LMS';
+#$LTI{v1p3}{LMS_name} = 'Blackboard';
+#$LTI{v1p3}{LMS_name} = 'Canvas';
+#$LTI{v1p3}{LMS_name} = 'D2L Brightspace';
+#$LTI{v1p3}{LMS_name} = 'Moodle';
 
 # This is a URL that should take users to a place they can log in to their LMS.  It will use the
 # text from LMS_name, but use LMS_url as the href.  If LMS_url is empty or undefined, the

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -248,25 +248,34 @@ async sub process_and_log_answer ($c) {
 					$c->param('startTime', '');
 				}
 
-				my $LTIGradeResult = -1;
-
-				# Try to update the student score on the LMS if that option is enabled.
-				if ($ce->{LTIGradeMode} && $ce->{LTIGradeOnSubmit}) {
-					$LTIGradeResult = 0;
-					my $grader = $ce->{LTI}{ $ce->{LTIVersion} }{grader}->new($c);
-					if ($ce->{LTIGradeMode} eq 'course') {
-						$LTIGradeResult = await $grader->submit_course_grade($problem->user_id);
-					} elsif ($ce->{LTIGradeMode} eq 'homework') {
-						$LTIGradeResult = await $grader->submit_set_grade($problem->user_id, $problem->set_id);
+				# Messages about passing the score back to the LMS
+				if ($ce->{LTIGradeMode}) {
+					my $LMSname        = $ce->{LTI}{ $ce->{LTIVersion} }{LMS_name};
+					my $LTIGradeResult = -1;
+					if ($ce->{LTIGradeOnSubmit}) {
+						$LTIGradeResult = 0;
+						my $grader = $ce->{LTI}{ $ce->{LTIVersion} }{grader}->new($c);
+						if ($ce->{LTIGradeMode} eq 'course') {
+							$LTIGradeResult = await $grader->submit_course_grade($problem->user_id);
+						} elsif ($ce->{LTIGradeMode} eq 'homework') {
+							$LTIGradeResult = await $grader->submit_set_grade($problem->user_id, $problem->set_id);
+						}
+						if ($LTIGradeResult == 0) {
+							$scoreRecordedMessage .=
+								$c->tag('br') . $c->maketext('Your score was not successfully sent to [_1].', $LMSname);
+						} elsif ($LTIGradeResult > 0) {
+							$scoreRecordedMessage .=
+								$c->tag('br') . $c->maketext('Your score was successfully sent to [_1].', $LMSname);
+						}
+					} elsif ($ce->{LTIMassUpdateInterval} > 0) {
+						my $massUpdateTime = "$ce->{LTIMassUpdateInterval} seconds";
+						$massUpdateTime = int($ce->{LTIMassUpdateInterval} / 60 + 0.99) . " minutes"
+							if ($ce->{LTIMassUpdateInterval} >= 120);
+						$massUpdateTime = int($ce->{LTIMassUpdateInterval} / 36000 + 0.9999) . " hours"
+							if ($ce->{LTIMassUpdateInterval} >= 7200);
+						$scoreRecordedMessage .= $c->tag('br')
+							. $c->maketext('Scores are sent to [_1] every [_2].', $LMSname, $massUpdateTime);
 					}
-				}
-
-				if ($LTIGradeResult == 0) {
-					$scoreRecordedMessage .=
-						$c->tag('br') . $c->maketext('Your score was not successfully sent to the LMS.');
-				} elsif ($LTIGradeResult > 0) {
-					$scoreRecordedMessage .=
-						$c->tag('br') . $c->maketext('Your score was successfully sent to the LMS.');
 				}
 			} else {
 				# The "sticky" answers get saved here when $will{recordAnswers} is false

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -268,13 +268,17 @@ async sub process_and_log_answer ($c) {
 								$c->tag('br') . $c->maketext('Your score was successfully sent to [_1].', $LMSname);
 						}
 					} elsif ($ce->{LTIMassUpdateInterval} > 0) {
-						my $massUpdateTime = "$ce->{LTIMassUpdateInterval} seconds";
-						$massUpdateTime = int($ce->{LTIMassUpdateInterval} / 60 + 0.99) . " minutes"
-							if ($ce->{LTIMassUpdateInterval} >= 120);
-						$massUpdateTime = int($ce->{LTIMassUpdateInterval} / 36000 + 0.9999) . " hours"
-							if ($ce->{LTIMassUpdateInterval} >= 7200);
-						$scoreRecordedMessage .= $c->tag('br')
-							. $c->maketext('Scores are sent to [_1] every [_2].', $LMSname, $massUpdateTime);
+						$scoreRecordedMessage .= $c->tag('br');
+						if ($ce->{LTIMassUpdateInterval} < 120) {
+							$scoreRecordedMessage .= $c->maketext('Scores are sent to [_1] every [quant,_2,second].',
+								$LMSname, $ce->{LTIMassUpdateInterval});
+						} elsif ($ce->{LTIMassUpdateInterval} < 7200) {
+							$scoreRecordedMessage .= $c->maketext('Scores are sent to [_1] every [quant,_2,minute].',
+								$LMSname, int($ce->{LTIMassUpdateInterval} / 60 + 0.99));
+						} else {
+							$scoreRecordedMessage .= $c->maketext('Scores are sent to [_1] every [quant,_2,hour].',
+								$LMSname, int($ce->{LTIMassUpdateInterval} / 36000 + 0.9999));
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
…ts know

This is mainly so that when there is an LTI grade passback mode (`course or homework`) but `$LTIGradeOnSubmit` is false, there will be a message about how frequently grades are updated. 

We have `$LTIGradeOnSubmit` false because for some students, having this true leads to D2L pinging them through their phone every time they submit a correct answer. But then I have been getting many messages from students this term who think something is broken because their grade in D2L is not matching the WW grade. (They just haven't waited the hour that we have `$LTIMassUpdateInterval` set to.)

This message will only help so much, since many students won't read it. But it is something.