### PR TITLE
Replace narrow no-break spaces in dates with regular spaces for PG.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -996,7 +996,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 		if ($MergedSet->{$_}) {
 			print $FH '\\def\\webwork'
 				. underscore_to_camel($_) . '{'
-				. $c->formatDateTime($MergedSet->{$_}, $ce->{studentDateDisplayFormat}) . "}%\n";
+				. ($c->formatDateTime($MergedSet->{$_}, $ce->{studentDateDisplayFormat}) =~ s/\x{202f}/ /gr) . "}%\n";
 		}
 	}
 	# Leave reduced scoring date blank if it is disabled, or enabled but on (or somehow later) than the close date
@@ -1006,7 +1006,9 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 		&& $MergedSet->{reduced_scoring_date} < $MergedSet->{due_date})
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
-			. $c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) . "}%\n";
+			. ($c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) =~
+				s/\x{202f}/ /gr)
+			. "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -90,7 +90,7 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 			$ce->{studentDateDisplayFormat},
 			$ce->{siteDefaults}{timezone},
 			$ce->{language}
-		);
+		) =~ s/\x{202f}/ /gr;
 		my $uc_date = ucfirst($date);
 		for (
 			[ 'DayOfWeek',       '%A' ],
@@ -111,14 +111,15 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 			)
 		{
 			$options{"$uc_date$_->[0]"} =
-				formatDateTime($options{$date}, $_->[1], $ce->{siteDefaults}{timezone}, $ce->{language});
+				formatDateTime($options{$date}, $_->[1], $ce->{siteDefaults}{timezone}, $ce->{language}) =~
+				s/\x{202f}/ /gr;
 		}
 	}
 	$options{reducedScoringDate}          = $set->reduced_scoring_date;
 	$options{formattedReducedScoringDate} = formatDateTime(
 		$options{reducedScoringDate},  $ce->{studentDateDisplayFormat},
 		$ce->{siteDefaults}{timezone}, $ce->{language}
-	);
+	) =~ s/\x{202f}/ /gr;
 
 	# State Information
 	$options{numOfAttempts} =


### PR DESCRIPTION
This is done for the dates explicitly passed to hardcopy in Hardcopy.pm as well as the dates passed to PG in general in Rendering.pm.

The DateTime::Locale package now uses a narrow no-break space in many of its en-US date time formats.  This fixes those characters breaking hardcopy without requiring a downgrade of the DateTime::Locale package.

A better solution will eventually be needed.  Perhaps now it is time to consider switching to XeTeX or LuaTeX which can handle UTF-8 characters, and droppping support for PDFLaTeX?