### PR TITLE
case insensitive sorting by name

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -177,6 +177,8 @@ sub sortByName ($field, @items) {
 	}
 
 	my @sKeys = sort {
+		return $a cmp $b if (uc($a) eq uc($b));
+
 		my @aParts = split m/(?<=\D)(?=\d)|(?<=\d)(?=\D)/, $a;
 		my @bParts = split m/(?<=\D)(?=\d)|(?<=\d)(?=\D)/, $b;
 
@@ -195,8 +197,8 @@ sub sortByName ($field, @items) {
 				next if $aPart == $bPart;    # check next pair
 				return $aPart <=> $bPart;    # compare numerically
 			} else {
-				next if $aPart eq $bPart;    # check next pair
-				return $aPart cmp $bPart;    # compare lexicographically
+				next if uc($aPart) eq uc($bPart);    # check next pair
+				return uc($aPart) cmp uc($bPart);    # compare alphabetically
 			}
 		}
 		return +1 if @aParts;    # a has more sections, should go second


### PR DESCRIPTION
Various things are currently sorted lexically with capitals before lowercase. This changes sorting to be case-insensitive. So for example in the file manager, what would currently be:

```
Banana.txt
apple.txt
```
would now be:
```
apple.txt
Banana.txt
```

If there is a tie, like `apple.txt` and `AppLE.txt` or `APPLE.TXT`, there may be inconsistent sorting. On a letter by letter basis, it would be easy to say make capitals come before lowercase. But then you end up with things like `Apricot` come before `apple`. I'm not sure how to modify this to put some consistent sorting when the words are a case-insensitive match. If that is a problem, this PR can be closed. But I thought it would be nice to have the File Manager (and other things) finally sort alphabetically instead of a character code based sorting.