### PR TITLE
Switch the default latex variant to xelatex.

### DIFF
--- a/bin/check_latex
+++ b/bin/check_latex
@@ -46,20 +46,20 @@ my $temp_dir = eval { tempdir('check_latex_XXXXXXXX') };
 
 die $@ if $@;
 
-my $pdflatex_cmd =
+my $latex_cmd =
 	"cd $temp_dir && "
 	. "TEXINPUTS=$ENV{WEBWORK_ROOT}/bin:"
 	. shell_quote($ce->{webworkDirs}{assetsTex}) . ':'
 	. shell_quote("$ce->{pg}{directories}{assetsTex}") . ': '
-	. $ce->{externalPrograms}{pdflatex}
+	. $ce->{externalPrograms}{latex2pdf}
 	. ' -interaction nonstopmode check_latex_article.tex > check_latex.nfo 2>&1 &&'
 	. "TEXINPUTS=$ENV{WEBWORK_ROOT}/bin:"
 	. shell_quote($ce->{webworkDirs}{assetsTex}) . ':'
 	. shell_quote("$ce->{pg}{directories}{assetsTex}") . ': '
-	. $ce->{externalPrograms}{pdflatex}
+	. $ce->{externalPrograms}{latex2pdf}
 	. ' -interaction nonstopmode check_latex_exam.tex >> check_latex.nfo 2>&1';
 
-if ((system $pdflatex_cmd) >> 8) {
+if ((system $latex_cmd) >> 8) {
 	if (open(my $fh, '<', "$temp_dir/check_latex.nfo")) {
 		local $/;
 		my $nfo = <$fh>;

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -54,7 +54,7 @@ my @applicationsList = qw(
 	gzip
 	latex
 	pandoc
-	pdflatex
+	xelatex
 	dvipng
 );
 

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -683,8 +683,14 @@ $mail{feedbackRecipients}    = [
 #	'hebrewTwoCol.xml',
 #];
 
-# The Hebrew themes need to use xelatex. Uncomment the following for xelatex
-#$externalPrograms{pdflatex} ="/usr/bin/xelatex --no-shell-escape";
+# xelatex is the default external program used to generate pdf from LaTeX.  It
+# supports unicode characters (needed for multilingual use among other things).
+# Newer versions of DateTime::Locale use a narrow no-break space in US dates.
+# So xelatex is needed even for English.  Note that --no-shell-escape is
+# important for security reasons.  You may be able to use pdflatex instead of
+# xelatex if you have an older version of DateTime::Locale on your system.
+# However, pdflatex does not support unicode characters.
+#$externalPrograms{latex2pdf} = "/usr/bin/pdflatex --no-shell-escape";
 
 # A course may have additional themes in $courseDirs{hardcopyThemes}.  All such
 # "course" hardcopy themes are effectively enabled and offered for use when

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -106,11 +106,16 @@ $externalPrograms{git} = "/usr/bin/git";
 # equation rendering/hardcopy utiltiies
 $externalPrograms{latex}    = "/usr/bin/latex --no-shell-escape";
 
-$externalPrograms{pdflatex} = "/usr/bin/pdflatex --no-shell-escape";
-# Note that --no-shell-escape is important for security reasons.
-# Consider using xelatex instead of pdflatex for multilingual use, and
-# use polyglossia and fontspec packages (which require xelatex or lualatex).
-#$externalPrograms{pdflatex} = "/usr/bin/xelatex --no-shell-escape";
+# xelatex is the default external program used to generate pdf from LaTeX.  It
+# supports unicode characters (needed for multilingual use among other things).
+# Newer versions of DateTime::Locale use a narrow no-break space in US dates. So
+# xelatex is needed even for English.  Note that --no-shell-escape is important
+# for security reasons.
+$externalPrograms{latex2pdf} = "/usr/bin/xelatex --no-shell-escape";
+# You may be able to use pdflatex instead of xelatex if you have an older
+# version of DateTime::Locale on your system.  However, pdflatex does not
+# support unicode characters.
+#$externalPrograms{latex2pdf} = "/usr/bin/pdflatex --no-shell-escape";
 
 $externalPrograms{dvipng}   = "/usr/bin/dvipng";
 

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -187,20 +187,20 @@ sub generate_hardcopy_pdf {
 	my $cwd = path->to_abs;
 	chdir($working_dir);
 
-	# Call pdflatex
-	my $pdflatex_cmd =
+	# Generate the pdf file with the configured LaTeX external command.
+	my $latex_cmd =
 		'TEXINPUTS=.:'
 		. shell_quote($ws->c->ce->{webworkDirs}{assetsTex}) . ':'
 		. shell_quote($ws->c->ce->{pg}{directories}{assetsTex}) . ': '
-		. $ws->c->ce->{externalPrograms}{pdflatex}
-		. ' > pdflatex.stdout 2> pdflatex.stderr hardcopy';
+		. $ws->c->ce->{externalPrograms}{latex2pdf}
+		. ' > latex.stdout 2> latex.stderr hardcopy';
 
-	if (my $rawexit = system $pdflatex_cmd) {
+	if (my $rawexit = system $latex_cmd) {
 		my $exit   = $rawexit >> 8;
 		my $signal = $rawexit & 127;
 		my $core   = $rawexit & 128;
 		push(@$errors,
-			qq{Failed to convert TeX to PDF with command "$pdflatex_cmd" (exit=$exit signal=$signal core=$core).},
+			qq{Failed to convert TeX to PDF with command "$latex_cmd" (exit=$exit signal=$signal core=$core).},
 			q{See the "hardcopy.log" file for details.});
 	}
 

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -761,22 +761,22 @@ sub find_log_first_error ($log) {
 }
 
 sub generate_hardcopy_pdf ($c, $temp_dir_path, $final_file_basename) {
-	# call pdflatex - we don't want to chdir in the mod_perl process, as
+	# call latex - we don't want to chdir in the mod_perl process, as
 	# that might step on the feet of other things (esp. in Apache 2.0)
-	my $pdflatex_cmd = "cd "
+	my $latex_cmd = "cd "
 		. shell_quote($temp_dir_path) . " && "
 		. "TEXINPUTS=.:"
 		. shell_quote($c->ce->{webworkDirs}{assetsTex}) . ':'
 		. shell_quote($c->ce->{pg}{directories}{assetsTex}) . ': '
-		. $c->ce->{externalPrograms}{pdflatex}
-		. " >pdflatex.stdout 2>pdflatex.stderr hardcopy";
-	if (my $rawexit = system $pdflatex_cmd) {
+		. $c->ce->{externalPrograms}{latex2pdf}
+		. " >latex.stdout 2>latex.stderr hardcopy";
+	if (my $rawexit = system $latex_cmd) {
 		my $exit   = $rawexit >> 8;
 		my $signal = $rawexit & 127;
 		my $core   = $rawexit & 128;
 		$c->add_error(
 			'Failed to convert TeX to PDF with command "',
-			$c->tag('code', $pdflatex_cmd),
+			$c->tag('code', $latex_cmd),
 			qq{" (exit=$exit signal=$signal core=$core).}
 		);
 
@@ -823,7 +823,7 @@ sub generate_hardcopy_pdf ($c, $temp_dir_path, $final_file_basename) {
 		$final_file_name = $dest_name;
 	}
 
-	return $final_file_name, qw/hardcopy.tex hardcopy.log hardcopy.aux pdflatex.stdout pdflatex.stderr/;
+	return $final_file_name, qw/hardcopy.tex hardcopy.log hardcopy.aux latex.stdout latex.stderr/;
 }
 
 ################################################################################

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/hardcopy_form.html.ep
@@ -24,7 +24,7 @@
 						'If "PDF" is selected, then a PDF file will be generated for download, unless there are '
 							. 'errors.  If errors occur generating a PDF file or "TeX Source" is selected then a '
 							. 'zip file will be generated for download that contains the TeX source file and '
-							. 'resources needed for generating the PDF file using pdflatex.'
+							. 'resources needed for generating the PDF file using LaTeX.'
 					),
 					bs_placement => 'top',
 					bs_toggle    => 'popover'

--- a/templates/HelpFiles/Hardcopy.html.ep
+++ b/templates/HelpFiles/Hardcopy.html.ep
@@ -54,8 +54,8 @@
 	<%== maketext('Once "Generate Hardcopy for selected sets and selected users" is clicked a file in the selected '
 		. 'hardcopy format will be generated and offered for download. If PDF output was selected, a single PDF file '
 		. 'is generated. If TeX output is selected, a zip file is generated that contains all files needed to '
-		. 'generated the hardcopy PDF file via [_1]. The main TeX file is called [_2].',
-		'<code>pdflatex</code>', '<code>hardcopy.tex</code>') =%>
+		. 'generated the hardcopy PDF file via LaTeX. The main TeX file is called [_2].',
+		'<code>hardcopy.tex</code>') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('Note that if there are errors, they will be shown at the top of the page. '

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -121,7 +121,7 @@
 			. 'can also change the format to "PDF" or "TeX Source". If "PDF" is selected, then a PDF file will be '
 			. 'generated for download, unless there are errors. If errors occur or "TeX Source" is selected, then a '
 			. 'zip file will be generated for download that contains the TeX source file and resources needed for '
-			. 'generating the PDF file using pdflatex.') =%>
+			. 'generating the PDF file using LaTeX.') =%>
 		</p>
 		<p>
 		<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be saved to '


### PR DESCRIPTION
The course environment variable is now `$externalPrograms{latex2pdf}`. This was changed as discussed in the development meeting today because it is odd for it to be named pdflatex if we are not using pdflatex, and furthermore it forces those upgrading to check their configuration and make the change.

Note that a change to PG will also be needed due to the change in the environment variable name.  This is done in https://github.com/openwebwork/pg/pull/1087.