### PR TITLE
Remove dvi2svg from `check_modules.pl`.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -54,7 +54,6 @@ my @applicationsList = qw(
 	gzip
 	latex
 	pandoc
-	pdf2svg
 	pdflatex
 	dvipng
 );


### PR DESCRIPTION
Since the default is now `dvisvgm` only check for that.