### PR TITLE
don't show achievement points when there aren't any

### DIFF
--- a/templates/AchievementEvaluator/cheevoMessage.html.ep
+++ b/templates/AchievementEvaluator/cheevoMessage.html.ep
@@ -16,7 +16,12 @@
 				</div>
 			% } else {
 				<h2><%= $achievement->{name} %></h2>
-				<div><i><%= $achievement->{points} %> Points</i>: <%= $achievement->{description} %></div>
+				<div>
+					% if ($achievement->{points}) {
+						<i><%= $achievement->{points} %> Points</i>:
+					% }
+					<%= $achievement->{description} %>
+				</div>
 			% }
 		</div>
 		<button type="button" class="btn-close me-2 m-auto" data-bs-dismiss="toast" aria-label="Close"></button>


### PR DESCRIPTION
When you earn an achievement, the notification message tells you that you earned so many points along with it. But the achievement might be worth 0 points, or not even have a point value entered. This change will suppress the point display in those situations.