### PR TITLE
adjustments to date extension achievement items

### DIFF
--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -79,7 +79,7 @@ sub use_item ($self, $userName, $c) {
 		my @probIDs = $db->listUserProblems($userName, $setID);
 		for my $probID (@probIDs) {
 			my $problem = $db->getUserProblem($userName, $setID, $probID);
-			$problem->problem_seed($problem->problem_seed + 100);
+			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}
 	}

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -28,7 +28,10 @@ sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDate',
 		name        => x('Tunic of Extension'),
-		description => x('Adds 24 hours to the close date of a homework.')
+		description => x(
+			'Adds 24 hours to the close date of a homework. '
+				. 'This will randomize problem details if used after the original close date.'
+		)
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -79,9 +79,7 @@ sub use_item ($self, $userName, $c) {
 
 	# Change the seed for all of the problems if the set is currently closed.
 	if (after($set->due_date)) {
-		my @probIDs = $db->listUserProblems($userName, $setID);
-		for my $probID (@probIDs) {
-			my $problem = $db->getUserProblem($userName, $setID, $probID);
+		for my $problem ($db->getUserProblemsWhere({ user_id => $userName, set_id => $setID })) {
 			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend a close date by 24 hours.
 
 use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after between);
 use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 use constant ONE_DAY => 86400;

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -37,7 +37,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + ONE_DAY())
+			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + ONE_DAY)
 				&& $sets->[$i]->assignment_type eq 'default');
 	}
 
@@ -85,11 +85,11 @@ sub use_item ($self, $userName, $c) {
 	}
 
 	# Add time to the reduced scoring date if it was defined in the first place
-	$userSet->reduced_scoring_date($set->reduced_scoring_date + ONE_DAY()) if $set->reduced_scoring_date;
+	$userSet->reduced_scoring_date($set->reduced_scoring_date + ONE_DAY) if $set->reduced_scoring_date;
 	# Add time to the close date
-	$userSet->due_date($set->due_date + ONE_DAY());
+	$userSet->due_date($set->due_date + ONE_DAY);
 	# This may require also extending the answer date.
-	$userSet->answer_date($userSet->due_date) if ($userSet->due_date > $set->answer_date);
+	$userSet->answer_date($userSet->due_date) if $userSet->due_date > $set->answer_date;
 	$db->putUserSet($userSet);
 
 	$globalData->{ $self->{id} }--;

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -22,6 +22,8 @@ use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
 use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
+use constant ONE_DAY => 86400;
+
 sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDate',
@@ -35,7 +37,8 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
+			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + ONE_DAY())
+				&& $sets->[$i]->assignment_type eq 'default');
 	}
 
 	return unless @openSets;
@@ -71,10 +74,22 @@ sub use_item ($self, $userName, $c) {
 	my $userSet = $db->getUserSet($userName, $setID);
 	return q{Couldn't find that set!} unless $set && $userSet;
 
-	# Add time to the reduced scoring date, due date, and answer date.
-	$userSet->reduced_scoring_date($set->reduced_scoring_date() + 86400) if $set->reduced_scoring_date;
-	$userSet->due_date($set->due_date() + 86400);
-	$userSet->answer_date($set->answer_date() + 86400);
+	# Change the seed for all of the problems if the set is currently closed.
+	if (after($set->due_date)) {
+		my @probIDs = $db->listUserProblems($userName, $setID);
+		for my $probID (@probIDs) {
+			my $problem = $db->getUserProblem($userName, $setID, $probID);
+			$problem->problem_seed($problem->problem_seed + 100);
+			$db->putUserProblem($problem);
+		}
+	}
+
+	# Add time to the reduced scoring date if it was defined in the first place
+	$userSet->reduced_scoring_date($set->reduced_scoring_date + ONE_DAY()) if $set->reduced_scoring_date;
+	# Add time to the close date
+	$userSet->due_date($set->due_date + ONE_DAY());
+	# This may require also extending the answer date.
+	$userSet->answer_date($userSet->due_date) if ($userSet->due_date > $set->answer_date);
 	$db->putUserSet($userSet);
 
 	$globalData->{ $self->{id} }--;

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -22,6 +22,8 @@ use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
 use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
+use constant ONE_DAY => 86400;
+
 sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDateGW',
@@ -78,10 +80,10 @@ sub use_item ($self, $userName, $c) {
 	return q{Couldn't find that set!} unless $set && $userSet;
 
 	# Add time to the reduced scoring date, due date, and answer date.
-	$userSet->reduced_scoring_date($set->reduced_scoring_date() + 86400)
+	$userSet->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY())
 		if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
-	$userSet->due_date($set->due_date() + 86400);
-	$userSet->answer_date($set->answer_date() + 86400);
+	$userSet->due_date($set->due_date() + ONE_DAY());
+	$userSet->answer_date($set->answer_date() + ONE_DAY());
 	$db->putUserSet($userSet);
 
 	# Add time to the reduced scoring date, due date, and answer date for all versions.
@@ -89,10 +91,10 @@ sub use_item ($self, $userName, $c) {
 
 	for my $version (@versions) {
 		$set = $db->getSetVersion($userName, $setID, $version);
-		$set->reduced_scoring_date($set->reduced_scoring_date() + 86400)
+		$set->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY())
 			if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
-		$set->due_date($set->due_date() + 86400);
-		$set->answer_date($set->answer_date() + 86400);
+		$set->due_date($set->due_date() + ONE_DAY());
+		$set->answer_date($set->answer_date() + ONE_DAY());
 		$db->putSetVersion($set);
 	}
 

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -80,10 +80,10 @@ sub use_item ($self, $userName, $c) {
 	return q{Couldn't find that set!} unless $set && $userSet;
 
 	# Add time to the reduced scoring date, due date, and answer date.
-	$userSet->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY())
+	$userSet->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY)
 		if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
-	$userSet->due_date($set->due_date() + ONE_DAY());
-	$userSet->answer_date($set->answer_date() + ONE_DAY());
+	$userSet->due_date($set->due_date() + ONE_DAY);
+	$userSet->answer_date($set->answer_date() + ONE_DAY);
 	$db->putUserSet($userSet);
 
 	# Add time to the reduced scoring date, due date, and answer date for all versions.
@@ -91,10 +91,10 @@ sub use_item ($self, $userName, $c) {
 
 	for my $version (@versions) {
 		$set = $db->getSetVersion($userName, $setID, $version);
-		$set->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY())
+		$set->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY)
 			if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
-		$set->due_date($set->due_date() + ONE_DAY());
-		$set->answer_date($set->answer_date() + ONE_DAY());
+		$set->due_date($set->due_date() + ONE_DAY);
+		$set->answer_date($set->answer_date() + ONE_DAY);
 		$db->putSetVersion($set);
 	}
 

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -31,7 +31,8 @@ sub new ($class) {
 		name        => x('Ring of Reduction'),
 		description => x(
 			'Enable reduced scoring for a homework set.  This will allow you to submit answers '
-				. 'for partial credit for 24 hours after the close date.'
+				. 'for partial credit for 24 hours after the close date. '
+				. 'This will randomize problem details if used after the original close date.'
 		)
 	}, $class;
 }

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -85,9 +85,7 @@ sub use_item ($self, $userName, $c) {
 
 	# Change the seed for all of the problems if the set is currently closed.
 	if (after($set->due_date)) {
-		my @probIDs = $db->listUserProblems($userName, $setID);
-		for my $probID (@probIDs) {
-			my $problem = $db->getUserProblem($userName, $setID, $probID);
+		for my $problem ($db->getUserProblemsWhere({ user_id => $userName, set_id => $setID })) {
 			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -20,7 +20,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Reduced scoring needs to be enabled for this item to work.
 
 use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after between);
 use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 use constant ONE_DAY => 86400;

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -87,7 +87,7 @@ sub use_item ($self, $userName, $c) {
 		my @probIDs = $db->listUserProblems($userName, $setID);
 		for my $probID (@probIDs) {
 			my $problem = $db->getUserProblem($userName, $setID, $probID);
-			$problem->problem_seed($problem->problem_seed + 100);
+			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}
 	}

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -41,7 +41,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + ONE_DAY())
+			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + ONE_DAY)
 				&& $sets->[$i]->assignment_type eq 'default');
 	}
 
@@ -97,7 +97,7 @@ sub use_item ($self, $userName, $c) {
 		unless ($set->reduced_scoring_date && ($set->reduced_scoring_date < $set->due_date));
 	$userSet->enable_reduced_scoring(1);
 	# Add time to the close date
-	$userSet->due_date($set->due_date + ONE_DAY());
+	$userSet->due_date($set->due_date + ONE_DAY);
 	# This may require also extending the answer date.
 	$userSet->answer_date($userSet->due_date) if ($userSet->due_date > $set->answer_date);
 	$db->putUserSet($userSet);

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -37,7 +37,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + TWO_DAYS())
+			if (between($sets->[$i]->open_date, $sets->[$i]->due_date + TWO_DAYS)
 				&& $sets->[$i]->assignment_type eq 'default');
 	}
 
@@ -85,9 +85,9 @@ sub use_item ($self, $userName, $c) {
 	}
 
 	# Add time to the reduced scoring date if it was defined in the first place
-	$userSet->reduced_scoring_date($set->reduced_scoring_date + TWO_DAYS()) if $set->reduced_scoring_date;
+	$userSet->reduced_scoring_date($set->reduced_scoring_date + TWO_DAYS) if $set->reduced_scoring_date;
 	# Add time to the close date
-	$userSet->due_date($set->due_date + TWO_DAYS());
+	$userSet->due_date($set->due_date + TWO_DAYS);
 	# This may require also extending the answer date.
 	$userSet->answer_date($userSet->due_date) if ($userSet->due_date > $set->answer_date);
 	$db->putUserSet($userSet);

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -79,7 +79,7 @@ sub use_item ($self, $userName, $c) {
 		my @probIDs = $db->listUserProblems($userName, $setID);
 		for my $probID (@probIDs) {
 			my $problem = $db->getUserProblem($userName, $setID, $probID);
-			$problem->problem_seed($problem->problem_seed + 100);
+			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}
 	}

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend a close date by 48 hours.
 
 use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after between);
 use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 use constant TWO_DAYS => 172800;

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -79,9 +79,7 @@ sub use_item ($self, $userName, $c) {
 
 	# Change the seed for all of the problems if the set is currently closed.
 	if (after($set->due_date)) {
-		my @probIDs = $db->listUserProblems($userName, $setID);
-		for my $probID (@probIDs) {
-			my $problem = $db->getUserProblem($userName, $setID, $probID);
+		for my $problem ($db->getUserProblemsWhere({ user_id => $userName, set_id => $setID })) {
 			$problem->problem_seed($problem->problem_seed % 2**31 + 1);
 			$db->putUserProblem($problem);
 		}

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -28,7 +28,10 @@ sub new ($class) {
 	return bless {
 		id          => 'SuperExtendDueDate',
 		name        => x('Robe of Longevity'),
-		description => x('Adds 48 hours to the close date of a homework.')
+		description => x(
+			'Adds 48 hours to the close date of a homework. '
+				. 'This will randomize problem details if used after the original close date.'
+		)
 	}, $class;
 }
 


### PR DESCRIPTION
This addresses some issues I've had in practice with these achievement items.

* A student is aware they have an item that can extend a due date 24 (or 48) hours. They have a set that closes at, say, 10:00pm. Their expectation is often that they can let the due date pass, then use the extension item. (They are not thinking to abuse the system by viewing answers; they are just thinking it shouldn't matter.) But that is not how it currently works. So the first change here is that if it is within the 24 (or 48) hour window after a close date, you can still use the reward item. [The only reason not to allow them to use it indefinitely is to save them from wasting it.]
* This then raises the issue of a set closing, and possibly the answer date passes too, and the student can see all the answers. So if they use the reward item in that 24 (or 48) hour window, the set's seeds are all re-randomized. (No attempt is made to leave the seeds alone where the student already had status 1.)
* Currently, these reward items always push back the answer date along with the close date. But that can leave them in a position where the set has closed for them (as well as for all other students), and other students have access to answers, but this student does not. So the last change here is to only push the answer date back to whatever the new close date is, or leave it alone, whichever is later.

And then there is `ExtendDueDateGW`.  This is not used by the default set of achievements, so I wonder if anyone even uses it. If anyone does use it, they are likely power users with extensive understanding of achievements. I started editing this one to make the same changes, but this reward item makes little sense to me in the first place. It adds 24 hours to a test template set, which seems perfectly reasonable to me. But it also adds 24 hours to every test version. So a student who activated a test that was only supposed to be 1 hour long could use this and have the test open for 25 hours. And it seems like that is not the best idea. Along with extending the template set by 24 hours, maybe just granting the student an additional test version would be good? Anyway, aside from introducing the constant for 24 hours in seconds, I did not change that one.

