### PR TITLE
let certain achievements apply to closed sets

### DIFF
--- a/lib/WeBWorK/AchievementItems/DoubleProb.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleProb.pm
@@ -21,7 +21,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use Mojo::JSON qw(encode_json);
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -39,7 +39,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+		if (after($sets->[$i]->open_date)
 			&& $sets->[$i]->assignment_type eq 'default'
 			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
 		{

--- a/lib/WeBWorK/AchievementItems/DoubleSet.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleSet.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to make a homework set worth twice as much
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -35,7 +35,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
+			if (after($sets->[$i]->open_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
 	return unless @openSets;

--- a/lib/WeBWorK/AchievementItems/FullCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditProb.pm
@@ -21,7 +21,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use Mojo::JSON qw(encode_json);
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -39,7 +39,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+		if (after($sets->[$i]->open_date)
 			&& $sets->[$i]->assignment_type eq 'default'
 			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
 		{

--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to give half credit on all problems in a homework set.
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -35,7 +35,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
+			if (after($sets->[$i]->open_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
 	return unless @openSets;

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -21,7 +21,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use Mojo::JSON qw(encode_json);
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -39,7 +39,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 	my (@openSets, @initialProblemIDs);
 
 	for my $i (0 .. $#$sets) {
-		if (between($sets->[$i]->open_date, $sets->[$i]->due_date)
+		if (after($sets->[$i]->open_date)
 			&& $sets->[$i]->assignment_type eq 'default'
 			&& @{ $setProblemIds->{ $sets->[$i]->set_id } })
 		{

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to give half credit on all problems in a homework set.
 
 use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(after);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 sub new ($class) {
@@ -35,7 +35,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 
 	for my $i (0 .. $#$sets) {
 		push(@openSets, [ format_set_name_display($sets->[$i]->set_id) => $sets->[$i]->set_id ])
-			if (between($sets->[$i]->open_date, $sets->[$i]->due_date) && $sets->[$i]->assignment_type eq 'default');
+			if (after($sets->[$i]->open_date) && $sets->[$i]->assignment_type eq 'default');
 	}
 
 	return unless @openSets;


### PR DESCRIPTION
The achievements affected by this PR currently only apply to open sets. But in these cases, to me it seems that students should be allowed to use them after the close date. So this would change it so that these can be used on sets after their close date. 

This may be controversial if people like these the way they are. But I find that students (a) get anxious about if they should use these when they don't know ahead of time what future sets will be like and (b) other students aren't aware they have these rewards until it's too late to use them.