### PR TITLE
Fix some cross-site scripting vulnerabilities.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -62,7 +62,10 @@ sub initialize ($c) {
 						eval { $db->addPassword($effectiveUserPassword) };
 						$password = $password // $effectiveUserPassword;
 						if ($@) {
-							$c->addbadmessage($c->maketext("Couldn't change [_1]'s password: [_2]", $e_user_name, $@));
+							$c->log->error("Error changing ${e_user_name}'s password: $@");
+							$c->addbadmessage($c->maketext(
+								"[_1]'s password was not changed due to an internal error.", $e_user_name
+							));
 						} else {
 							$c->addgoodmessage($c->maketext("[_1]'s password has been changed.", $e_user_name));
 						}
@@ -71,7 +74,10 @@ sub initialize ($c) {
 						eval { $db->putPassword($effectiveUserPassword) };
 						$password = $password // $effectiveUserPassword;
 						if ($@) {
-							$c->addbadmessage($c->maketext("Couldn't change [_1]'s password: [_2]", $e_user_name, $@));
+							$c->log->error("Error changing ${e_user_name}'s password: $@");
+							$c->addbadmessage($c->maketext(
+								"[_1]'s password was not changed due to an internal error.", $e_user_name
+							));
 						} else {
 							$c->addgoodmessage($c->maketext("[_1]'s password has been changed.", $e_user_name));
 						}
@@ -106,8 +112,11 @@ sub initialize ($c) {
 		eval { $db->putUser($c->{effectiveUser}) };
 		if ($@) {
 			$c->{effectiveUser}->email_address($oldA);
-			$c->addbadmessage($c->maketext("Couldn't change your email address: [_1]", $@));
+			$c->log->error("Unable to save new email address for $userID: $@");
+			$c->addbadmessage($c->maketext('Your email address has not been changed due to an internal error.'));
 		} else {
+			$c->param('currAddress', $c->param('newAddress'));
+			$c->param('newAddress',  undef);
 			$c->addgoodmessage($c->maketext('Your email address has been changed.'));
 		}
 	}
@@ -127,7 +136,8 @@ sub initialize ($c) {
 
 			eval { $db->putUser($c->{effectiveUser}) };
 			if ($@) {
-				$c->addbadmessage($c->maketext("Couldn't save your display options: [_1]", $@));
+				$c->log->error("Unable to save display options for $userID: $@");
+				$c->addbadmessage($c->maketext('Your display options were not saved due to an internal error.'));
 			} else {
 				$c->addgoodmessage($c->maketext('Your display options have been saved.'));
 			}

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -573,13 +573,14 @@ sub setup_content_generator_routes_recursive {
 	my $action = $routeParameters{$child}{action} // 'go';
 
 	if ($routeParameters{$child}{children}) {
-		my $child_route = $route->under($routeParameters{$child}{path})->name($child);
+		my $child_route = $route->under($routeParameters{$child}{path}, [ problemID => qr/\d+/ ])->name($child);
 		$child_route->any('/')->to("$routeParameters{$child}{module}#$action")->name($child);
 		for (@{ $routeParameters{$child}{children} }) {
 			setup_content_generator_routes_recursive($child_route, $_);
 		}
 	} else {
-		$route->any($routeParameters{$child}{path})->to("$routeParameters{$child}{module}#$action")->name($child);
+		$route->any($routeParameters{$child}{path}, [ problemID => qr/\d+/ ])
+			->to("$routeParameters{$child}{module}#$action")->name($child);
 	}
 
 	return;

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -74,7 +74,7 @@
 				$setID, $effectiveUserID, $c->{invalidVersionCreation} ? " (acted as by $userID)" : ''
 			) =%>
 		</div>
-		<div><%== $c->{invalidSet} %></div>
+		<div><%= $c->{invalidSet} %></div>
 		% if ($c->{invalidVersionCreation} && $c->{invalidVersionCreation} == 1) {
 			<p>
 				<%= link_to 'Create new set version.' => $c->systemLink(

--- a/templates/ContentGenerator/ProblemSet.html.ep
+++ b/templates/ContentGenerator/ProblemSet.html.ep
@@ -13,7 +13,7 @@
 				stash('setID'), param('effectiveUser')
 			) =%>
 		</p>
-		<p class="mb-0"><%== $c->{invalidSet} %></p>
+		<p class="mb-0"><%= $c->{invalidSet} %></p>
 	</div>
 	% last;
 % }


### PR DESCRIPTION
These were identified in a scan of @glarose's server.

The first cross-site scripting vulnerability occurs because an invalid set id is found and when that invalid set id is reported it is done so without XML escaping it.  To test it use (for example): `https://your.server.edu/webwork2/courseID/feedback%3cimg%20src%3da%20onerror%3dalert(1)%3e` Of course replace `https://your.server.edu/webwork2/courseID` with the URL on your server for a valid course.

The second vulnerability occurs because a problem id that starts with an integer and has certain text appended can validate by only the integer part, and yet be used in the page including that text part.  To test this use `https://your.server.edu/webwork2/courseID/setID/1%3cimg%20src%3da%20onerror%3dalert(1)%3e` where 1 is a valid problem in the set.  To fix this the problemID route parameter is forced to be an integer.  So if you use a URL like the above, it will now just give "Page not found".

The last vulnerability is probably more prevalent in the code than just what is fixed in this pull request.  It occurs on the user options page when certain URL params are added.  For example,
`https://your.server.edu/webwork2/courseID/options?useMathQuill=%3cscript%3ealert(1)%3c%2fscript%3&changeOptions=1`. Although the issue was specifically reported for the `useMathQuill` parameter, it occurs with any of the integer valued option parameters on that page.  Note that the `changeOptions` parameter is needed in all cases, because it only occurs when saving options.  The problem is that there is an error saving those values to the database because they are not integer values.  Then we put the exception in `$@` unescaped into the html, and that exception message includes the original invalid value.  To fix this the value of `$@` is no longer used in the error message.  Instead it is logged to the app log file (via $c->log->error), and a generic error is reported to the user.  This needs to be done throughout the code.  We really never should use a direct system exception message in html.  That should be logged for the system administrator, and a generic error message shown in the UI.  The same goes for Perl warnings in general.  So there is much work to be done here.