### PR TITLE
also clear tmpEdit folder when 'cleaning' a newly unarchived course

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1305,6 +1305,11 @@ sub do_unarchive_course ($c) {
 				eval { Mojo::File->new($ce_new->{courseDirs}{scoring})->remove_tree({ keep_root => 1 }) };
 				$c->addbadmessage($c->maketext('Failed to remove scoring files: [_1]', $@)) if $@;
 			}
+
+			if (-d $ce_new->{courseDirs}{tmpEditFileDir}) {
+				eval { Mojo::File->new($ce_new->{courseDirs}{tmpEditFileDir})->remove_tree({ keep_root => 1 }) };
+				$c->addbadmessage($c->maketext('Failed to remove temporary edited files: [_1]', $@)) if $@;
+			}
 		}
 
 		return $c->c(

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
@@ -11,7 +11,8 @@
 		<div class="col-12">
 			<div class="form-check">
 				<label class="form-check-label" id="clean_up_course">
-					<%= maketext('Clean course after unarchiving (remove student users, scoring files, log files)') =%>
+					<%= maketext('Clean course after unarchiving (remove student users, scoring files, log files, '
+						. 'temporary edited files)') =%>
 					<%= check_box clean_up_course => 1, class => 'form-check-input' =%>
 				</label>
 			</div>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -40,7 +40,7 @@
 						<%= check_box clean_up_course => 1, class => 'form-check-input', id => 'clean_up_course' %>
 						<label for="clean_up_course" class="form-check-label" id="clean_up_course">
 							<%= maketext('Clean course after unarchiving '
-								. '(remove student users, scoring files, log files)') %>
+								. '(remove student users, scoring files, log files, temporary edited files)') %>
 						</label>
 					</div>
 				</div>

--- a/templates/HelpFiles/AdminUnarchiveCourse.html.ep
+++ b/templates/HelpFiles/AdminUnarchiveCourse.html.ep
@@ -29,5 +29,5 @@
 <p class="mb-0">
 	<%= maketext('You may check the box to "clean" the unarchived course. This will remove student users '
 		. 'and their associated data from the database after the course is unarchived. It will also remove '
-		. 'the log files and and any files in the scoring folder.') =%>
+		. 'the log files, any files in the scoring folder, and any temporary edited files.') =%>
 </p>


### PR DESCRIPTION
This should have been included with #2291, which lets you clear things from a course when you unarchive it. This is useful for when you are creating a new course by unarchiving, and you are really just using the archived course as a template.

So this PR also clears the tmpEdit folder when you do that.