### PR TITLE
Allow instructors with no email saved to enter an email address.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -185,10 +185,10 @@ $emailableURL
 			$msg .= "***** Data about the environment: *****\n\n" . Dumper($ce) . "\n\n";
 		}
 
-		my $from_name = $user ? $user->full_name : $ce->{generic_sender_name};
-		my $email     = Email::Stuffer->to(join(',', @recipients))->subject($subject)->text_body($msg)
+		my $email = Email::Stuffer->to(join(',', @recipients))->subject($subject)->text_body($msg)
 			->header('X-Remote-Host' => $remote_host);
 		if ($ce->{feedback_sender_email}) {
+			my $from_name = $user ? $user->full_name : $ce->{generic_sender_name};
 			$email->from("$from_name <$ce->{feedback_sender_email}>")->reply_to($sender);
 		} else {
 			$email->from($sender);

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -216,6 +216,7 @@ sub initialize ($c) {
 		# read info from the form
 		# bail if there is no message body
 
+		$c->{from} = $c->param('from') unless $c->{from};
 		$subject = $c->param('subject');
 		my $body = $c->param('body');
 		# Sanity check: body must contain non-white space when previewing message.
@@ -302,7 +303,7 @@ sub initialize ($c) {
 		# verify format of From address (one valid rfc2822/rfc5322 address)
 		my @parsed_from_addrs = Email::Address::XS->parse($c->{from});
 		unless (@parsed_from_addrs == 1) {
-			$c->addbadmessage($c->maketext("From field must contain one valid email address."));
+			$c->addbadmessage($c->maketext("From field must contain a single valid email address."));
 			return;
 		}
 

--- a/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
+++ b/templates/ContentGenerator/Instructor/SendMail/main_form.html.ep
@@ -34,7 +34,10 @@
 						<%= label_for from => maketext('From:'),
 							class => 'col-sm-3 col-form-label col-form-label-sm' =%>
 						<div class="col-sm-9">
-							<%= text_field from => $c->{from}, id => 'from', readonly => undef, disabled => undef,
+							<%= text_field from => $c->{from}, id => 'from',
+								$c->{from} && $c->{from} eq $c->{defaultPreviewUser}->rfc822_mailbox
+									? (readonly => undef, disabled => undef)
+									: (),
 								class => 'form-control form-control-sm' =%>
 						</div>
 					</div>


### PR DESCRIPTION
If an instructor does not have an email address in the database, then currently the from field on the instructor "Email" page is disabled, and there is no way to enter an email address.  Attempting to send an email address gives the message "From field must contain one valid email address", and yet there is still no way to enter an email address.

This makes it so that in the case that an instructor does not have an email address in the database the from field is not disabled, and the instructor can enter an email address.

The message was changed because I find it a bit confusing even if the instructor can change the email address, if the message says the "From field must contain one valid email address".  It seems to me that means that it would be valid to enter more than one email address as long as one is valid.  The message now reads "From field must contain a single valid email address."