### PR TITLE
Don't log out items in $authen{user_module} not in $authen{admin_module}

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -154,17 +154,13 @@ sub verify {
 
 	debug('BEGIN VERIFY');
 
-	return $self->call_next_authen_method if !$self->request_has_data_for_this_verification_module;
 	my $authen_ref = ref($self);
-	if ($c->ce->{courseName} eq $c->ce->{admin_course_id}
-		&& !(grep {/^$authen_ref$/} @{ $c->ce->{authen}{admin_module} }))
+	if (
+		!$self->request_has_data_for_this_verification_module
+		|| ($c->ce->{courseName} eq $c->ce->{admin_course_id}
+			&& !(grep {/^$authen_ref$/} @{ $c->ce->{authen}{admin_module} }))
+		)
 	{
-		$self->write_log_entry("Cannot authenticate into admin course using $authen_ref.");
-		$c->stash(
-			authen_error => $c->maketext(
-				'There was an error during the login process.  Please speak to your instructor or system administrator.'
-			)
-		);
 		return $self->call_next_authen_method();
 	}
 


### PR DESCRIPTION
When looping through $authen{user_module} for the admin course, modules not in $authen{admin_module} can be logged and `authen_error` is set before attempting the next module. This can cause the logins to the admin course to fail under certain configurations.

This removes both the logging and error message, and just attempts the next authentication method.

This is an alternative to fix the issue described in #2490.

One side affect of this is logging into the admin course if `$authen{admin_module}` does not contain any elements of `$authen{user_module}`, the login will silently fail. I just couldn't figure out any logic when looping through the login methods, that `$authen{admin_module}`, to test if no matches were found and creating an error message as a result.