### PR TITLE
Make the `admin_module` separate from the `user_module` for authentication.

### DIFF
--- a/conf/authen_CAS.conf.dist
+++ b/conf/authen_CAS.conf.dist
@@ -13,7 +13,7 @@ $authen{user_module} = {
 };
 
 # List of authentication modules that may be used to enter the admin course.
-# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# This is used instead of $authen{user_module} when logging into the admin course.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
 # have available to you.

--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -46,19 +46,10 @@ $authen{user_module} = [
 ];
 
 # List of authentication modules that may be used to enter the admin course.
-# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# This is used instead of $authen{user_module} when logging into the admin course.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
-# have available to you.  The current default is
-# WeBWorK::Authen::Basic_TheLastOption which is simple password based
-# authentication for a password locally stored in your WeBWorK server's
-# database.  On one hand, this is necessary as the initial setting, as it is the
-# only option available when a new server is being installed.  However, since
-# this option does not make use of multi-factor authentication or provide any
-# capabilities to prevent dictionary attacks, etc.  At the very least you should
-# use a very strong password.  If you have the option to use a more secure
-# authentication approach to the admin course (one which you are confident
-# cannot be spoofed) that is preferable.
+# have available to you.
 $authen{admin_module} = [
 	#'WeBWorK::Authen::LTIAdvantage',
 	#'WeBWorK::Authen::LTIAdvanced',

--- a/conf/authen_ldap.conf.dist
+++ b/conf/authen_ldap.conf.dist
@@ -8,12 +8,10 @@
 ########################################################################################
 
 # Set LDAP as the authentication module to use.
-$authen{user_module} = {
-	"*" => "WeBWorK::Authen::LDAP",
-};
+$authen{user_module} = { "*" => "WeBWorK::Authen::LDAP" };
 
 # List of authentication modules that may be used to enter the admin course.
-# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# This is used instead of $authen{user_module} when logging into the admin course.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
 # have available to you.
@@ -41,23 +39,23 @@ $authen{ldap_options} = {
 	# Edit the data below:
 	net_ldap_base => "ou=people,dc=myschool,dc=edu",
 
-        # Use a Bind account if set to 1
-        bindAccount => 0,
+	# Use a Bind account if set to 1
+	bindAccount => 0,
 
-        searchDN => "cn=search,DC=youredu,DC=edu",
-        bindPassword =>  "password",
+	searchDN     => "cn=search,DC=youredu,DC=edu",
+	bindPassword => "password",
 
 	# The LDAP module searches for a DN whose RDN matches the username
 	# entered by the user. The net_ldap_rdn setting tells the LDAP
 	# backend what part of your LDAP schema you want to use as the RDN.
 	# The correct value for net_ldap_rdn will depend on your LDAP setup.
-	#
+
 	# Uncomment this line if you use Active Directory.
 	#net_ldap_rdn => "sAMAccountName",
-	#
+
 	# Uncomment this line if your schema uses uid as an RDN.
 	#net_ldap_rdn => "uid",
-	#
+
 	# By default, net_ldap_rdn is set to "sAMAccountName".
 
 	# If failover = "all", then all LDAP failures will be checked
@@ -69,4 +67,4 @@ $authen{ldap_options} = {
 	failover => "all",
 };
 
-1; #final line of the file to reassure perl that it was read properly.
+1;    #final line of the file to reassure perl that it was read properly.

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -745,8 +745,7 @@ $authen{user_module} = {"*" => "WeBWorK::Authen::Basic_TheLastOption"};
 $authen{proctor_module} = "WeBWorK::Authen::Proctor";
 
 # List of authentication modules that may be used to enter the admin course.
-# This should always be an array reference with a subset of the modules named
-# in $authen{user_module}.
+# This is used instead of $authen{user_module} when logging into the admin course.
 $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 
 ################################################################################

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -485,19 +485,18 @@ $mail{feedbackRecipients}    = [
 #$authen{proctor_module} = "WeBWorK::Authen::Proctor";
 
 # List of authentication modules that may be used to enter the admin course.
-# This should be a non-empty sublist of whatever is in $authen{user_module}.
+# This is used instead of $authen{user_module} when logging into the admin course.
 # Since the admin course provides overall power to add/delete courses, access
 # to this course should be protected by the best possible authentication you
 # have available to you.  The current default is
 # WeBWorK::Authen::Basic_TheLastOption which is simple password based
 # authentication for a password locally stored in your WeBWorK server's
 # database.  On one hand, this is necessary as the initial setting, as it is the
-# only option available when a new server is being installed.  However, since
-# this option does not make use of multi-factor authentication or provide any
-# capabilities to prevent dictionary attacks, etc.  At the very least you should
-# use a very strong password.  If you have the option to use a more secure
-# authentication approach to the admin course (one which you are confident
-# cannot be spoofed) that is preferable.
+# only option available when a new server is being installed, on the other hand,
+# this option does not provide any capabilities to prevent dictionary attacks, etc.
+# At the very least you should use a very strong password with two factor authentication.
+# If you have the option to use a more secure authentication approach to the admin course
+# (one which you are confident cannot be spoofed) that is preferable.
 #
 # Note that if you include authentication module config files further down,
 # those may override the setting of $authen{admin_module} here.

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -475,9 +475,8 @@ $mail{feedbackRecipients}    = [
 # responds affirmatively will be used.
 
 #$authen{user_module} = {
-#	sql_moodle => "WeBWorK::Authen::Moodle",
-#	sql_ldap   => "WeBWorK::Authen::LDAP"
-#	"*"        => "WeBWorK::Authen::Basic_TheLastOption"
+#	"*" => "WeBWorK::Authen::LDAP"
+#	"*" => "WeBWorK::Authen::Basic_TheLastOption"
 #};
 
 # Select the authentication module to use for proctor logins.
@@ -502,7 +501,6 @@ $mail{feedbackRecipients}    = [
 # those may override the setting of $authen{admin_module} here.
 
 #$authen{admin_module} = [
-#	'WeBWorK::Authen::Moodle',
 #	'WeBWorK::Authen::LDAP',
 #	'WeBWorK::Authen::Basic_TheLastOption'
 #];

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -153,11 +153,12 @@ async sub dispatch ($c) {
 	my $authz = WeBWorK::Authz->new($c);
 	$c->authz($authz);
 
-	my $user_authen_module = WeBWorK::Authen::class($ce, 'user_module');
+	my $user_authen_module =
+		WeBWorK::Authen::class($ce, $ce->{courseName} eq $ce->{admin_course_id} ? 'admin_module' : 'user_module');
 
 	runtime_use $user_authen_module;
 	my $authen = $user_authen_module->new($c);
-	debug("Using user_authen_module $user_authen_module: $authen\n");
+	debug("Using authentication module $user_authen_module: $authen\n");
 	$c->authen($authen);
 
 	if ($routeCaptures{courseID}) {

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -131,9 +131,8 @@ sub call_next_authen_method {
 	my $ce   = $c->{ce};
 
 	my $user_authen_module =
-		$ce->{courseName} eq $ce->{admin_course_id}
-		? WeBWorK::Authen::class($ce, "admin_module")
-		: WeBWorK::Authen::class($ce, "user_module");
+		WeBWorK::Authen::class($ce, $ce->{courseName} eq $ce->{admin_course_id} ? 'admin_module' : 'user_module');
+
 	if (!defined $user_authen_module || $user_authen_module eq '') {
 		$self->{error} = $c->maketext(
 			"No authentication method found for your request.  If this recurs, please speak with your instructor.");

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -130,7 +130,10 @@ sub call_next_authen_method {
 	my $c    = $self->{c};
 	my $ce   = $c->{ce};
 
-	my $user_authen_module = WeBWorK::Authen::class($ce, "user_module");
+	my $user_authen_module =
+		$ce->{courseName} eq $ce->{admin_course_id}
+		? WeBWorK::Authen::class($ce, "admin_module")
+		: WeBWorK::Authen::class($ce, "user_module");
 	if (!defined $user_authen_module || $user_authen_module eq '') {
 		$self->{error} = $c->maketext(
 			"No authentication method found for your request.  If this recurs, please speak with your instructor.");
@@ -155,18 +158,6 @@ sub verify {
 	debug('BEGIN VERIFY');
 
 	return $self->call_next_authen_method if !$self->request_has_data_for_this_verification_module;
-	my $authen_ref = ref($self);
-	if ($c->ce->{courseName} eq $c->ce->{admin_course_id}
-		&& !(grep {/^$authen_ref$/} @{ $c->ce->{authen}{admin_module} }))
-	{
-		$self->write_log_entry("Cannot authenticate into admin course using $authen_ref.");
-		$c->stash(
-			authen_error => $c->maketext(
-				'There was an error during the login process.  Please speak to your instructor or system administrator.'
-			)
-		);
-		return $self->call_next_authen_method();
-	}
 
 	$self->{was_verified} = $self->do_verify;
 


### PR DESCRIPTION
Make the `admin_module` separate from the `user_module` for authentication.

When signing in to the admin course the course `$authen{admin_module}` is used, and for all other courses the `$authen{user_module}` is used. So the two lists are completely separate.  Neither needs to be a subset of the other.

Also fix the `net_ldap_options` course environment variable usage.  It is `net_ldap_options` in the `authen_ldap.conf` file, but was `net_ldap_opts` in the code.  Furthermore, the variable was dereferenced as an array, but is actually a hash which causes an error.

Note that this is built on top of #2490.  @somiaj I hope you don't mind me taking this over.  This is also rebased onto main and put in as a hotfix.

Note that the `$authen{user_module}` that is demonstrated in `localOverrides.conf.dist` is nonsensical.  The `LDAP.pm` authentication module is terminal.  In other words, if it is encountered in the list, it never allows anything after it to be used.  In fact the only authentication modules that actually allow later elements in the list to be used are the LTI authentication modules.  All others are terminal.   I removed the `Moodle` authentication module from the demonstrated list because that module should be considered deprecated (and I am absolutely certain does not work anymore), and removed the database config name (which also needs to be dropped) for now.  This needs to be reworked quite a bit.