### PR TITLE
Handle user's with no password record for two factor authentication.

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -472,7 +472,8 @@ sub verify_normal_user {
 			# two_factor_verification_needed is deleted from the session.
 			my $otp_code = trim($c->param('otp_code'));
 			if (defined $otp_code && $otp_code ne '') {
-				my $password = $c->db->getPassword($user_id);
+				# The password record may not be defined (e.g. for LDAP authentication). So create one if it isn't.
+				my $password = $c->db->getPassword($user_id) // $c->db->newPassword(user_id => $user_id);
 				if (
 					WeBWorK::Utils::TOTP->new(
 						secret    => $self->session->{otp_secret} // $password->otp_secret,

--- a/lib/WeBWorK/ContentGenerator/TwoFactorAuthentication.pm
+++ b/lib/WeBWorK/ContentGenerator/TwoFactorAuthentication.pm
@@ -44,11 +44,9 @@ sub pre_header_initialize ($c) {
 	$c->stash->{otp_qrcode} = '';
 	$c->stash->{authen_error} //= '';
 
-	# Note that this user has already authenticated with username and password,
-	# so this and the $user below should exist.
 	my $password = $c->db->getPassword($c->authen->{user_id});
 
-	if (!$password->otp_secret) {
+	if (!$password || !$password->otp_secret) {
 		my $totp =
 			WeBWorK::Utils::TOTP->new(
 				$c->authen->session->{otp_secret} ? (secret => $c->authen->session->{otp_secret}) : ());
@@ -61,6 +59,7 @@ sub pre_header_initialize ($c) {
 			GD::Barcode::QRcode->new($otp_link, { Ecc => 'L', ModuleSize => 4, Version => 0 })->plot->png;
 		};
 
+		# Note that this user has already authenticated so the user record should exist.
 		my $user = $c->db->getUser($c->authen->{user_id});
 
 		if ($ce->{twoFA}{email_sender} && (my $recipient = $user->email_address)) {


### PR DESCRIPTION
It makes sense for a system configured for LDAP authentication to also want to use two factor authentication, and a user does not need to have a local password defined for LDAP authentcation.  However, this is not something that I realized when I implemented two factor authentication. So I assumed a password record would exist.

This fixes the OTP verification for the case that a password does not exist in the database for a user.  I.e., this fixes issue #2494.

Should this be a hotfix?