### PR TITLE
Skip checking a password for the LDAP authentication module if not given

### DIFF
--- a/lib/WeBWorK/Authen/LDAP.pm
+++ b/lib/WeBWorK/Authen/LDAP.pm
@@ -29,6 +29,9 @@ sub checkPassword {
 
 	debug("LDAP module is doing the password checking.\n");
 
+	# Don't attempt to check a password if one wasn't entered.
+	return 0 unless $possibleClearPassword =~ /\S/;
+
 	# check against LDAP server
 	my $ret = $self->ldap_authen_uid($userID, $possibleClearPassword);
 	return 1 if ($ret == 1);


### PR DESCRIPTION
This fixes issue #2496.