### PR TITLE
when copying sets from a new course and adding an instructor, assign …

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -384,10 +384,11 @@ sub do_add_course ($c) {
 
 	eval {
 		addCourse(
-			courseID      => $add_courseID,
-			ce            => $ce2,
-			courseOptions => \%courseOptions,
-			users         => \@users,
+			courseID       => $add_courseID,
+			ce             => $ce2,
+			courseOptions  => \%courseOptions,
+			users          => \@users,
+			initial_userID => $add_initial_userID,
 			%optional_arguments,
 		);
 	};

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -405,6 +405,10 @@ sub addCourse {
 				assignSetsToUsers($db, $ce, \@user_sets, [$user_id]);
 			}
 		}
+		if (defined $options{initial_userID}) {
+			my ($initialUser) = grep { $_->[0]{user_id} eq $options{initial_userID} } @users;
+			assignSetsToUsers($db, $ce, \@set_ids, [ $initialUser->[0]{user_id} ]) if $initialUser;
+		}
 	}
 
 	# add achievements


### PR DESCRIPTION
…all sets to that instructor

In 2.19, when you are creating a new course, you have the option to select an existing course and copy all of the sets into the new course. You also (as you've always been able to do) have the option of adding one "professor" level user to the new course. As things stand, the new professor will not have all of the copied sets assigned to them.

This commit changes it so that they will get all of those sets assigned to them.

I can't see a scenario where you want to copy sets from another course, but would not want them to be assigned to the new instructor. Maybe there is such a scenario. But I think it would be much more common to want that instructor to have everything assigned to them.