### PR TITLE
Prevent a NULL title from being saved in the database when a course is created/copied.

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -688,12 +688,13 @@ sub page_title ($c) {
 	my $db = $c->db;
 
 	# If the current route name is 'set_list' and the course has a course title then display that.
-	if ($c->current_route eq 'set_list' && (my $courseTitle = $db->getSettingValue('courseTitle'))) {
-		return $courseTitle;
-	} else {
-		# Display the route name
-		return route_title($c, $c->current_route, 1);
+	if ($c->current_route eq 'set_list') {
+		my $courseTitle = $db->getSettingValue('courseTitle');
+		return $courseTitle if defined $courseTitle && $courseTitle ne '';
 	}
+
+	# Display the route name
+	return route_title($c, $c->current_route, 1);
 }
 
 =item webwork_url

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -688,8 +688,8 @@ sub page_title ($c) {
 	my $db = $c->db;
 
 	# If the current route name is 'set_list' and the course has a course title then display that.
-	if ($c->current_route eq 'set_list' && $db->settingExists('courseTitle')) {
-		return $db->getSettingValue('courseTitle');
+	if ($c->current_route eq 'set_list' && (my $courseTitle = $db->getSettingValue('courseTitle'))) {
+		return $courseTitle;
 	} else {
 		# Display the route name
 		return route_title($c, $c->current_route, 1);

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -300,9 +300,9 @@ sub do_add_course ($c) {
 	my $db    = $c->db;
 	my $authz = $c->authz;
 
-	my $add_courseID          = trim_spaces($c->param('new_courseID'))          // '';
-	my $add_courseTitle       = trim_spaces($c->param('add_courseTitle'))       // '';
-	my $add_courseInstitution = trim_spaces($c->param('add_courseInstitution')) // '';
+	my $add_courseID          = trim_spaces($c->param('new_courseID')) // '';
+	my $add_courseTitle       = ($c->param('add_courseTitle')       // '') =~ s/^\s*|\s*$//gr;
+	my $add_courseInstitution = ($c->param('add_courseInstitution') // '') =~ s/^\s*|\s\*$//gr;
 
 	my $add_initial_userID          = trim_spaces($c->param('add_initial_userID'))          // '';
 	my $add_initial_password        = trim_spaces($c->param('add_initial_password'))        // '';

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -432,9 +432,10 @@ sub addCourse {
 	for my $setting ('Title', 'Institution') {
 		if ($db0 && $options{"copy$setting"}) {
 			my $settingValue = $db0->getSettingValue("course$setting");
-			$db->setSettingValue("course$setting", $settingValue) if $settingValue;
+			$db->setSettingValue("course$setting", $settingValue) if defined $settingValue && $settingValue ne '';
 		} else {
-			$db->setSettingValue("course$setting", $options{"course$setting"}) if $options{"course$setting"};
+			$db->setSettingValue("course$setting", $options{"course$setting"})
+				if defined $options{"course$setting"} && $options{"course$setting"} ne '';
 		}
 	}
 
@@ -649,10 +650,10 @@ sub renameCourse {
 		#update title and institution
 		my $newDB = new WeBWorK::DB($newCE->{dbLayouts}{$dbLayoutName});
 		eval {
-			if ($options{courseTitle}) {
+			if (defined $options{courseTitle} && $options{courseTitle} ne '') {
 				$newDB->setSettingValue('courseTitle', $options{courseTitle});
 			}
-			if ($options{courseInstitution}) {
+			if (defined $options{courseInstitution} && $options{courseInstitution} ne '') {
 				$newDB->setSettingValue('courseInstitution', $options{courseInstitution});
 			}
 		};
@@ -692,10 +693,10 @@ sub retitleCourse {
 	my $dbLayoutName = $ce->{dbLayoutName};
 	my $db           = new WeBWorK::DB($ce->{dbLayouts}{$dbLayoutName});
 	eval {
-		if ($options{courseTitle}) {
+		if (defined $options{courseTitle} && $options{courseTitle} ne '') {
 			$db->setSettingValue('courseTitle', $options{courseTitle});
 		}
-		if ($options{courseInstitution}) {
+		if (defined $options{courseInstitution} && $options{courseInstitution} ne '') {
 			$db->setSettingValue('courseInstitution', $options{courseInstitution});
 		}
 	};

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -431,10 +431,10 @@ sub addCourse {
 	# copy title and/or institution if requested
 	for my $setting ('Title', 'Institution') {
 		if ($db0 && $options{"copy$setting"}) {
-			$db->setSettingValue("course$setting", $db0->getSettingValue("course$setting"))
-				if ($options{"copy$setting"});
+			my $settingValue = $db0->getSettingValue("course$setting");
+			$db->setSettingValue("course$setting", $settingValue) if $settingValue;
 		} else {
-			$db->setSettingValue("course$setting", $options{"course$setting"}) if (exists $options{"course$setting"});
+			$db->setSettingValue("course$setting", $options{"course$setting"}) if $options{"course$setting"};
 		}
 	}
 
@@ -649,10 +649,10 @@ sub renameCourse {
 		#update title and institution
 		my $newDB = new WeBWorK::DB($newCE->{dbLayouts}{$dbLayoutName});
 		eval {
-			if (exists($options{courseTitle}) and $options{courseTitle}) {
+			if ($options{courseTitle}) {
 				$newDB->setSettingValue('courseTitle', $options{courseTitle});
 			}
-			if (exists($options{courseInstitution}) and $options{courseInstitution}) {
+			if ($options{courseInstitution}) {
 				$newDB->setSettingValue('courseInstitution', $options{courseInstitution});
 			}
 		};
@@ -692,10 +692,10 @@ sub retitleCourse {
 	my $dbLayoutName = $ce->{dbLayoutName};
 	my $db           = new WeBWorK::DB($ce->{dbLayouts}{$dbLayoutName});
 	eval {
-		if (exists($options{courseTitle}) and $options{courseTitle}) {
+		if ($options{courseTitle}) {
 			$db->setSettingValue('courseTitle', $options{courseTitle});
 		}
-		if (exists($options{courseInstitution}) and $options{courseInstitution}) {
+		if ($options{courseInstitution}) {
 			$db->setSettingValue('courseInstitution', $options{courseInstitution});
 		}
 	};


### PR DESCRIPTION
Also don't use an undefined course title on the course home page.  Note that a NULL setting in the database becomes undef when converted to a Perl scalar value.

This fixes issue #2515 and probably #2497 as well.