### PR TITLE
allow users to manage their first/last name from Account Settings

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -784,6 +784,7 @@ $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 	use_two_factor_auth            => "student",
 	report_bugs                    => "ta",
 	submit_feedback                => "student",
+	change_name                    => "student",
 	change_password                => "student",
 	change_email_address           => "student",
 	change_pg_display_settings     => "student",

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -542,6 +542,19 @@ sub getConfigValues ($ce) {
 				type => 'permission'
 			},
 			{
+				var  => 'permissionLevels{change_name}',
+				doc  => x('Allowed to change their name'),
+				doc2 => x(
+					'Users at this level and higher are allowed to change their first and last name. '
+						. 'Note that if WeBWorK is used with an LMS, it may be configured to allow the LMS to '
+						. 'manage user data such as user names. Then if a user changes their name in WeBWorK, '
+						. 'the LMS might override that later. This course might be configured to allow you to '
+						. 'control whether or not the LMS is allowed to manage user date in the LTI tab of the '
+						. 'Course Configuration page.'
+				),
+				type => 'permission'
+			},
+			{
 				var  => 'permissionLevels{change_email_address}',
 				doc  => x('Allowed to change their email address'),
 				doc2 => x(
@@ -922,11 +935,13 @@ sub getConfigValues ($ce) {
 			var  => 'LMSManageUserData',
 			doc  => x('Allow the LMS to update user account data'),
 			doc2 => x(
-				'WeBWorK will automatically create users when logging in via the LMS for the first time. If '
-					. 'this flag is enabled then it will also keep the user account data (first name, last '
-					. 'name, section, recitation) up to date with the LMS. If a user\'s information changes '
-					. 'in the LMS then it will change in WeBWorK. However, any changes to the user data via '
-					. 'WeBWorK will be overwritten the next time the user logs in.'
+				'If this is set to true, then when a user enters WeBWorK using LTI from an LMS, their user account '
+					. 'data in WeBWorK will be updated to match the data from the LMS.  This applies to first name, '
+					. 'last name, section, recitation, and email address.  If a user\'s information changes in the LMS '
+					. 'then it will change in WeBWorK the next time the user enters WeBWorK from the LMS.  Any changes '
+					. 'to the user data that are made in WeBWorK will be overwritten.  So if this is set to true, you '
+					. 'may want to review the settings in the Permissions tab for who is allowed to change their own '
+					. 'name and email address.'
 			),
 			type => 'boolean'
 		},

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -72,6 +72,7 @@
 		% }
 		%
 		% if ($authz->hasPermissions($userID, 'change_password')
+			% || $authz->hasPermissions($userID, 'change_name')
 			% || $authz->hasPermissions($userID, 'change_email_address')
 			% || $authz->hasPermissions($userID, 'change_pg_display_settings'))
 		% {

--- a/templates/ContentGenerator/Options.html.ep
+++ b/templates/ContentGenerator/Options.html.ep
@@ -18,18 +18,56 @@
 %= form_for current_route, method => 'POST', begin
 	<%= $c->hidden_authen_fields =%>
 	%
+	% if ($authz->hasPermissions($userID, 'change_name')) {
+		<h2><%= maketext('Name') %></h2>
+		<div class="row mb-2">
+			<div class="col-lg-8 col-md-10">
+				<div class="row mb-2">
+					<%= label_for currFirstName => maketext("Current First Name"),
+						class => 'col-form-label col-sm-6' =%>
+					<div class="col-sm-6">
+						<%= text_field currFirstName => $c->{effectiveUser}->first_name, readonly => undef,
+							id => 'currFirstName', class => 'form-control bg-light', dir => 'ltr' =%>
+					</div>
+				</div>
+				<div class="row mb-2">
+					<%= label_for currLastName => maketext("Current Last Name"),
+						class => 'col-form-label col-sm-6' =%>
+					<div class="col-sm-6">
+						<%= text_field currLastName => $c->{effectiveUser}->last_name, readonly => undef,
+							id => 'currLastName', class => 'form-control bg-light', dir => 'ltr' =%>
+					</div>
+				</div>
+				<div class="row mb-2">
+					<%= label_for newFirstName => maketext("New First Name"),
+						class => 'col-form-label col-sm-6' =%>
+					<div class="col-sm-6">
+						<%= text_field newFirstName => '', id => 'newFirstName', class => 'form-control', dir => 'ltr' =%>
+					</div>
+				</div>
+				<div class="row mb-2">
+					<%= label_for newLastName => maketext("New Last Name"),
+						class => 'col-form-label col-sm-6' =%>
+					<div class="col-sm-6">
+						<%= text_field newLastName => '', id => 'newLastName', class => 'form-control', dir => 'ltr' =%>
+					</div>
+				</div>
+			</div>
+		</div>
+	% }
+	%
 	% if ($authz->hasPermissions($userID, 'change_password')) {
-		<h2><%= maketext('Change Password') %></h2>
+		<h2><%= maketext('Password') %></h2>
 		<div class="row mb-2">
 			<div class="col-lg-8 col-md-10">
 				<div class="row mb-2">
 					<%= label_for 'currPassword', class => 'col-form-label col-sm-6', begin =%>
 						<%= maketext(
-							q{[_1]'s Current Password},
-							$c->{user}->first_name . ' ' . $c->{user}->last_name
+							q{[_1]'s Current Password}, $eUserName
 						) =%>
 					<% end =%>
 					<div class="col-sm-6">
+						<%= text_field dummyUsername => '', class => 'd-none' =%>
 						<%= password_field 'currPassword', id => 'currPassword', class => 'form-control', dir => 'ltr',
 							$c->{has_password} ? () : (disabled => 1) =%>
 					</div>
@@ -38,15 +76,16 @@
 					<%= label_for newPassword => maketext("[_1]'s New Password", $eUserName),
 						class => 'col-form-label col-sm-6' =%>
 					<div class="col-sm-6">
-						<%= password_field 'newPassword', id => 'newPassword', class => 'form-control', dir => 'ltr' =%>
+						<%= password_field 'newPassword', id => 'newPassword', class => 'form-control',
+							dir => 'ltr', autocomplete => 'new-password' =%>
 					</div>
 				</div>
 				<div class="row mb-2">
 					<%= label_for confirmPassword => maketext("Confirm [_1]'s New Password", $eUserName),
 						class => 'col-form-label col-sm-6' =%>
 					<div class="col-sm-6">
-						<%= password_field 'confirmPassword', id => 'confirmPassword',
-							class => 'form-control', dir => 'ltr' =%>
+						<%= password_field 'confirmPassword', id => 'confirmPassword', class => 'form-control',
+							dir => 'ltr', autocomplete => 'new-password' =%>
 					</div>
 				</div>
 			</div>
@@ -54,15 +93,15 @@
 	% }
 	%
 	% if ($authz->hasPermissions($userID, 'change_email_address')) {
-		<h2><%= maketext('Change Email Address') %></h2>
+		<h2><%= maketext('Email Address') %></h2>
 		<div class="row mb-2">
 			<div class="col-lg-8 col-md-10">
 				<div class="row mb-2">
 					<%= label_for currAddress => maketext("[_1]'s Current Address", $eUserName),
 						class => 'col-form-label col-sm-6' =%>
 					<div class="col-sm-6">
-						<%= text_field currAddress => $c->{effectiveUser}->email_address,
-							readonly => undef, id => 'currAddress', class => 'form-control', dir => 'ltr' =%>
+						<%= text_field currAddress => $c->{effectiveUser}->email_address, readonly => undef,
+							id => 'currAddress', class => 'form-control bg-light', dir => 'ltr' =%>
 					</div>
 				</div>
 				<div class="row mb-2">
@@ -77,7 +116,7 @@
 	% }
 	%
 	% if ($authz->hasPermissions($userID, 'change_pg_display_settings')) {
-		<h2><%= maketext('Change Display Settings') %></h2>
+		<h2><%= maketext('Display Settings') %></h2>
 		%
 		% my $display_settings_block = begin
 			% my $curr_displayMode = $c->{effectiveUser}->displayMode || $ce->{pg}{options}{displayMode};
@@ -170,5 +209,5 @@
 		% }
 	% }
 	%
-	<%= submit_button maketext('Change Account Settings'), name => 'changeOptions', class => 'btn btn-primary' =%>
+	<%= submit_button maketext('Save Account Settings'), name => 'changeOptions', class => 'btn btn-primary' =%>
 % end

--- a/templates/HelpFiles/Options.html.ep
+++ b/templates/HelpFiles/Options.html.ep
@@ -22,6 +22,14 @@
 		. 'login_proctor or higher for the permissions to change password, change email address, and change display '
 		. 'settings used in pg problems.') =%>
 </p>
+<h2><%= maketext('Name') %></h2>
+<p>
+	<%= maketext('The first and last name can be any combination of letters, numbers and special symbols. Name changes '
+		. 'and preferences can be respected here. Students should use a name that will not confuse their instructor. '
+		. 'If WeBWorK is used with an LMS (Canvas, Moodle, D2L, Blackboard, etc) the LMS might periodically override '
+		. 'a name setting here if WeBWorK is configured to allow that. Name settings will only appear here if a user '
+		. 'has permission to change their name.') =%>
+</p>
 <h2><%= maketext('Password') %></h2>
 <p>
 	<%= maketext('The password can be any combination of letters, numbers and special symbols. Students are encouraged '


### PR DESCRIPTION
This is mostly so that a user can go to Account Settings and change their first and last name. That is, if they have the new permission allowing them to do that.

This also now prints the effective user ID in the page title, to be clear which user is being altered. The individual items already said the first and last name of the user being edited, but now that we could be editing first and last names, it seemed appropriate to put the effective user ID front and center.

A few cosmetic changes:

- remove "Change" from all the sections of the Course Config page. It seems unnecessary and would now be even more repetitive than it already is.
- change the button to use "Save" instead of "Change"
- make the read-only fields visually appear as plain text 

Overall that page could probably look a little better with some layout design work. But that is for another time.

This may need changes, so I'm not opening a parallel hotfix for now.