### PR TITLE
fix some validation issues on the achievements page

### DIFF
--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -44,7 +44,7 @@ sub print_form ($self, $sets, $setProblemIds, $c) {
 		$c->tag('p', $c->maketext('Choose the set whose close date you would like to extend.')),
 		WeBWorK::AchievementItems::form_popup_menu_row(
 			$c,
-			id         => 'ext_set_id',
+			id         => 'super_ext_set_id',
 			label_text => $c->maketext('Set Name'),
 			values     => \@openSets,
 			menu_attr  => { dir => 'ltr' }
@@ -64,7 +64,7 @@ sub use_item ($self, $userName, $c) {
 	my $globalData = thaw_base64($globalUserAchievement->frozen_hash);
 	return "You are $self->{id} trying to use an item you don't have" unless $globalData->{ $self->{id} };
 
-	my $setID = $c->param('ext_set_id');
+	my $setID = $c->param('super_ext_set_id');
 	return 'You need to input a Set Name' unless defined $setID;
 
 	my $set     = $db->getMergedSet($userName, $setID);

--- a/templates/ContentGenerator/Achievements/achievement_badges.html.ep
+++ b/templates/ContentGenerator/Achievements/achievement_badges.html.ep
@@ -27,7 +27,7 @@
 					% my $percentage = int(100 * ($userAchievement->counter || 0) / $achievement->max_counter);
 					% $percentage = 100 if $percentage > 100;
 					<div class="cheevoouterbar mt-1" title="<%= maketext('[_1]% Complete', $percentage) %>"
-						aria-label="<%= maketext('[_1]% Complete', $percentage) %>" role="figure" =%>
+						aria-label="<%= maketext('[_1]% Complete', $percentage) %>" role="figure">
 						<div class="cheevoinnerbar" style="width:<%= $percentage %>%;"></div>
 					</div>
 				% }


### PR DESCRIPTION
This fixes some HTML validation errors I happened to see in the Achievements page.

* some stray accidental mojolicious control characters coming out as text in the raw HTML
* the id for the item that extends a date by 24 hours is the same as that for the one that extends by 48 hours. So if both are on the page, there is a duplicate HTML id. So this changes one of those item's id.

I noticed this while looking at that page to try and make it more clear that an item button applies to the item described above the button, not the item below the button. The current spacing makes it hard to tell:

 
<img width="639" alt="Screenshot 2024-08-18 at 11 21 52 AM" src="https://github.com/user-attachments/assets/9986d48c-cae8-4638-ae20-0c170eb5564d">

So as long as anyone is looking at this page, I will ask:  is there any objection to me structuring this differently? Currently each item is an `h3`, but I am wondering if a `dl` structure to this list would be more semantically correct. Either way, I will do something to clarify which item a given button applies to.
