### PR TITLE
correct the confirmation message when selecting sets for export

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -573,8 +573,8 @@ sub export_handler ($c) {
 	$c->{exportMode}     = 1;
 
 	return $scope eq 'all'
-		? (1, $c->maketext('All sets were exported.'))
-		: (1, $c->maketext('Selected sets were exported.'));
+		? (1, $c->maketext('All sets have been marked for export.'))
+		: (1, $c->maketext('Selected sets were marked for export.'));
 }
 
 sub cancel_export_handler ($c) {


### PR DESCRIPTION
In the Sets Manager, when you select some sets and click to export, that does not actually export those sets. It takes you to a page where you must confirm the selected sets first. So the message here saying "Selected sets were exported." is not correct. This changes that message.