### PR TITLE
Use an "expression" to specify the `session` column default in the `key` table. (hotfix of #2537)

### DIFF
--- a/lib/WeBWorK/DB/Record/Key.pm
+++ b/lib/WeBWorK/DB/Record/Key.pm
@@ -30,7 +30,7 @@ BEGIN {
 		user_id   => { type => "VARCHAR(100) NOT NULL", key => 1 },
 		key       => { type => "TEXT" },
 		timestamp => { type => "BIGINT" },
-		session   => { type => "TEXT NOT NULL DEFAULT '{}'" },
+		session   => { type => "TEXT NOT NULL DEFAULT ('{}')" },
 	);
 }
 

--- a/lib/WeBWorK/DB/Record/LTILaunchData.pm
+++ b/lib/WeBWorK/DB/Record/LTILaunchData.pm
@@ -30,7 +30,7 @@ BEGIN {
 		state     => { type => "VARCHAR(200) NOT NULL", key => 1 },
 		nonce     => { type => "TEXT NOT NULL" },
 		timestamp => { type => "BIGINT" },
-		data      => { type => "TEXT NOT NULL DEFAULT '{}'" }
+		data      => { type => "TEXT NOT NULL DEFAULT ('{}')" }
 	);
 }
 


### PR DESCRIPTION
MySQL requires that the default value for a `TEXT` column be written as an expression.  See https://dev.mysql.com/doc/refman/8.4/en/data-type-defaults.html. MariaDB apparently works fine without this, but works fine with it as well.

This fixes issue #2536.