### PR TITLE
Update date and version in webwork2.sty

### DIFF
--- a/assets/tex/webwork2.sty
+++ b/assets/tex/webwork2.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{webwork2}[2024/08/28 version 2.19]
+\ProvidesPackage{webwork2}[2024/08/28 version 3]
 
 % packages that are used by webwork2 itself, probably by Hardcopy.pm
 \usepackage{path}

--- a/assets/tex/webwork2.sty
+++ b/assets/tex/webwork2.sty
@@ -1,5 +1,5 @@
 \NeedsTeXFormat{LaTeX2e}
-\ProvidesPackage{webwork2}[2023/06/26 version 2.18]
+\ProvidesPackage{webwork2}[2024/08/28 version 2.19]
 
 % packages that are used by webwork2 itself, probably by Hardcopy.pm
 \usepackage{path}


### PR DESCRIPTION
I'm assuming that we want to keep the version of webwork2.sty in sync with the version of WW.

I guess that this (and pg.sty in the pg repo) should probably be added to the release checklist.  Does such a thing exist?