### PR TITLE
Cannot, toward, and typos

### DIFF
--- a/assets/pg/PGMLLab/PGML-lab.pg
+++ b/assets/pg/PGMLLab/PGML-lab.pg
@@ -507,7 +507,7 @@ TEXT(tag(
 								>]{ [ style => 'border: 1px solid black; padding: 1rem;' ] }
 
 								One useful application is when using the parserMultiAnswer.pl macro with
-								singleResult answers. Wrap the answers in in a div tag with the
+								singleResult answers. Wrap the answers in a div tag with the
 								"ww-feedback-container" class to tell PG where to place the feedback
 								button. The feedback button will be placed at the end of the containing div
 								tag.

--- a/bin/dev_scripts/run-perltidy.pl
+++ b/bin/dev_scripts/run-perltidy.pl
@@ -28,7 +28,7 @@ Run perltidy on webwork2 source files.
 
 =head1 OPTIONS
 
-For this script to work the the .perltidyrc file in the webwork2 root directory
+For this script to work the .perltidyrc file in the webwork2 root directory
 must be readable.  Note that the webwork2 root directory is automatically
 detected.
 

--- a/lib/Mojolicious/WeBWorK/Tasks/AchievementNotification.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/AchievementNotification.pm
@@ -71,7 +71,7 @@ sub send_achievement_notification ($job, $ce, $db, $mail_data) {
 	$compartment->share_from('main',
 		[qw(%Encode:: %Mojo::Base:: %Mojo::Exception:: %Mojo::Template:: %WeBWorK::SafeTemplate::)]);
 
-	# Since the WeBWorK::SafeTemplate module can not add "no warnings 'ambiguous'", those warnings must be prevented
+	# Since the WeBWorK::SafeTemplate module cannot add "no warnings 'ambiguous'", those warnings must be prevented
 	# with the following $SIG{__WARN__} handler.
 	local $SIG{__WARN__} = sub {
 		my $warning = shift;

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -63,7 +63,7 @@ sub use_item ($self, $userName, $c) {
 	# Validate data
 
 	return q{This item won't work unless your instructor enables the reduced scoring feature.  }
-		. 'Let your instructor know that you recieved this message.'
+		. 'Let your instructor know that you received this message.'
 		unless $ce->{pg}{ansEvalDefaults}{reducedScoringPeriod};
 
 	my $globalUserAchievement = $db->getGlobalUserAchievement($userName);

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -213,7 +213,7 @@ sub get_credentials ($self) {
 		}
 
 		# Save these for later if they are available in the JWT.  It is important that the lti_lms_user_id be updated
-		# with the 'sub' value from the claim.  The value from the state can not entirely be trusted.  In addition, this
+		# with the 'sub' value from the claim.  The value from the state cannot entirely be trusted.  In addition, this
 		# may not be the same as the original login_hint (it is different for Canvas, but the same for Moodle).
 		$c->stash->{lti_lms_user_id} = $claims->{sub};
 		$c->stash->{lti_lms_lineitem} =

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -323,7 +323,7 @@ async sub submit_grade ($self, $LMSuserID, $lineitem, $scoreGiven, $scoreMaximum
 # already exist.  If $private is true then the JSON decoded private key is returned, otherwise the JSON decoded public
 # key is returned as a keyset. If an error occurs in this process then the returned key will be undefined, and the error
 # that was thrown will also be returned. Note that this is not a class method and the only required parameter is $ce
-# which should be a a minimal course environment.  The course environment is only needed to determine the site DATA
+# which should be a minimal course environment.  The course environment is only needed to determine the site DATA
 # directory.
 sub get_site_key ($ce, $private = 0) {
 	my $key;

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -39,7 +39,7 @@ sub verify {
 	my $c    = $self->{c};
 
 	# At this point the usual authentication has already occurred and the user has been verified.  If the
-	# use_grade_auth_proctor option is set to 'No', then proctor authorization is not not needed.  So return
+	# use_grade_auth_proctor option is set to 'No', then proctor authorization is not needed.  So return
 	# 1 here to skip proctor authorization and proceed on to the GatewayQuiz module which will grade the test.
 	if ($c->req->body_params->param('submitAnswers')) {
 		my ($setName, $versionNum) = grok_vsetID($c->stash('setID'));

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -404,7 +404,7 @@ sub checkSet {
 		}
 		# Don't allow versioned sets to be viewed from the problem-list page.
 		if ($node_name eq 'problem_list') {
-			return $c->maketext("Requested version ([_1]) of set '[_2]' can not be directly accessed.", $verNum,
+			return $c->maketext("Requested version ([_1]) of set '[_2]' cannot be directly accessed.", $verNum,
 				$setName);
 		}
 	} else {

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -457,7 +457,7 @@ sub getConfigValues ($ce) {
 						. 'answers.</li><li><b>SMAshowHints</b>: Show hints <i>for the new problem</i> (assuming '
 						. 'hints exist).</li></ul>Note: There is very little point enabling the Show Me Another '
 						. 'feature unless you check at least one of these options. Otherwise the students would '
-						. 'simply see a new version that can not be attempted or learned from.'
+						. 'simply see a new version that cannot be attempted or learned from.'
 				),
 				min    => 0,
 				values => [ 'SMAcheckAnswers', 'SMAshowSolutions', 'SMAshowCorrect', 'SMAshowHints' ],

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -358,7 +358,7 @@ sub getConfigValues ($ce) {
 						. 'to set the default length of the reduced scoring period and the value of work done in '
 						. 'the reduced scoring period below.</p><p>To use this, you also have to enable Reduced '
 						. 'Scoring for individual assignments and set their Reduced Scoring Dates by editing the '
-						. 'set data.</p><p>This works with the avg_problem_grader (which is the the default grader) '
+						. 'set data.</p><p>This works with the avg_problem_grader (which is the default grader) '
 						. 'and the std_problem_grader (the all or nothing grader). It will work with custom graders '
 						. 'if they are written appropriately.</p>'
 				),
@@ -374,7 +374,7 @@ sub getConfigValues ($ce) {
 						. 'will see the message "You are in the Reduced Scoring Period: All additional work done '
 						. 'counts 50% of the original." </p><p>To use this, you also have to enable Reduced Scoring '
 						. 'and set the Reduced Scoring Date for individual assignments by editing the set data '
-						. 'using the Sets Manager.</p><p>This works with the avg_problem_grader (which is the the '
+						. 'using the Sets Manager.</p><p>This works with the avg_problem_grader (which is the '
 						. 'default grader) and the std_problem_grader (the all or nothing grader). It will work '
 						. 'with custom graders if they are written appropriately.</p>'
 				),
@@ -838,7 +838,7 @@ sub getConfigValues ($ce) {
 				var  => 'feedback_by_section',
 				doc  => x('Feedback by Section.'),
 				doc2 => x(
-					'By default, feedback is always sent to all users specified to recieve feedback. This '
+					'By default, feedback is always sent to all users specified to receive feedback. This '
 						. 'variable sets the system to only email feedback to users who have the same section as '
 						. 'the user initiating the feedback. I.e., feedback will only be sent to section leaders.'
 				),

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1149,7 +1149,7 @@ C<effectiveUser>, and C<key>) are included with their default values.
 =item authen
 
 If set to a false value, the authentication parameters (C<user>,
-C<effectiveUser>, and C<key>) are included in the the generated link unless
+C<effectiveUser>, and C<key>) are included in the generated link unless
 explicitly listed in C<params>.
 
 =item use_abs_url

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -377,7 +377,7 @@ sub header {
 Not defined in this package.
 
 May be defined by a subclass to perform any early processing that is needed.
-This method can not be used if responding with a file or redirect.
+This method cannot be used if responding with a file or redirect.
 
 This method may be asynchronous.
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1033,7 +1033,7 @@ async sub pre_header_initialize ($c) {
 			}
 		}
 
-		# Finally, log student answers answers are being submitted, provided that answers can be recorded.  Note that
+		# Finally, log student answers that are being submitted, provided that answers can be recorded.  Note that
 		# this will log an overtime submission (or any case where someone submits the test, or spoofs a request to
 		# submit a test).
 		my $answer_log = $ce->{courseFiles}{logs}{answer_log};

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -549,7 +549,7 @@ async sub pre_header_initialize ($c) {
 
 				$problem = $db->getMergedProblemVersion($effectiveUserID, $setID, $setVersionNumber, $setPNum[0]);
 
-				# Convert the floating point value from Time::HiRes to an integer for use below. Truncate towards 0.
+				# Convert the floating point value from Time::HiRes to an integer for use below. Truncate toward 0.
 				my $timeNowInt = int($c->submitTime);
 
 				# Set up creation time, and open and due dates.
@@ -872,7 +872,7 @@ async sub pre_header_initialize ($c) {
 	my $setVName  = "$setID,v$versionID";
 
 	# Report everything with the request submit time. Convert the floating point
-	# value from Time::HiRes to an integer for use below. Truncate towards 0.
+	# value from Time::HiRes to an integer for use below. Truncate toward 0.
 	my $timeNowInt = int($c->submitTime);
 
 	# Answer processing

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -994,7 +994,7 @@ async sub pre_header_initialize ($c) {
 						. $problem->num_correct . "\t"
 						. $problem->num_incorrect);
 			} elsif ($c->{submitAnswers}) {
-				# This is the case answers were submitted but can not be saved. Report an error message.
+				# This is the case answers were submitted but cannot be saved. Report an error message.
 				if ($c->{isClosed}) {
 					$scoreRecordedMessage[ $probOrder[$i] ] =
 						$c->maketext('Your score was not recorded because this problem set version is not open.');
@@ -1148,7 +1148,7 @@ async sub pre_header_initialize ($c) {
 		# is false.
 
 		# Save persistent data to database even in this case, when answers
-		# would not or can not be recorded.
+		# would not or cannot be recorded.
 		my @pureProblems = $db->getAllProblemVersions($effectiveUserID, $setID, $versionID);
 		for my $i (0 .. $#problems) {
 			# Process each problem.

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -362,7 +362,7 @@ sub delete_handler ($c) {
 	return (1, $c->maketext('Deleted [quant,_1,achievement].', scalar @achievementIDsToDelete));
 }
 
-# Handler for creating an ahcievement
+# Handler for creating an achievement
 sub create_handler ($c) {
 	my $db   = $c->db;
 	my $ce   = $c->ce;

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -311,7 +311,7 @@ sub Rename ($c) {
 
 	my $realpath = Mojo::File->new($oldfile)->realpath;
 	if (grep { $realpath eq Mojo::File->new("$c->{courseRoot}/$_")->realpath } @{ $c->ce->{uneditableCourseFiles} }) {
-		$c->addbadmessage($c->maketext('The file "[_1]" is protected and can not be renamed.', $original));
+		$c->addbadmessage($c->maketext('The file "[_1]" is protected and cannot be renamed.', $original));
 		return $c->Refresh();
 	}
 
@@ -601,7 +601,7 @@ sub unpack_archive ($c, $archive) {
 				'p',
 				$c->maketext(
 					'The following [plural,_1,file is,files are] outside the current working directory '
-						. 'and can not be safely unpacked.',
+						. 'and cannot be safely unpacked.',
 					scalar(@outside_files),
 				)
 				)
@@ -1075,7 +1075,7 @@ sub verifyPath ($c, $path, $name) {
 					$c->addbadmessage($c->maketext('You have specified an illegal path'));
 				}
 			} else {
-				$c->addbadmessage($c->maketext('You can not specify an absolute path'));
+				$c->addbadmessage($c->maketext('You cannot specify an absolute path'));
 			}
 		} else {
 			$c->addbadmessage($c->maketext('Your file name contains illegal characters'));

--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -203,7 +203,7 @@ sub delete_handler ($c) {
 	for my $jobID (keys %{ $c->stash->{selectedJobs} }) {
 		# If a job was inactive (not yet started) when the page was previously loaded, then it may be selected to be
 		# deleted.  By the time the delete form is submitted the job may have started and may now be active. In that
-		# case it can not be deleted.
+		# case it cannot be deleted.
 		if ($c->stash->{jobs}{$jobID}{state} eq 'active') {
 			$c->addbadmessage(
 				$c->maketext('Unable to delete job [_1] as it has transitioned to an active state.', $jobID));

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -421,7 +421,7 @@ sub determineTempEditFilePath ($c, $path) {
 		unless $path =~ m|^/|;
 
 	if ($path =~ /^$tmpEditFileDirectory/) {
-		$c->addbadmessage($c->maketext('The path can not be the temporary edit directory.'));
+		$c->addbadmessage($c->maketext('The path cannot be the temporary edit directory.'));
 	} else {
 		if ($path =~ /^$templatesDirectory/) {
 			$path = $c->getRelativeSourceFilePath($path);
@@ -646,7 +646,7 @@ sub saveFileChanges ($c, $outputFilePath, $backup = 0) {
 
 	unless (path_is_subdir($outputFilePath, $ce->{courseDirs}{templates}, 1)) {
 		$c->addbadmessage($c->maketext(
-			'The file [_1] is not contained in the course templates directory and can not be modified.',
+			'The file [_1] is not contained in the course templates directory and cannot be modified.',
 			$outputFilePath
 		));
 		return;
@@ -737,7 +737,7 @@ sub saveFileChanges ($c, $outputFilePath, $backup = 0) {
 			$c->{inputFilePath} = $c->{editFilePath};
 		} else {
 			$c->addbadmessage($c->maketext(
-				'The temporary file [_1] is not in the course templates directory and can not be deleted!',
+				'The temporary file [_1] is not in the course templates directory and cannot be deleted!',
 				$c->{tempFilePath}
 			));
 		}
@@ -1291,7 +1291,7 @@ sub revert_handler ($c) {
 
 	unless (path_is_subdir($c->{tempFilePath}, $ce->{courseDirs}{templates}, 1)) {
 		$c->addbadmessage($c->maketext(
-			'The temporary file [_1] is not contained in the course templates directory and can not be deleted.',
+			'The temporary file [_1] is not contained in the course templates directory and cannot be deleted.',
 			$c->{tempFilePath}
 		));
 		return;

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -52,7 +52,7 @@ The suffix for a temporary file is "user_name.tmp" by default.
 
 This is the most common type. This editor can be called by an instructor when
 viewing any problem.  The information for retrieving the source file is found
-using the problemID in order to look look up the source file path.
+using the problemID in order to look up the source file path.
 
 =item source_path_for_problem_file
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -644,7 +644,7 @@ use constant FIELD_PROPERTIES => {
 			'0' => x('No'),
 		},
 		help_text => x(
-			'If this flag is set then this problem will count towards the grade of its parent problem.  In '
+			'If this flag is set then this problem will count toward the grade of its parent problem.  In '
 				. 'general the adjusted status on a problem is the larger of the problem\'s status and the weighted '
 				. 'average of the status of its child problems which have this flag enabled.'
 		),

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1977,7 +1977,7 @@ sub initialize ($c) {
 		}
 	}
 
-	# Check that every user that that is being editing for has a valid UserSet.
+	# Check that every user that is being edited has a valid UserSet.
 	my @unassignedUsers;
 	if (@editForUser) {
 		my @assignedUsers;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -535,7 +535,7 @@ sub pre_header_initialize ($c) {
 			$use_previous_problems = 0;
 		}
 	} elsif ($c->param('view_course_set')) {
-		# View problems selected from the a set in this course
+		# View problems selected from a set in this course
 		my $set_to_display = $c->{current_library_set} // '';
 		debug("set_to_display is $set_to_display");
 		if ($set_to_display eq '') {

--- a/lib/WeBWorK/ContentGenerator/LTIAdvanced.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvanced.pm
@@ -27,7 +27,7 @@ use WeBWorK::DB;
 $Net::OAuth::PROTOCOL_VERSION = Net::OAuth::PROTOCOL_VERSION_1_0A;
 
 sub initializeRoute ($c, $routeCaptures) {
-	# If this is an LTI 1.1 content item request from an LMS course, then find the courseID of the course that that has
+	# If this is an LTI 1.1 content item request from an LMS course, then find the courseID of the course that has
 	# this LMS course name set in its course environment.  If this is a submission of the content selection form, then
 	# get it from the form parameter.
 	if ($c->current_route eq 'ltiadvanced_content_selection') {

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -233,12 +233,12 @@ sub can_showMeAnother ($c, $user, $effectiveUser, $set, $problem, $submitAnswers
 			&& $c->authen->session->{showMeAnother}{problemID} eq $problem->problem_id
 			&& ($c->{checkAnswers} || $c->{previewAnswers});
 
-		# If the student has not attempted the original problem enough times yet, then showMeAnother can not be used.
+		# If the student has not attempted the original problem enough times yet, then showMeAnother cannot be used.
 		return 0
 			if $problem->num_correct + $problem->num_incorrect + ($submitAnswers ? 1 : 0) <
 			$c->{showMeAnother}{TriesNeeded};
 
-		# If the number of showMeAnother uses has been exceeded, then the user can not use it again.
+		# If the number of showMeAnother uses has been exceeded, then the user cannot use it again.
 		return 0 if $c->{showMeAnother}{Count} >= $c->{showMeAnother}{MaxReps} && $c->{showMeAnother}{MaxReps} > -1;
 
 		return 1;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1353,12 +1353,9 @@ sub output_score_summary ($c) {
 		# If it doesn't (and its not a top level problem) then its grade doesnt matter.
 		if ($problem->counts_parent_grade() && scalar(@seq) != 1) {
 			pop @seq;
-			push(
-				@$output,
+			push(@$output,
 				$c->tag('br'),
-				$c->maketext(
-					'The score for this problem can count toward score of problem [_1].', join('.', @seq)
-				)
+				$c->maketext('The score for this problem can count toward score of problem [_1].', join('.', @seq))
 			);
 		} elsif (scalar(@seq) != 1) {
 			pop @seq;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -385,7 +385,7 @@ async sub pre_header_initialize ($c) {
 		$c->{invalidProblem} =
 			!(defined $problem && ($c->{set}->visible || $authz->hasPermissions($userID, 'view_hidden_sets')));
 
-		$c->addbadmessage($c->maketext('This problem will not count towards your grade.'))
+		$c->addbadmessage($c->maketext('This problem will not count toward your grade.'))
 			if $problem && !$problem->value && !$c->{invalidProblem};
 	}
 
@@ -1230,7 +1230,7 @@ sub output_score_summary ($c) {
 				$c->maketext(
 					'Your overall recorded score is [_1].  [_2]',
 					wwRound(0, $problem->status * 100) . '%',
-					$problem->value ? '' : $c->maketext('(This problem will not count towards your grade.)')
+					$problem->value ? '' : $c->maketext('(This problem will not count toward your grade.)')
 				),
 				$c->tag('br')
 				)
@@ -1349,7 +1349,7 @@ sub output_score_summary ($c) {
 				);
 			}
 		}
-		# Show information if this problem counts towards the grade of its parent.
+		# Show information if this problem counts toward the grade of its parent.
 		# If it doesn't (and its not a top level problem) then its grade doesnt matter.
 		if ($problem->counts_parent_grade() && scalar(@seq) != 1) {
 			pop @seq;
@@ -1357,7 +1357,7 @@ sub output_score_summary ($c) {
 				@$output,
 				$c->tag('br'),
 				$c->maketext(
-					'The score for this problem can count towards score of problem [_1].', join('.', @seq)
+					'The score for this problem can count toward score of problem [_1].', join('.', @seq)
 				)
 			);
 		} elsif (scalar(@seq) != 1) {

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -132,7 +132,7 @@ sub siblings ($c) {
 	return '' unless $authz->hasPermissions($user, 'navigation_allowed');
 
 	# Note that listUserSets does not list versioned sets, but listUserSetsWhere does.  On the other hand, listUserSets
-	# can not sort in the database, while listUserSetsWhere can.
+	# cannot sort in the database, while listUserSetsWhere can.
 	my @setIDs =
 		map { $_->[1] } $db->listUserSetsWhere({ user_id => $eUserID, set_id => { not_like => '%,v%' } }, 'set_id');
 

--- a/lib/WeBWorK/ContentGenerator/Skeleton.pm
+++ b/lib/WeBWorK/ContentGenerator/Skeleton.pm
@@ -21,7 +21,7 @@
 #
 # When you've finished, I recommend you do some cleanup. These modules are much
 # easier to maintain if they doesn't contain "vestigal" garbage code. Remove the
-# "SKEL" comments and anything else that that you're not using in your module.
+# "SKEL" comments and anything else that you're not using in your module.
 
 # SKEL: Declare the name and superclass of your module here:
 package WeBWorK::ContentGenerator::Skeleton;

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -87,7 +87,7 @@ In C<%dblayout>, each table is assigned a record class, used for passing
 complete records to and from the database. The default record classes are
 subclasses of the WeBWorK::DB::Record class, and are named as follows: User,
 Password, PermissionLevel, Key, Set, UserSet, Problem, UserProblem. In the
-following documentation, a reference the the record class for a table means the
+following documentation, a reference the record class for a table means the
 record class currently defined for that table in C<%dbLayout>.
 
 =cut

--- a/lib/WeBWorK/DB/Schema.pm
+++ b/lib/WeBWorK/DB/Schema.pm
@@ -41,7 +41,7 @@ corresponding field is not used in the match. Some methods require all elements
 of C<@keyparts> to be defined. This is noted below.
 
 A "record key", as in the C<list> method, is a reference to a list containing
-values which correspond to the the fields returned by the C<KEYFIELDS> method
+values which correspond to the fields returned by the C<KEYFIELDS> method
 of the table's record class.
 
 =cut

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -386,7 +386,7 @@ sub rebuild_indexes {
 	my @indexes = grep { $_->[3] == 1 } @{ $self->dbh->selectall_arrayref("SHOW INDEXES FROM `$sql_table_name`") };
 
 	# The columns need to be obtained from the database to determine the types of the columns.  The information from the
-	# schema can not be trusted because it doesn't have information about the field being dropped.  Note that each
+	# schema cannot be trusted because it doesn't have information about the field being dropped.  Note that each
 	# element of the returned array is an array reference of the form [ Field, Type, Null, Key, Default, Extra ] and
 	# Extra contains AUTO_INCREMENT for those fields that have that attribute.
 	my $columns = $self->dbh->selectall_arrayref("SHOW COLUMNS FROM `$sql_table_name`");

--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -662,7 +662,7 @@ SET: for my $set (@sets) {
 				};
 		}
 
-		# These dates can not be created in locale of the course language and need to be in the specified format.  The
+		# These dates cannot be created in locale of the course language and need to be in the specified format.  The
 		# set import method uses the WeBWorK::Utils::parseDateTime method which does not know how to parse dates in
 		# other locales than the hard coded old format.  Furthermore, even modern libraries that parse date/time strings
 		# claim not to be able to do so reliably when they are localized.

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -628,7 +628,7 @@ If C<$field> is a string naming a single field, then this returns the elements
 in C<@items> sorted by that field.
 
 If C<$field> is a reference to an array of strings each naming a field, then
-this returns a the entries of C<@items> sorted first by the first name field,
+this returns the entries of C<@items> sorted first by the first name field,
 then by second, etc.
 
 A natural sort algorithm is used for sorting, i.e., numeric parts are sorted

--- a/lib/WeBWorK/Utils/FormatRecords.pm
+++ b/lib/WeBWorK/Utils/FormatRecords.pm
@@ -152,7 +152,7 @@ Given the name of a record class, returns the preset formats available for that
 class.
 
 The return value is a reference to a list of two element lists. The first
-element in each list is a a string description of a format name and the second
+element in each list is a string description of a format name and the second
 element is the format name.  The return value is suitable for passing as the
 second value argument to the Mojolicious select_field tag helper method.
 

--- a/lib/WeBWorK/Utils/JITAR.pm
+++ b/lib/WeBWorK/Utils/JITAR.pm
@@ -241,7 +241,7 @@ ID: for my $id (@problemIDs) {
 			next ID unless $seq[$_] == $problemSeq[$_];
 		}
 
-		# Check to see if this counts towards the parent grade.
+		# Check to see if this counts toward the parent grade.
 		my $problem = $db->getMergedProblem($userProblem->user_id, $userProblem->set_id, $id);
 
 		die "Couldn't get problem $id for user "
@@ -285,7 +285,7 @@ ID: for my $id (@problemIDs) {
 			next ID unless $seq[$_] == $problemSeq[$_];
 		}
 
-		# Check to see if this counts towards the parent grade
+		# Check to see if this counts toward the parent grade
 		my $problem = $db->getMergedProblem($userProblem->user_id, $userProblem->set_id, $id);
 
 		die "Couldn't get problem $id for user "
@@ -303,7 +303,7 @@ ID: for my $id (@problemIDs) {
 		push @scores,  jitar_problem_adjusted_status($problem, $db);
 	}
 
-	# If no children count towards the problem grade return status.
+	# If no children count toward the problem grade return status.
 	return $userProblem->status unless (@weights && @scores);
 
 	# If children do count then return the larger of the two.

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -100,7 +100,7 @@ async sub process_and_log_answer ($c) {
 		if (!$authz->hasPermissions($effectiveUser, 'dont_log_past_answers')) {
 			# Use the time the submission processing began, but must convert the
 			# floating point value from Time::HiRes to an integer for use below.
-			# Truncate towards 0 intentionally, so the integer value set is never
+			# Truncate toward 0 intentionally, so the integer value set is never
 			# larger than the original floating point value.
 			my $timestamp = int($c->submitTime);
 

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -239,7 +239,7 @@ This method requires a course environment, user, set, problem, psvn, form
 fields, and translation options.  These are passed to the WeBWorK::PG
 constructor inside of a subprocess.  The created object is then parsed into a
 hash that containing all of the data webwork2 needs for rendering and processing
-the problem.  Note that this hash can not contain any blessed references.  Those
+the problem.  Note that this hash cannot contain any blessed references.  Those
 will all be lost in the return value from the process.
 
 The return value of the method is a Mojo::Promise that will resolve to the above

--- a/lib/WeBWorK/Utils/SortRecords.pm
+++ b/lib/WeBWorK/Utils/SortRecords.pm
@@ -74,7 +74,7 @@ Given the name of a record class, returns the sort methods available for that
 class.
 
 The return value is a reference to a list of two element lists. The first
-element in each list is a a string description of the sort method and the second
+element in each list is a string description of the sort method and the second
 element is the sort name.  The return value is suitable for passing as the
 second value argument to the Mojolicious select_field tag helper method.
 

--- a/lib/WeBWorK/Utils/Tags.pm
+++ b/lib/WeBWorK/Utils/Tags.pm
@@ -211,7 +211,7 @@ sub new {
 	my $textno;
 	my $textinfo = [];
 
-	open(IN, '<:encoding(UTF-8)', "$name") or die "can not open $name: $!";
+	open(IN, '<:encoding(UTF-8)', "$name") or die "cannot open $name: $!";
 	if ($name !~ /pg$/ && $name !~ /\.pg\.[-a-zA-Z0-9_.@]*\.tmp$/) {
 		warn "Not a pg file";    #print caused trouble with XMLRPC
 		$self->{file} = undef;
@@ -421,10 +421,10 @@ sub dumptags {
 sub write {
 	my $self = shift;
 	# First read it into an array
-	open(IN, $self->{file}) or die "can not open $self->{file}: $!";
+	open(IN, $self->{file}) or die "cannot open $self->{file}: $!";
 	my @lines = <IN>;
 	close(IN);
-	my $fh = IO::File->new(">" . $self->{file}) or die "can not open $self->{file}: $!";
+	my $fh = IO::File->new(">" . $self->{file}) or die "cannot open $self->{file}: $!";
 	my ($line, $lineno) = ('', 0);
 	while ($line = shift @lines) {
 		$lineno++;

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -60,7 +60,7 @@ sub putUserProblem {
 	}
 
 	# The status is the only thing that users with the problem_grader permission can change.
-	# This method can not be called without the problem_grader permission.
+	# This method cannot be called without the problem_grader permission.
 	$userProblem->{status} = $params->{status} if defined $params->{status};
 
 	# Remove the needs_grading flag if the mark_graded parameter is set.
@@ -99,7 +99,7 @@ sub putProblemVersion {
 	}
 
 	# The status is the only thing that users with the problem_grader permission can change.
-	# This method can not be called without the problem_grader permission.
+	# This method cannot be called without the problem_grader permission.
 	$problemVersion->{status} = $params->{status} if defined $params->{status};
 
 	# Remove the needs_grading flag if the mark_graded parameter is set.
@@ -137,7 +137,7 @@ sub putPastAnswer {
 	}
 
 	# The comment_string is the only thing that users with the problem_grader permission can change.
-	# This method can not be called without the problem_grader permission.
+	# This method cannot be called without the problem_grader permission.
 	$pastAnswer->{comment_string} = $params->{comment_string} if defined $params->{comment_string};
 
 	eval { $db->putPastAnswer($pastAnswer) };

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -370,7 +370,7 @@
 % $action =~ s/(test_mode\/$setID)\/?$/$1,v$setVersionID\//;
 %
 % if (!$c->{can}{recordAnswersNextTime} && !$c->{can}{showWork}) {
-	% # Problems can not be shown.
+	% # Problems cannot be shown.
 	<div class="gwProblem">
 		% if ($c->{set}->hide_work eq 'BeforeAnswerDate') {
 			<strong>

--- a/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
+++ b/templates/ContentGenerator/Instructor/FileManager/refresh.html.ep
@@ -35,7 +35,7 @@
 		<%= select_field files => $files, id => 'files', class => 'form-select font-monospace h-100',
 			dir => 'ltr', size => 17, multiple => undef,
 			data => {
-				link_message         => maketext('Symbolic links can not be followed.'),
+				link_message         => maketext('Symbolic links cannot be followed.'),
 				non_viewable_message => maketext('This is not a viewable file type.'),
 				close_title          => maketext('Close')
 			} =%>

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -145,7 +145,7 @@
 				% for my $jobID (@$sortedJobs) {
 					<tr>
 						% if ($jobs->{$jobID}{state} eq 'active') {
-							% # Active jobs can not be deleted, and so a checkbox is not provided to select them.
+							% # Active jobs cannot be deleted, and so a checkbox is not provided to select them.
 							<td></td>
 							<td><%= $jobID =%></td>
 						% } else {

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -326,7 +326,7 @@
 		<p>
 			<b>
 				<%= maketext(
-					'Screen and Hardcopy set header information can not be overridden for individual students.') =%>
+					'Screen and Hardcopy set header information cannot be overridden for individual students.') =%>
 			</b>
 		</p>
 	% }

--- a/templates/ContentGenerator/Instructor/Stats/problem_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/problem_stats.html.ep
@@ -86,7 +86,7 @@
 %
 % if ($c->{problemRecord}->source_file =~ /^group:/) {
 	<div class="alert alert-info">
-		<%= maketext('Problem source is drawn from a grouping set and can not be directly rendered or edited.') %>
+		<%= maketext('Problem source is drawn from a grouping set and cannot be directly rendered or edited.') %>
 	</div>
 	% last;
 % }

--- a/templates/ContentGenerator/Problem/submit_buttons.html.ep
+++ b/templates/ContentGenerator/Problem/submit_buttons.html.ep
@@ -78,7 +78,7 @@
 						? maketext('The problem set is not yet open')
 						: $exhausted
 						? maketext('This feature has been used the maximum allowed number of times for this problem, '
-							. 'and can not be used again.'
+							. 'and cannot be used again.'
 						)
 						: maketext(
 							'You must attempt this problem [quant,_1,more time] before this feature is available',

--- a/templates/ContentGenerator/ProblemSet/problem_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/problem_list.html.ep
@@ -25,7 +25,7 @@
 									bs_content   => maketext(
 										q{The adjusted status of a problem is the larger of the problem's status and}
 											. 'the weighted average of the status of those problems which count '
-											. 'towards the parent grade.'
+											. 'toward the parent grade.'
 									)
 								},
 								begin =%>

--- a/templates/HelpFiles/InstructorJobManager.html.ep
+++ b/templates/HelpFiles/InstructorJobManager.html.ep
@@ -73,7 +73,7 @@
 	</dd>
 	<dt><%= maketext('Delete') %></dt>
 	<dd>
-		<%= maketext('Delete selected jobs.  Note that jobs that are in the "active" state can not be deleted. '
+		<%= maketext('Delete selected jobs.  Note that jobs that are in the "active" state cannot be deleted. '
 			. 'Jobs that are in the "inactive" state can be deleted, but it is possible that by the time the request '
 			. 'to delete the job occurs the job may have transitioned into the "active" state.  In that case the job '
 			. 'will not be deleted. Jobs that are in the "finished" or "failed" states can always be deleted.') =%>

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -164,7 +164,7 @@
 				. 'set detail page of the "Sets Manager".') =%>
 		</p>
 		<p>
-			<%= maketext('If the original problem can not be edited than the path name must be changed in order to be '
+			<%= maketext('If the original problem cannot be edited than the path name must be changed in order to be '
 				. 'allowed to save the problem. Adding "local/" to the beginning of the original path is the default '
 				. 'solution. All locally created and edited files will then appear in a subdirectory named '
 				. '"local".') =%>

--- a/templates/HelpFiles/InstructorUserDetail.html.ep
+++ b/templates/HelpFiles/InstructorUserDetail.html.ep
@@ -36,5 +36,5 @@
 		. '(The grade of each problem is called the "status".) You can also change the number of allowed attempts and '
 		. q{further modify the individual student's homework set.) You will also be able to change a student's seed }
 		. q{which determines the individual values used in the individual version of the student's problem and the }
-		. 'weight (how much a problem counts towards the grade.)') =%>
+		. 'weight (how much a problem counts toward the grade.)') =%>
 </p>

--- a/templates/HelpFiles/Options.html.ep
+++ b/templates/HelpFiles/Options.html.ep
@@ -31,7 +31,7 @@
 </p>
 <h2><%= maketext('Email Address') %></h2>
 <p>
-	<%= maketext('It is important that students enter an email address or they will not recieve any of the important '
+	<%= maketext('It is important that students enter an email address or they will not receive any of the important '
 		. 'emails sent by the instructor. The email address will only be present on the page if the user has '
 		. 'permission to change the email address.') =%>
 </p>


### PR DESCRIPTION
I have had a typos branch running, collecting typos I notice that are unrelated to whatever I am working on. So one thing here is those typos.

Also as I was reviewing UK versus US English relating to #2553, I found that 'toward' is the US variant and 'towards' is preferred in the UK. So I changed several 'towards' to the US version. If this is OK, perhaps I will then need to change the en-GB to use 'towards' again.

Lastly, it came up that whether it's the US or the UK, 'cannot' is preferred over 'can not', and I made such changes.

These three things are in separate commits if any of them is not a good change to make. This is just all rather cosmetic/irrelevant stuff, so I packaged them together. 