### PR TITLE
in Course Config, don't claim database settings are defaults

### DIFF
--- a/lib/WeBWorK/ConfigObject/setting.pm
+++ b/lib/WeBWorK/ConfigObject/setting.pm
@@ -18,7 +18,14 @@ use Mojo::Base 'WeBWorK::ConfigObject', -signatures;
 
 # Configure settings in the course's setting table.
 
-sub get_value ($self, $ce) { return $self->{c}->db->getSettingValue($self->{var}) // '' }
+sub get_value ($self, $ce) {
+	# If the course name of the controller's course environment is the same as the passed course environment, then
+	# return the value from the database.  Otherwise this is the default site wide setting. So return the empty string
+	# (there is no default).
+	return $self->{c}->ce->{courseName} eq $ce->{courseName}
+		? ($self->{c}->db->getSettingValue($self->{var}) // '')
+		: '';
+}
 
 # This actually changes a database value, and so must return the empty string
 # so that it is not represented in the course's simple.conf file.


### PR DESCRIPTION
IIRC when I added the course title as something you can change in the config page (and "setting" values in general), the "Default" column was left blank for that row. Somewhere along the line things changed so now you see the current course title in the "Default" column. But that doesn't make sense. It's not like you could clear the entry in the "Current" column and it would revert to what it says in the "Default" column.

So this change makes it so that entry is once again empty.

Before:

<img width="1287" alt="Screenshot 2024-09-02 at 11 22 39 PM" src="https://github.com/user-attachments/assets/430938d9-e8c9-49ee-8a89-bfecf876ae53">

After:

<img width="1287" alt="Screenshot 2024-09-02 at 11 22 07 PM" src="https://github.com/user-attachments/assets/4774273f-0ab4-4222-9a70-d8d5c8fb4bdf">
