### PR TITLE
Preserve check and radio state when performing a submit action in the File Manager.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -135,11 +135,11 @@ sub Init ($c) {
 
 sub HiddenFlags ($c) {
 	return $c->c(
-		$c->hidden_field(dates      => ''),
-		$c->hidden_field(overwrite  => ''),
-		$c->hidden_field(unpack     => ''),
-		$c->hidden_field(autodelete => ''),
-		$c->hidden_field(autodelete => 'Automatic'),
+		$c->hidden_field(dates      => $c->getFlag('dates')),
+		$c->hidden_field(format     => $c->getFlag('format', 'Automatic')),
+		$c->hidden_field(overwrite  => $c->getFlag('overwrite')),
+		$c->hidden_field(unpack     => $c->getFlag('unpack')),
+		$c->hidden_field(autodelete => $c->getFlag('autodelete')),
 	)->join('');
 }
 


### PR DESCRIPTION
This was an error in the conversion from mod_perl2 to Mojolicious.  The hidden form fields set in the `HiddenFlags` method of `WeBWorK::ContentGenerator::Instructor::FileManager` need to set the value of each field to the paramater (done via the `getFlag` method). That is how it was before the conversion to Mojolicious, but I made a mistake and dropped it in the conversion.

This fixes issue #2567.