### PR TITLE
Remove code to strip spaces from pg filenames when imported .def files

### DIFF
--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -562,7 +562,6 @@ sub readSetDef ($ce, $fileName) {
 					$problemData->{$item} = $value if defined $value;
 				} elsif ($item eq 'problem_end') {
 					# Clean up and validate values
-					$problemData->{source_file} =~ s/\s*//g;
 					push(@errors, [ 'No source_file for problem in "[_1]"', $fileName ])
 						unless $problemData->{source_file};
 


### PR DESCRIPTION
This is to address #2563.  I have tested with def files exported from 2.17.

I haven't checked if this works on the old format for .def files, but they haven't been used in many years.