### PR TITLE
Fix the `$webworkDirs{valid_symlinks}` course environment option.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -899,11 +899,11 @@ sub directoryListing ($c, $pwd) {
 			my $file = "$dir/$name";
 
 			my $type = 0;
-			$type |= 1  if -l $file;                         # Symbolic link
-			$type |= 2  if !-l $file && -d $file;            # Directory
-			$type |= 4  if -f $file;                         # Regular file
-			$type |= 8  if -T $file;                         # Text file
-			$type |= 16 if $file =~ m/\.(gif|jpg|png)$/i;    # Image file
+			$type |= 1  if $c->isSymLink($file);                 # Symbolic link
+			$type |= 2  if !$c->isSymLink($file) && -d $file;    # Directory
+			$type |= 4  if -f $file;                             # Regular file
+			$type |= 8  if -T $file;                             # Text file
+			$type |= 16 if $file =~ m/\.(gif|jpg|png)$/i;        # Image file
 
 			my $label = $name;
 			$label .= '@' if $type & 1;


### PR DESCRIPTION
This was broken in the recent rewrite of the file manager.  Any symlink to a directory listed in the `$webworkDirs{valid_symlinks}` array should be allowed to be followed.  This is a quick fix that makes those symlinks look and behave like they are actually directories in the file manager.