### PR TITLE
Fix rendering static images when checking answers in the PG problem editor.

### DIFF
--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -189,13 +189,13 @@ async sub renderProblem {
 	my $r_problem_source;
 	if ($rh->{problemSource}) {
 		$r_problem_source = \(decode_utf8_base64($rh->{problemSource}) =~ tr/\r/\n/r);
-		$problemRecord->source_file(defined $rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
+		$problemRecord->source_file($rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
 	} elsif ($rh->{rawProblemSource}) {
 		$r_problem_source = \$rh->{rawProblemSource};
-		$problemRecord->source_file(defined $rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
+		$problemRecord->source_file($rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
 	} elsif ($rh->{uriEncodedProblemSource}) {
 		$r_problem_source = \(url_unescape($rh->{uriEncodedProblemSource}));
-		$problemRecord->source_file(defined $rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
+		$problemRecord->source_file($rh->{fileName} ? $rh->{fileName} : $rh->{sourceFilePath});
 	} elsif (defined $rh->{sourceFilePath} && $rh->{sourceFilePath} =~ /\S/) {
 		$problemRecord->source_file($rh->{sourceFilePath});
 		$r_problem_source = \(readFile($ce->{courseDirs}{templates} . '/' . $rh->{sourceFilePath}));


### PR DESCRIPTION
This fixes issue #2556 essentially as @somiaj suggests (although there is no need to first check that `$rh->{fileName}` is defined).

The reason that `$rh->{fileName}` is defined is because the `default.html.ep` template always adds the `fileName` hidden field even when the `fileName` parameter is not defined in the original request. So if you click "Check Answers" it will be defined in `RenderProblem.pm` on that request.