### PR TITLE
configuration option to allow students to work on sets that are missi…

### DIFF
--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -189,6 +189,20 @@ $LTI{v1p3}{LMSrolesToWeBWorKroles} = {
 #  $userSet->answer_date($niceAnswerTime);
 #};
 
+################################################################################################
+# Miscellaneous
+################################################################################################
+
+# When grade passback mode is 'homework', someone must use a set-specific link from the LMS in
+# order for grade passback to begin happening for that set. Use of the set-specific link lets
+# WeBWorK store the set's "sourced_ID". So if there is no sourced_ID, the default behavior is
+# that a user in WeBWorK sees the sets as disabled and there is a message about needing to
+# access the set from the LMS. The following option can be set to allow users to work on the set
+# anyway. There will be no grade passback until some later time when an LMS user clicks the
+# set-specific link. In some LMSs, it is possible for the instructor to activate the link.
+
+$LTI{v1p3}{ignoreMissingSourcedID} = 0;
+
 # Do not change this.
 $LTI{v1p3}{grader} = 'WeBWorK::Authen::LTIAdvantage::SubmitGrade';
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -191,12 +191,14 @@ sub getSetStatus ($c, $set) {
 			$link_is_active = 0 unless $canViewUnopened;
 			push(@$other_messages, $c->restricted_progression_msg(0, $set->restricted_status * 100, @restricted));
 		} elsif (!$canViewUnopened
+			&& ($ce->{LTIVersion} ne 'v1p3' || !$ce->{LTI}{v1p3}{ignoreMissingSourcedID})
 			&& defined $ce->{LTIGradeMode}
 			&& $ce->{LTIGradeMode} eq 'homework'
 			&& !$set->lis_source_did)
 		{
 			# The set shouldn't be shown if LTI grade mode is set to homework and a
-			# sourced_id is not available to use to send back grades.
+			# sourced_id is not available to use to send back grades
+			# (unless we are using LTI 1.3 and $LTI{v1p3}{ignoreMissingSourcedID} is set)
 			push(
 				@$other_messages,
 				$c->maketext(


### PR DESCRIPTION
…ng the set sourced ID even in homework grade passback mode

This is what I proposed in #2582.

I'm open to changing the name of the config variable. Also since it only makes sense to do this with LTI 1.3, I put it in `authem_LTI_1_3.conf` but maybe that is not the best place.