### PR TITLE
For LTI 1.3 only consider roles in the context for automatically created users.

### DIFF
--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -144,6 +144,12 @@ $LTI{v1p3}{LMSrolesToWeBWorKroles} = {
 	'Grader'                  => 'ta',
 };
 
+# The LMS reports roles context (or membership), instititution, and system
+# roles.  WeBWorK always ignores system roles, and also ignores institution
+# roles by default.  In some cases you may also want to consider institution
+# roles.  In that case set the following to 1.
+$LTI{v1p3}{AllowInstitutionRoles} = 0;
+
 ################################################################################################
 # Local routine to modify users
 ################################################################################################

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -369,10 +369,15 @@ sub create_user ($self) {
 	# Determine the roles defined for this user defined in the LTI request and assign a permission level on that basis.
 	my @LTIroles = @{ $self->{roles} };
 
-	# Restrict to institution and context roles and remove the purl link portion (ignore system roles).
+	# Restrict to context roles and remove the purl link portion.  System roles are always ignored, but institution
+	# roles are also included if $LTI{v1p3}{AllowInstitutionRoles} = 1.
 	@LTIroles =
 		map {s|^[^#]*#||r}
-		grep {m!^http://purl.imsglobal.org/vocab/lis/v2/(membership|institution\/person)#!} @LTIroles;
+		grep {
+			m!^http://purl.imsglobal.org/vocab/lis/v2/membership#!
+			|| ($ce->{LTI}{v1p3}{AllowInstitutionRoles}
+				&& m!^http://purl.imsglobal.org/vocab/lis/v2/institution/person#!)
+		} @LTIroles;
 
 	if ($ce->{debug_lti_parameters}) {
 		warn "The adjusted LTI roles defined for this user are: \n-- " . join("\n-- ", @LTIroles),


### PR DESCRIPTION
Currently the context  and institution roles are are considered.  This makes it so that only context roles are considered by default.  If someone needs the institution roles, then the new $LTI{v1p3}{AllowInstitutionRoles} option defined in conf/authen_LTI_1_3 can be set to 1, and then those roles will also be considered.  For now system roles are always ignored (as they were before).

This is to fix the issue discussed in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8565#p21514.

