### PR TITLE
Fix multiple loading of javscript for the single problem grader. (hotfix of #2590)

### DIFF
--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -1,8 +1,11 @@
 % use WeBWorK::Utils 'wwRound';
 %
-% content_for js => begin
-	<%= javascript getAssetURL($ce, 'js/ProblemGrader/singleproblemgrader.js'), defer => undef =%>
-% end
+% if (!stash->{jsInserted}) {
+	% stash->{jsInserted} = 1;
+	% content_for js => begin
+		<%= javascript getAssetURL($ce, 'js/ProblemGrader/singleproblemgrader.js'), defer => undef =%>
+	% end
+% }
 %
 <div class="problem-grader">
 	<hr>


### PR DESCRIPTION
This is the cause of issue #2588.

If a gateway quiz has mulitple problems on the same page, then the single problem grader template is loaded once for each problem.  Each time the template is loaded, it adds the single problem grader javacript to the page.  So as many instances of the javascript are active on the page as there are problems on the page.  As such, the save button event handlers are added once for each problem on the page as well.  So when the save button is clicked, the score and comment for that problem are submitted once for each problem on the page.  All of those requests firing at the same time can cause authentication to fail because the session key can be deleted and put back in again by different processes, and the timing of things can mess things up.  Note that this does reveal some deeper database issues though.