### PR TITLE
Change key bindings for folding in PGCodeMirror.

### DIFF
--- a/htdocs/js/PGCodeMirror/pgeditor.js
+++ b/htdocs/js/PGCodeMirror/pgeditor.js
@@ -78,12 +78,10 @@
 		lineWrapping: true,
 		extraKeys: {
 			Tab: (cm) => cm.execCommand('insertSoftTab'),
-			'Shift-Ctrl-F': (cm) => cm.foldCode(cm.getCursor(), { scanUp: true }),
-			'Shift-Cmd-F': (cm) => cm.foldCode(cm.getCursor(), { scanUp: true }),
-			'Shift-Ctrl-A': (cm) => CodeMirror.commands.foldAll(cm),
-			'Shift-Cmd-A': (cm) => CodeMirror.commands.foldAll(cm),
-			'Shift-Ctrl-G': (cm) => CodeMirror.commands.unfoldAll(cm),
-			'Shift-Cmd-G': (cm) => CodeMirror.commands.unfoldAll(cm)
+			'Shift-Ctrl-[': (cm) => cm.foldCode(cm.getCursor(), { scanUp: true }),
+			'Cmd-Alt-[': (cm) => cm.foldCode(cm.getCursor(), { scanUp: true }),
+			'Ctrl-Alt-[': (cm) => CodeMirror.commands.foldAll(cm),
+			'Ctrl-Alt-]': (cm) => CodeMirror.commands.unfoldAll(cm)
 		},
 		highlightSelectionMatches: { annotateScrollbar: true },
 		matchBrackets: true,

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -76,8 +76,8 @@
 	<dd class="list-group-item">
 		<%= maketext('This is where you edit the text of the problem template. Type Ctrl-Enter while this '
 			. 'window has focus to re-render the problem. Code folding is enabled either by clicking on '
-			. 'the triangles in the gutter next to line numbers or using the shortcut Shift-Ctrl-F.  Folding '
-			. 'all regions can be accomplished with Shift-Ctrl-A and unfold all regions with Shift-Ctrl-G. '
+			. 'the triangles in the gutter next to line numbers or using the shortcut Shift-Ctrl-~[.  Folding '
+			. 'all regions can be accomplished with Ctrl-Alt-~[ and unfold all regions with Ctrl-Alt-~]. '
 			. 'Comments can be toggled with Ctrl-/.') =%>
 	</dd>
 	<dt><%= maketext('Text Editor Options') %></dt>


### PR DESCRIPTION
By default code mirror uses Shift-Ctrl-F for find/replace and Shift-Ctrl-G for find previous. These key bindings were overwritten when folding was added.

This changes the fold binding to Shift-Ctrl-W and unfold all to Shift-Ctrl-Q, so they no longer interfere with the find replace key bindings.

Note, I just picked key bindings close together, but if those who use folding have better suggestions, please share.