### PR TITLE
Remove the special case in the `getThirdPartyAssetURL` method for MathQuill.

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -401,13 +401,13 @@ sub readJSON ($fileName) {
 sub getThirdPartyAssetURL ($file, $dependencies, $baseURL, $useCDN = 0) {
 	for (keys %$dependencies) {
 		if ($file =~ /^node_modules\/$_\/(.*)$/) {
-			if ($useCDN && $1 !~ /mathquill/) {
+			if ($useCDN) {
 				return
 					"https://cdn.jsdelivr.net/npm/$_\@"
 					. substr($dependencies->{$_}, 1) . '/'
 					. ($1 =~ s/(?:\.min)?\.(js|css)$/.min.$1/gr);
 			} else {
-				return "$baseURL/$file?version=" . ($dependencies->{$_} =~ s/#/@/gr);
+				return "$baseURL/$file?version=$dependencies->{$_}";
 			}
 		}
 	}


### PR DESCRIPTION
That special handling is no longer needed now that MathQuill is installed via npm from the npm repositories.  Furthermore, jsdelivr provides the files from the package that can be used when the `$options{thirdPartyAssetsUseCDN}` option is set to 1.