### PR TITLE
Change to more reasonable dates in the Student Orientation set definition.

### DIFF
--- a/assets/pg/Student_Orientation/setStudent_Orientation.def
+++ b/assets/pg/Student_Orientation/setStudent_Orientation.def
@@ -1,8 +1,8 @@
 assignmentType          = default
 openDate                = 01/01/2024 at 12:00am
-reducedScoringDate      = 12/31/2024 at 11:59pm
-dueDate                 = 12/31/2024 at 11:59pm
-answerDate              = 12/31/2024 at 11:59pm
+reducedScoringDate      = 12/31/2045 at 11:59pm
+dueDate                 = 12/31/2045 at 11:59pm
+answerDate              = 12/31/2045 at 11:59pm
 enableReducedScoring    = N
 paperHeaderFile         = defaultHeader
 screenHeaderFile        = defaultHeader

--- a/assets/pg/Student_Orientation/setStudent_Orientation.def
+++ b/assets/pg/Student_Orientation/setStudent_Orientation.def
@@ -1,8 +1,8 @@
 assignmentType          = default
 openDate                = 01/01/2024 at 12:00am
-reducedScoringDate      = 12/31/2124 at 11:59pm
-dueDate                 = 12/31/2124 at 11:59pm
-answerDate              = 12/31/2124 at 11:59pm
+reducedScoringDate      = 12/31/2024 at 11:59pm
+dueDate                 = 12/31/2024 at 11:59pm
+answerDate              = 12/31/2024 at 11:59pm
 enableReducedScoring    = N
 paperHeaderFile         = defaultHeader
 screenHeaderFile        = defaultHeader


### PR DESCRIPTION
Using a date that is not in this century for the reduced scoring date, due date, and answer date leads to confusion due to some limited default date display formats.  Some not so intelligent locales like to only use the last two digits for the year.  For example, in the "en" locale the date displays as "12/31/24, 11:59 PM" in the date picker.  Looking at that you might think the date is set for the end of this year (at the time of this writing this year is 2024) instead of 100 years from now.

Initially, I though that the "en" US locale was the only one with this issue, but about half of the supported languages have the same problem.

This was the issue that was occurring when I was looking at the date picker during our meeting this week, and had nothing to do with the reduced scoring date being set.

Edit: This now uses December 31, 2045 as discussed in the development meeting.