### PR TITLE
Fix checkboxes for permission levels on Config page

### DIFF
--- a/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
+++ b/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
@@ -52,8 +52,8 @@ sub comparison_value ($self, $val) {
 }
 
 sub entry_widget ($self, $default, $is_secret = 0) {
-    my $c = $self->{c};
-    my $userRoles = $self->{c}->ce->{userRoles};
+	my $c         = $self->{c};
+	my $userRoles = $self->{c}->ce->{userRoles};
 	$default = role_and_above($userRoles, $default) unless ref($default) eq 'ARRAY';
 	return $c->c(
 		map {
@@ -73,7 +73,7 @@ sub entry_widget ($self, $default, $is_secret = 0) {
 					)->join('')
 				)
 			)
-	    } grep { $_ ne 'nobody' } sort { $userRoles->{$a} <=> $userRoles->{$b} } keys(%$userRoles)
+		} grep { $_ ne 'nobody' } sort { $userRoles->{$a} <=> $userRoles->{$b} } keys(%$userRoles)
 	)->join('');
 }
 

--- a/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
+++ b/lib/WeBWorK/ConfigObject/permission_checkboxlist.pm
@@ -52,8 +52,9 @@ sub comparison_value ($self, $val) {
 }
 
 sub entry_widget ($self, $default, $is_secret = 0) {
-	my $c = $self->{c};
-	$default = role_and_above($self->{c}->ce->{userRoles}, $default) unless ref($default) eq 'ARRAY';
+    my $c = $self->{c};
+    my $userRoles = $self->{c}->ce->{userRoles};
+	$default = role_and_above($userRoles, $default) unless ref($default) eq 'ARRAY';
 	return $c->c(
 		map {
 			$c->tag(
@@ -72,7 +73,7 @@ sub entry_widget ($self, $default, $is_secret = 0) {
 					)->join('')
 				)
 			)
-		} ('guest', 'student', 'login_proctor', 'grade_proctor', 'ta', 'professor', 'admin')
+	    } grep { $_ ne 'nobody' } sort { $userRoles->{$a} <=> $userRoles->{$b} } keys(%$userRoles)
 	)->join('');
 }
 


### PR DESCRIPTION
This is to address #2602.

As suggested by @Alex-Jordan it orders the permissions by their numerical levels, and skips the 'nobody' permission if it is defined.  Is it okay to hard-code skipping 'nobody'?