### PR TITLE
Update the github check formats action to use Ubuntu 24.04.

### DIFF
--- a/.github/workflows/check-formats.yml
+++ b/.github/workflows/check-formats.yml
@@ -13,9 +13,9 @@ on:
 jobs:
   perltidy:
     name: Check Perl file formatting with perltidy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container:
-      image: perl:5.34
+      image: perl:5.38
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -30,7 +30,7 @@ jobs:
 
   prettier:
     name: Check JavaScript, style, and HTML file formatting with prettier
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
The docker build is already using 24.04.  It is time to get the workflow in line.

Also update to using the perl 5.38 image which is the version of perl used by Ubuntu 24.04.

This is just maintenance.