### PR TITLE
Fix warnings that occur when the Accounts Manager page is loaded.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -236,9 +236,16 @@ sub pre_header_initialize ($c) {
 
 	# Always have a definite sort order in case the first three sorts don't determine things.
 	$c->{sortedUserIDs} = [
-		map  { $_->user_id }
-		sort { &$primarySortSub || &$secondarySortSub || &$ternarySortSub || byLastName || byFirstName || byUserID }
-		grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
+		map { $_->user_id }
+			sort {
+				$primarySortSub->()
+				|| $secondarySortSub->()
+				|| $ternarySortSub->()
+				|| byLastName()
+				|| byFirstName()
+				|| byUserID()
+		}
+			grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
 	];
 
 	return;


### PR DESCRIPTION
With perl 5.38 the sorting of users at the end of the `pre_header_initialize` method in `lib/WeBWorK/ContentGenerator/Instructor/UserList.pm` is now issuing the warning `Implicit use of @_ in subroutine entry with signatured subroutine is experimental at /opt/webwork/webwork2/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm line 239.`

This warning is really a false positive as `@_` is not actually used by the sort methods.  They instead use the global `$a` and `$b` variables. However, perl thinks that since the arguments are not explicitly listed that `@_` is being passed.  To fix this the sort subroutines need to be explicitly called with no arguments.

Note that this warning is only shown in the console.  This means that if you are running webwork2 via hypnotoad started from the webwork2 systemd service, then you won't see these warnings.