### PR TITLE
Guessing at fixes for Shibboleth issues.

### DIFF
--- a/lib/WeBWorK/Controller.pm
+++ b/lib/WeBWorK/Controller.pm
@@ -63,7 +63,7 @@ sub param ($c, @opts) {
 # Override the Mojolicious::Controller session method to set the cookie parameters
 # from the course environment the first time it is called.
 sub session ($c, @args) {
-	return if $c->stash('disable_cookies');
+	return {} if $c->stash('disable_cookies');
 
 	# Initialize the cookie session the first time this is called.
 	unless ($c->stash->{'webwork2.cookie_session_initialized'}) {


### PR DESCRIPTION
There are two problems with the Shibboleth authenticaiton that I have identified in discussion with @glarose together with analyzing code and the issues posted in the forums (see
https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8534#p21568).

The first is that the Shibboleth module overrides the WeBWorK::Authen check_session method, and does not properly initialize the database session.  This causes anything that uses the database session (which includes test proctor authentication) to fail.

The second is that the WeBWorK::Controller session method returns undefined in the case that cookies are disabled (which the Shibboleth authentication module does).  The Mojolicious::Plugin::DefaultHelpers _validation method then calls the session method expecting it to be an object or a hash reference.

I have no way to test that this fixes the issues that have been reported, and can only write code that should work.  So someone with a Shibboleth identity provider will need to test this.