### PR TITLE
Tests, disable start button when acting as another user.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -331,7 +331,8 @@ async sub pre_header_initialize ($c) {
 		$c->{assignment_type} = 'gateway';
 
 		if (!$authz->hasPermissions($userID, 'modify_problem_sets')) {
-			$c->{invalidSet} = 'You do not have the authorization level required to view/edit undefined sets.';
+			$c->{invalidSet} =
+				$c->maketext('You do not have the authorization level required to view/edit undefined sets.');
 
 			# Define these so that we can drop through to report the error in body.
 			$tmplSet = fake_set($db);
@@ -340,8 +341,8 @@ async sub pre_header_initialize ($c) {
 		} else {
 			# In this case we're creating a fake set from the input, so the input must include a source file.
 			if (!$c->param('sourceFilePath')) {
-				$c->{invalidSet} =
-					'An Undefined_Set was requested, but no source file for the contained problem was provided.';
+				$c->{invalidSet} = $c->maketext(
+					'An Undefined_Set was requested, but no source file for the contained problem was provided.');
 
 				# Define these so that we can drop through to report the error in body.
 				$tmplSet = fake_set($db);
@@ -529,9 +530,11 @@ async sub pre_header_initialize ($c) {
 				&& (
 					$effectiveUserID eq $userID
 					|| (
-						$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
-						|| ($authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student')
-							&& $c->param('createnew_ok'))
+						(
+							$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
+							|| $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student')
+						)
+						&& $c->param('createnew_ok')
 					)
 				)
 				)
@@ -586,26 +589,33 @@ async sub pre_header_initialize ($c) {
 				$currentNumAttempts = 0;
 
 			} elsif ($maxAttempts != -1 && $totalNumVersions > $maxAttempts) {
-				$c->{invalidSet} = 'No new versions of this assignment are available, '
-					. 'because you have already taken the maximum number allowed.';
+				$c->{invalidSet} = $c->maketext('No new versions of this test are available, '
+						. 'because you have already taken the maximum number allowed.');
 
-			} elsif ($effectiveUserID ne $userID
-				&& $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student'))
+			} elsif (
+				$effectiveUserID ne $userID
+				&& ($authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
+					|| $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student'))
+				)
 			{
 
-				$c->{invalidSet} =
-					"User $effectiveUserID is being acted "
-					. 'as.  If you continue, you will create a new version of this set '
-					. 'for that user, which will count against their allowed maximum '
-					. 'number of versions for the current time interval.  IN GENERAL, THIS '
-					. 'IS NOT WHAT YOU WANT TO DO.  Please be sure that you want to '
-					. 'do this before clicking the "Create new set version" link '
-					. 'below.  Alternately, PRESS THE "BACK" BUTTON and continue.';
+				$c->{invalidSet} = $c->maketext(
+					'User [_1] is being acted as.  If you continue, you will create a new version of '
+						. 'this set for that user, which will count against their allowed maximum '
+						. 'number of versions for the current time interval.  IN GENERAL, THIS IS NOT '
+						. 'WHAT YOU WANT TO DO.  Please be sure that you want to do this before clicking '
+						. 'the "Create New Test Version" button below.  Alternately, PRESS THE "BACK" BUTTON '
+						. 'and continue.',
+					$effectiveUserID
+				);
 				$c->{invalidVersionCreation} = 1;
 
 			} elsif ($effectiveUserID ne $userID) {
-				$c->{invalidSet} = "User $effectiveUserID is being acted as.  "
-					. 'When acting as another user, new versions of the set cannot be created.';
+				$c->{invalidSet} = $c->maketext(
+					'User [_1] is being acted as. When acting as another user, '
+						. 'new versions of the test cannot be created.',
+					$effectiveUserID
+				);
 				$c->{invalidVersionCreation} = 2;
 
 			} elsif (($maxAttemptsPerVersion == 0 || $currentNumAttempts < $maxAttemptsPerVersion)
@@ -615,16 +625,16 @@ async sub pre_header_initialize ($c) {
 					$versionIsOpen = 1;
 				} else {
 					$c->{invalidSet} =
-						'No new  versions of this assignment are available, because the set is not open or its time'
-						. ' limit has expired.';
+						$c->maketext('No new versions of this test are available, because the test is '
+							. 'not open or its time limit has expired.');
 				}
 
 			} elsif ($versionsPerInterval
 				&& ($currentNumVersions >= $versionsPerInterval))
 			{
 				$c->{invalidSet} =
-					'You have already taken all available versions of this test in the current time interval.  '
-					. 'You may take the test again after the time interval has expired.';
+					$c->maketext('You have already taken all available versions of this test in the current '
+						. 'time interval. You may take the test again after the time interval has expired.');
 
 			}
 
@@ -643,7 +653,7 @@ async sub pre_header_initialize ($c) {
 		}
 
 	} elsif (!$c->{invalidSet} && !$requestedVersion) {
-		$c->{invalidSet} = 'This set is closed.  No new set versions may be taken.';
+		$c->{invalidSet} = $c->maketext('This test is closed.  No new test versions may be taken.');
 	}
 
 	# If the proctor session key does not have a set version id, then add it.  This occurs when a student
@@ -656,7 +666,7 @@ async sub pre_header_initialize ($c) {
 	}
 
 	# If the set or problem is invalid, then delete any proctor session keys and return.
-	if ($c->{invalidSet} || $c->{invalidProblem}) {
+	if ($c->{invalidSet}) {
 		if (defined $c->{assignment_type} && $c->{assignment_type} eq 'proctored_gateway') {
 			delete $c->authen->session->{proctor_authorization_granted};
 		}
@@ -700,7 +710,7 @@ async sub pre_header_initialize ($c) {
 
 	# Bail without doing anything if the set isn't yet open for this user.
 	if (!($c->{isOpen} || $authz->hasPermissions($userID, 'view_unopened_sets'))) {
-		$c->{invalidSet} = 'This set is not yet open.';
+		$c->{invalidSet} = $c->maketext('This test is not yet open.');
 		return;
 	}
 
@@ -821,7 +831,7 @@ async sub pre_header_initialize ($c) {
 		my $problemN = $mergedProblems[$pIndex];
 
 		if (!defined $problemN) {
-			$c->{invalidSet} = 'One or more of the problems in this set have not been assigned to you.';
+			$c->{invalidSet} = $c->maketext('One or more of the problems in this test have not been assigned to you.');
 			return;
 		}
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -600,20 +600,19 @@ async sub pre_header_initialize ($c) {
 			{
 
 				$c->{invalidSet} = $c->maketext(
-					'User [_1] is being acted as.  If you continue, you will create a new version of '
-						. 'this set for that user, which will count against their allowed maximum '
-						. 'number of versions for the current time interval.  IN GENERAL, THIS IS NOT '
-						. 'WHAT YOU WANT TO DO.  Please be sure that you want to do this before clicking '
-						. 'the "Create New Test Version" button below.  Alternately, PRESS THE "BACK" BUTTON '
-						. 'and continue.',
+					'You are acting as user [_1].  If you continue, you will create a new version of '
+						. 'this test for that user, which will count against their allowed maximum '
+						. 'number of versions for the current time interval.  In general, this is not '
+						. 'what you want to do.  Please be sure that you want to do this before clicking '
+						. 'the "Create New Test Version" button below.  Alternatively, click "Cancel".',
 					$effectiveUserID
 				);
 				$c->{invalidVersionCreation} = 1;
 
 			} elsif ($effectiveUserID ne $userID) {
 				$c->{invalidSet} = $c->maketext(
-					'User [_1] is being acted as. When acting as another user, '
-						. 'new versions of the test cannot be created.',
+					'You are acting as user [_1], and do not have the permission to create a new test version '
+						. 'when acting as another user.',
 					$effectiveUserID
 				);
 				$c->{invalidVersionCreation} = 2;

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -48,7 +48,7 @@ async sub initialize ($c) {
 	my $eUserID = $c->param('effectiveUser');
 
 	# Don't show "Start New Test" button when acting as another user, unless user has permissions to do so.
-	$c->{hide_start_new_test} = $userID ne $eUserID
+	$c->{disable_start_new_test} = $userID ne $eUserID
 		&& !($authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
 			|| $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student'));
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -48,7 +48,7 @@ async sub initialize ($c) {
 	my $eUserID = $c->param('effectiveUser');
 
 	# Don't show "Start New Test" button when acting as another user, unless user has permissions to do so.
-	$c->{disable_start_new_test} = $userID ne $eUserID
+	$c->stash->{disable_start_new_test} = $userID ne $eUserID
 		&& !($authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
 			|| $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student'));
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -47,6 +47,11 @@ async sub initialize ($c) {
 	my $userID  = $c->param('user');
 	my $eUserID = $c->param('effectiveUser');
 
+	# Don't show "Start New Test" button when acting as another user, unless user has permissions to do so.
+	$c->{hide_start_new_test} = $userID ne $eUserID
+		&& !($authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
+			|| $authz->hasPermissions($userID, 'create_new_set_version_when_acting_as_student'));
+
 	my $user          = $db->getUser($userID);
 	my $effectiveUser = $db->getUser($eUserID);
 	$c->{set} = $authz->{merged_set};

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -90,6 +90,12 @@
 					),
 					class => 'btn btn-primary'
 				=%>
+				<%= link_to maketext('Cancel') => $c->systemLink(
+						url_for('problem_list', setID => $setID),
+						params => { effectiveUser => $effectiveUserID, user => $userID }
+					),
+					class => 'btn btn-primary'
+				=%>
 			</div>
 		% }
 	</div>

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -66,22 +66,31 @@
 % my $effectiveUserID = param('effectiveUser');
 %
 % # If the set or problem is invalid, then show that information and exit.
-% if ($c->{invalidSet} || $c->{invalidProblem}) {
+% if ($c->{invalidSet}) {
 	<div class="alert alert-danger mb-2">
 		<div class="mb-2">
-			<%= maketext(
-				'The selected problem set ([_1]) is not a valid set for [_2]: [_3]',
-				$setID, $effectiveUserID, $c->{invalidVersionCreation} ? " (acted as by $userID)" : ''
-			) =%>
+			% if ($c->{invalidVersionCreation}) {
+				<%= maketext(
+					'The selected test ([_1]) is not a valid test for [_2] (acted as by [_3]).',
+					$setID, $effectiveUserID, $userID
+				) =%>
+			% } else {
+				<%= maketext(
+					'The selected test ([_1]) is not a valid test for [_2].',
+					$setID, $effectiveUserID
+				) =%>
+			% }
 		</div>
 		<div><%= $c->{invalidSet} %></div>
 		% if ($c->{invalidVersionCreation} && $c->{invalidVersionCreation} == 1) {
-			<p>
-				<%= link_to 'Create new set version.' => $c->systemLink(
-					url_for,
-					params => { effectiveUser => $effectiveUserID, user => $userID, createnew_ok => 1 }
-				) =%>
-			</p>
+			<div class="mt-3">
+				<%= link_to maketext('Create New Test Version') => $c->systemLink(
+						url_for,
+						params => { effectiveUser => $effectiveUserID, user => $userID, createnew_ok => 1 }
+					),
+					class => 'btn btn-primary'
+				=%>
+			</div>
 		% }
 	</div>
 	%

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -126,10 +126,13 @@
 		<div class="alert alert-warning"><%= maketext('This test requires a proctor password to start.') %></div>
 	% }
 	%
-	<div class="mb-3">
-		<%= link_to maketext('Start New Test') => $c->systemLink(url_for($routeName, setID => $set->set_id)),
-			class => 'btn btn-primary' =%>
-	</div>
+	% # Hide "Start New Test" button when acting as another use who doesn't have permissions to start test.
+	% unless ($c->{hide_start_new_test}) {
+		<div class="mb-3">
+			<%= link_to maketext('Start New Test') => $c->systemLink(url_for($routeName, setID => $set->set_id)),
+				class => 'btn btn-primary' =%>
+		</div>
+	% }
 % } else {
 	% # Message about if/when next version will be available.
 	% my $msg = maketext('No more tests available.');

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -128,7 +128,7 @@
 	%
 	<div class="mb-3">
 		% # Disable "Start New Test" button when acting as another user who doesn't have permissions to start tests.
-		% if ($c->{disable_start_new_test}) {
+		% if ($disable_start_new_test) {
 			<span class="d-inline-block set-id-tooltip" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
 				data-bs-title="<%=maketext(
 					'You are acting as another user and do not have permission to start a new test for other users.'

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -126,13 +126,20 @@
 		<div class="alert alert-warning"><%= maketext('This test requires a proctor password to start.') %></div>
 	% }
 	%
-	% # Hide "Start New Test" button when acting as another use who doesn't have permissions to start test.
-	% unless ($c->{hide_start_new_test}) {
-		<div class="mb-3">
+	<div class="mb-3">
+		% # Disable "Start New Test" button when acting as another user who doesn't have permissions to start tests.
+		% if ($c->{disable_start_new_test}) {
+			<span class="d-inline-block set-id-tooltip" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
+				data-bs-title="<%=maketext(
+					'You are acting as another user and do not have permission to start a new test for other users.'
+				) %>">
+				<button class="btn btn-primary" type="button" disabled><%= maketext('Start New Test') %></button>
+			</span>
+		% } else {
 			<%= link_to maketext('Start New Test') => $c->systemLink(url_for($routeName, setID => $set->set_id)),
 				class => 'btn btn-primary' =%>
-		</div>
-	% }
+		% }
+	</div>
 % } else {
 	% # Message about if/when next version will be available.
 	% my $msg = maketext('No more tests available.');


### PR DESCRIPTION
~~Hide the "Start New Test" button when acting as another user unless the user has permissions to do so.~~

**Edit:**  This now just disables the "Start New Test" button and displays a tool tip informing the user they don't have permission to start new tests when acting as another user.

Fix some logic where the warning about creating new test version wouldn't show with the record_answers_when_acting_as_student permission, and instead the version would be created without warning.

Translate the error messages that are created for an invalidSet.

Remove the test for invalidProblem, which isn't used in tests.

Update error messages to state 'test' instead of 'set'.

Note, to me it wasn't clear from the comment in defaults.conf that the `record_answers_when_acting_as_student` also applied to creating tests and recording answers for tests, but from the code it appears that is the intent, so that is what I went with here.