### PR TITLE
Control when sets with score 0 are included in LTI grade passback

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -135,6 +135,12 @@ $LTIGradeMode = '';
 #$LTIGradeMode = 'course';
 #$LTIGradeMode = 'homework';
 
+# This can be set to 'open', 'reduced', 'close', 'answer', or 'never'. It controls when a set
+# with score 0 will be included in grades that are passed back to the LMS. For example, setting
+# this to 'close' means that a set with score 0 is only included in grades sent to the LMS once
+# it is past the set's close date.
+$LTISendZeroScores = 'open';
+
 # When set this variable sends grades back to the LMS every time a user submits an answer.  This
 # keeps students grades up to date but can be a drain on the server.
 $LTIGradeOnSubmit = 1;
@@ -170,6 +176,7 @@ $LTIMassUpdateInterval = 86400;    #in seconds
 	#'LTI{v1p3}{LMS_url}',
 	#'external_auth',
 	#'LTIGradeMode',
+	#'LTISendZeroScores',
 	#'LTIGradeOnSubmit',
 	#'LTIMassUpdateInterval',
 	#'LMSManageUserData',

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -912,6 +912,25 @@ sub getConfigValues ($ce) {
 			labels => { '' => 'None', 'course' => 'Course', 'homework' => 'Homework' },
 			type   => 'popuplist'
 		},
+		LTISendZeroScores => {
+			var  => 'LTISendZeroScores',
+			doc  => x('When to send zero scores to the LMS'),
+			doc2 => x(
+				'If the grade passback mode is "homework", this controls when a set with score 0 will have '
+					. 'that score sent to the LMS, as opposed to leaving the score null in the LMS. If the grade '
+					. 'passback mode is "course", this controls when a set with score 0 will be included in the '
+					. 'overall grade calculation that is sent to the LMS.'
+			),
+			values => [qw(open reduced close answer never)],
+			labels => {
+				open    => 'After Open Date',
+				reduced => 'After Reduced Scoring Date',
+				close   => 'After Close Date',
+				answer  => 'After Answer Date',
+				never   => 'Never'
+			},
+			type => 'popuplist'
+		},
 		LTIGradeOnSubmit => {
 			var  => 'LTIGradeOnSubmit',
 			doc  => x('Update LMS Grade Each Submit'),


### PR DESCRIPTION
The first thing I want to say about this is that I have not tested it actually works. It's too risky to try it with my production LMS. So when time permits, if anyone can test with their local Canvas or Moodle, and if that works, I'll risk trying it with my instance of D2L.

This adds a config variable `$LTISendZeroScores`. Its purpose is to control when sets with score 0 are included in passing grades data to the LMS. Its value can be `open', 'reduced', 'close', 'answer', or 'never'. The first four correspond to dates for a set. The idea is that you only include a zero-score set in grades data to the LMS if it is after this setting. So even if all sets open when the term begins, they do not necessarily contribute to tanking a student's overall grade in the LMS simply because the scores are all initially zero.

In "course" grade passback mode, zero-score sets are omitted from the overall calculation if it is presently earlier than that set's date corresponding to this setting. For example if this setting is "close", open sets with no work completed will be omitted from the scoring calculation until we reach the close date for those sets.

In "homework" grade passback mode, scores for zero-score sets are not sent to the LMS it is later than that set's date corresponding to this setting. There may already be null grade items in the LMS, and they will stay null until either we reach the appropriate date, or there is a nonzero score for the set.

This is configurable, because some instructors will always put close dates at the end of the term and want to use the reduced scoring date as the "due date". And other variations.

Note that prior to this commit, all sets are included in grade data sent to the LMS if it is after the open date. That is why I set the default for this to be `'open'`. If it's better, we could change the default behavior.

Also note that with this commit, if the score on a set is nonzero, that set will be included in grades data sent to the LMS as long as we are past the set's open date. Using the open date is hard coded. I have often thought we might want to change that behavior or make it configurable too. But I think it is a separate question from when to include sets with score zero.
