### PR TITLE
Split up macros on PODViewer index page.

### DIFF
--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -96,18 +96,39 @@ sub process_dir {
 	my $source_dir = shift;
 	return unless $source_dir =~ /\/webwork2$/ || $source_dir =~ /\/pg$/;
 
+	my $is_pg    = $source_dir =~ /\/pg$/;
 	my $dest_dir = $source_dir;
-	$dest_dir =~ s/^$webwork_root/$output_dir\/webwork2/ if ($source_dir =~ /\/webwork2$/);
-	$dest_dir =~ s/^$pg_root/$output_dir\/pg/            if ($source_dir =~ /\/pg$/);
+	$dest_dir =~ s/^$webwork_root/$output_dir\/webwork2/ unless $is_pg;
+	$dest_dir =~ s/^$pg_root/$output_dir\/pg/ if $is_pg;
 
 	remove_tree($dest_dir);
 	make_path($dest_dir);
+
+	my $sections =
+		$is_pg
+		? [ doc => 'Documentation', macros => 'Macros',        lib => 'Libraries' ]
+		: [ bin => 'Scripts',       doc    => 'Documentation', lib => 'Libraries' ];
+	my $macros = $is_pg
+		? [
+			core       => 'Core',
+			contexts   => 'Contexts',
+			parsers    => 'Parsers',
+			answers    => 'Answers',
+			graph      => 'Graph',
+			math       => 'Math',
+			ui         => 'User Interface',
+			misc       => 'Miscellaneous',
+			deprecated => 'Deprecated'
+		]
+		: [];
 
 	my $htmldocs = PODtoHTML->new(
 		source_root  => $source_dir,
 		dest_root    => $dest_dir,
 		template_dir => "$webwork_root/bin/dev_scripts/pod-templates",
 		dest_url     => $base_url,
+		sections     => $sections,
+		macros       => $macros,
 		verbose      => $verbose
 	);
 	$htmldocs->convert_pods;

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -106,8 +106,8 @@ sub process_dir {
 
 	my $sections =
 		$is_pg
-		? [ doc => 'Documentation', macros => 'Macros',        lib => 'Libraries' ]
-		: [ bin => 'Scripts',       doc    => 'Documentation', lib => 'Libraries' ];
+		? [ doc => 'Documentation', bin => 'Scripts', macros => 'Macros', lib => 'Libraries' ]
+		: [ bin => 'Scripts', doc => 'Documentation', lib => 'Libraries' ];
 	my $macros = $is_pg
 		? [
 			core       => 'Core',

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -96,39 +96,18 @@ sub process_dir {
 	my $source_dir = shift;
 	return unless $source_dir =~ /\/webwork2$/ || $source_dir =~ /\/pg$/;
 
-	my $is_pg    = $source_dir =~ /\/pg$/;
 	my $dest_dir = $source_dir;
-	$dest_dir =~ s/^$webwork_root/$output_dir\/webwork2/ unless $is_pg;
-	$dest_dir =~ s/^$pg_root/$output_dir\/pg/ if $is_pg;
+	$dest_dir =~ s/^$webwork_root/$output_dir\/webwork2/ if ($source_dir =~ /\/webwork2$/);
+	$dest_dir =~ s/^$pg_root/$output_dir\/pg/            if ($source_dir =~ /\/pg$/);
 
 	remove_tree($dest_dir);
 	make_path($dest_dir);
-
-	my $sections =
-		$is_pg
-		? [ doc => 'Documentation', bin => 'Scripts', macros => 'Macros', lib => 'Libraries' ]
-		: [ bin => 'Scripts', doc => 'Documentation', lib => 'Libraries' ];
-	my $macros = $is_pg
-		? [
-			core       => 'Core',
-			contexts   => 'Contexts',
-			parsers    => 'Parsers',
-			answers    => 'Answers',
-			graph      => 'Graph',
-			math       => 'Math',
-			ui         => 'User Interface',
-			misc       => 'Miscellaneous',
-			deprecated => 'Deprecated'
-		]
-		: [];
 
 	my $htmldocs = PODtoHTML->new(
 		source_root  => $source_dir,
 		dest_root    => $dest_dir,
 		template_dir => "$webwork_root/bin/dev_scripts/pod-templates",
 		dest_url     => $base_url,
-		sections     => $sections,
-		macros       => $macros,
 		verbose      => $verbose
 	);
 	$htmldocs->convert_pods;

--- a/bin/dev_scripts/pod-templates/category-index.mt
+++ b/bin/dev_scripts/pod-templates/category-index.mt
@@ -25,15 +25,14 @@
 	%
 	% my ($index, $macro_index, $content, $macro_content) = ('', '', '', '');
 	% for my $macro (@$macros_order) {
-		% next unless defined $pod_index->{$macro};
 		% my $new_index = begin
-			<a href="#macro-<%= $macro %>" class="nav-link"><%= $macros->{$macro} %></a>
+			<a href="#macro-<%= $macro %>" class="nav-link"><%= $macro_names->{$macro} // $macro %></a>
 		% end
 		% $macro_index .= $new_index->();
 		% my $new_content = begin
-			<h3><a href="#_podtop_" id="macro-<%= $macro %>"><%= $macros->{$macro} %></a></h3>
+			<h3><a href="#_podtop_" id="macro-<%= $macro %>"><%= $macro_names->{$macro} // $macro %></a></h3>
 			<div class="list-group mb-2">
-				% for my $file (sort { $a->[1] cmp $b->[1] } @{ $pod_index->{$macro} }) {
+				% for my $file (sort { $a->[1] cmp $b->[1] } @{ $macros->{$macro} }) {
 					<a href="<%= $file->[0] %>" class="list-group-item list-group-item-action"><%= $file->[1] %></a>
 				% }
 			</div>

--- a/bin/dev_scripts/pod-templates/category-index.mt
+++ b/bin/dev_scripts/pod-templates/category-index.mt
@@ -23,18 +23,45 @@
 		</div>
 	</div>
 	%
-	% my ($index, $content) = ('', '');
+	% my ($index, $macro_index, $content, $macro_content) = ('', '', '', '');
+	% for my $macro (@$macros_order) {
+		% next unless defined $pod_index->{$macro};
+		% my $new_index = begin
+			<a href="#macro-<%= $macro %>" class="nav-link"><%= $macros->{$macro} %></a>
+		% end
+		% $macro_index .= $new_index->();
+		% my $new_content = begin
+			<h3><a href="#_podtop_" id="macro-<%= $macro %>"><%= $macros->{$macro} %></a></h3>
+			<div class="list-group mb-2">
+				% for my $file (sort { $a->[1] cmp $b->[1] } @{ $pod_index->{$macro} }) {
+					<a href="<%= $file->[0] %>" class="list-group-item list-group-item-action"><%= $file->[1] %></a>
+				% }
+			</div>
+		% end
+		% $macro_content .= $new_content->();
+	% }
 	% for my $section (@$section_order) {
 		% next unless defined $pod_index->{$section};
 		% my $new_index = begin
 			<a href="#<%= $section %>" class="nav-link"><%= $sections->{$section} %></a>
+			% if ($section eq 'macros') {
+				<div class="nav flex-column ms-3">
+					<%= $macro_index %>
+				</div>
+			% }
 		% end
 		% $index .= $new_index->();
 		% my $new_content = begin
 			<h2><a href="#_podtop_" id="<%= $section %>"><%= $sections->{$section} %></a></h2>
 			<div class="list-group mb-2">
-				% for my $file (sort { $a->[1] cmp $b->[1] } @{ $pod_index->{$section} }) {
-					<a href="<%= $file->[0] %>" class="list-group-item list-group-item-action"><%= $file->[1] %></a>
+				% if ($section eq 'macros') {
+					<%= $macro_content =%>
+				% } else {
+					% for my $file (sort { $a->[1] cmp $b->[1] } @{ $pod_index->{$section} }) {
+						<a href="<%= $file->[0] %>" class="list-group-item list-group-item-action">
+							<%= $file->[1] %>
+						</a>
+					% }
 				% }
 			</div>
 		% end

--- a/templates/ContentGenerator/PODViewer.html.ep
+++ b/templates/ContentGenerator/PODViewer.html.ep
@@ -29,9 +29,9 @@
 	</div>
 	<h2><a href="#_podtop_" id="macros"><%= $section_names{macros} %></a></h2>
 % end
-% for my $macro (qw(core contexts parsers answers graph math ui misc deprecated)) {
+% for my $macro (sort keys %$macros) {
 	% content_for macros_toc => begin
-		<%= link_to $macro_names{$macro} => "#macro-$macro", class => 'nav-link' %>
+		<%= link_to $macro_names{$macro} // $macro => "#macro-$macro", class => 'nav-link' %>
 	% end
 	% content_for pod_links => begin
 		<h3><a href="#_podtop_" id="macro-<%= $macro %>"><%= $macro_names{$macro} %></a></h3>

--- a/templates/ContentGenerator/PODViewer.html.ep
+++ b/templates/ContentGenerator/PODViewer.html.ep
@@ -6,26 +6,62 @@
 	% lib    => maketext('Libraries'),
 	% macros => maketext('Macros')
 % );
+% my %macro_names = (
+	% answers    => maketext('Answers'),
+	% contexts   => maketext('Contexts'),
+	% core       => maketext('Core'),
+	% deprecated => maketext('Deprecated'),
+	% graph      => maketext('Graph'),
+	% math       => maketext('Math'),
+	% misc       => maketext('Miscellaneous'),
+	% parsers    => maketext('Parsers'),
+	% ui         => maketext('User Interface')
+% );
 %
-% for my $section (sort keys %$sections) {
-	% content_for toc => begin
-		<%= link_to $section_names{$section} => "#$section", class => 'nav-link' %>
+% content_for pod_links => begin
+	<h2><a href="#_podtop_" id="doc"><%= $section_names{doc} %></a></h2>
+	<div class="list-group mb-2">
+		% for (@$docs) {
+			% my $link_name = $_ =~ s!^(doc|macros)/!!r;
+			<%= link_to $link_name, 'pod_viewer', { filePath => "$_" },
+				class => 'list-group-item list-group-item-action' =%>
+		% }
+	</div>
+	<h2><a href="#_podtop_" id="macros"><%= $section_names{macros} %></a></h2>
+% end
+% for my $macro (qw(core contexts parsers answers graph math ui misc deprecated)) {
+	% content_for macros_toc => begin
+		<%= link_to $macro_names{$macro} => "#macro-$macro", class => 'nav-link' %>
 	% end
-	% content_for subjects => begin
-		<h2><a href="#_podtop_" id="<%= $section %>"><%= $section_names{$section} %></a></h2>
+	% content_for pod_links => begin
+		<h3><a href="#_podtop_" id="macro-<%= $macro %>"><%= $macro_names{$macro} %></a></h3>
 		<div class="list-group mb-2">
-			% for (@{ $sections->{$section} }) {
-				% my $link_name = $_;
-				% $link_name = $1 =~ s!/!::!gr if $link_name =~ m/^(.*)\.pm$/;
-				<%= link_to $link_name, 'pod_viewer', { filePath => "$section/$_" },
+			% for (@{ $macros->{$macro} }) {
+				<%= link_to $_, 'pod_viewer', { filePath => "macros/$macro/$_" },
 					class => 'list-group-item list-group-item-action' =%>
 			% }
 		</div>
 	% end
 % }
+% content_for pod_links => begin
+	<h2><a href="#_podtop_" id="lib"><%= $section_names{lib} %></a></h2>
+	<div class="list-group mb-2">
+		% for (@$libs) {
+			% my $link_name = $_;
+			% $link_name = $1 =~ s!/!::!gr if $link_name =~ m/^(.*)\.pm$/;
+			<%= link_to $link_name, 'pod_viewer', { filePath => "lib/$_" },
+				class => 'list-group-item list-group-item-action' =%>
+		% }
+	</div>
+% end
 % content_for sidebar => begin
 	<nav class="nav flex-column w-100">
-		<%= content 'toc' %>
+		<%= link_to $section_names{doc} => '#doc', class => 'nav-link' %>
+		<%= link_to $section_names{macros} => '#macros', class => 'nav-link' %>
+		<div class="nav flex-column ms-3">
+			<%= content 'macros_toc' %>
+		</div>
+		<%= link_to $section_names{lib} => '#lib', class => 'nav-link' %>
 	</nav>
 % end
-<%= content 'subjects' %>
+<%= content 'pod_links' %>


### PR DESCRIPTION
This splits up the macros on the PODViwer index page to be grouped by their location in the `pg/macros` directory. In addition macros are listed before the libraries. The two macros not in a subdirectory, `PG.pl` and `PGcourse.pl`, are grouped with the pod in `pg/doc`. This makes finding the POD for a specific macro easier.