### PR TITLE
Remove mention of adding instructors to admin course in help.

### DIFF
--- a/templates/HelpFiles/admin_links.html.ep
+++ b/templates/HelpFiles/admin_links.html.ep
@@ -52,8 +52,7 @@
 	</dd>
 	<dt><%= maketext('Accounts Manager') %></dt>
 	<dd>
-		<%= maketext('Manage instructors.  When instructors are added to a newly created course, they are also '
-			. 'added to the admin course with username "userID_courseID".') =%>
+		<%= maketext('Manage users. Note, only admin users have access to the course administration tools.') =%>
 	</dd>
 	<dt><%= maketext('Email') %></dt>
 	<dd><%= maketext('Send emails to selected instructors.') %></dd>


### PR DESCRIPTION
Instructors are no longer added to the admin course when creating a new course, so remove mention of this from the admin help.