### PR TITLE
Add course admin tool to manage OTP secrets.

### DIFF
--- a/htdocs/js/CourseAdmin/manage_otp_secrets.js
+++ b/htdocs/js/CourseAdmin/manage_otp_secrets.js
@@ -1,0 +1,34 @@
+(() => {
+	// Save user menus to be updated.
+	const sourceSingleUserMenu = document.getElementById('sourceSingleUserID');
+	const destSingleUserMenu = document.getElementById('destSingleUserID');
+	const sourceMultipleUserMenu = document.getElementById('sourceMultipleUserID');
+	const destResetUserMenu = document.getElementById('destResetUserID');
+
+	const updateUserMenu = (e, menu, selectFirst) => {
+		const userList = e.target.options[e.target.selectedIndex].dataset.users.split(':');
+		while (menu.length > 1) menu.lastChild.remove();
+		if (selectFirst) {
+			menu.selectedIndex = 0;
+		}
+		userList.forEach((user) => {
+			const userOption = document.createElement('option');
+			userOption.value = userOption.text = user;
+			menu.append(userOption);
+		});
+	};
+
+	// Update user menu when course ID is selected/changed.
+	document.getElementById('sourceSingleCourseID')?.addEventListener('change', (e) => {
+		updateUserMenu(e, sourceSingleUserMenu, true);
+	});
+	document.getElementById('destSingleCourseID')?.addEventListener('change', (e) => {
+		updateUserMenu(e, destSingleUserMenu, true);
+	});
+	document.getElementById('sourceMultipleCourseID')?.addEventListener('change', (e) => {
+		updateUserMenu(e, sourceMultipleUserMenu, false);
+	});
+	document.getElementById('sourceResetCourseID')?.addEventListener('change', (e) => {
+		updateUserMenu(e, destResetUserMenu, false);
+	});
+})();

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -83,7 +83,6 @@ sub pre_header_initialize ($c) {
 				}
 			} elsif (defined $c->param('confirm_retitle_course')) {
 				$method_to_call = 'do_retitle_course';
-
 			} elsif (defined $c->param('upgrade_course_tables')) {
 				@errors = $c->rename_course_validate;
 				if (@errors) {
@@ -213,6 +212,16 @@ sub pre_header_initialize ($c) {
 				}
 			} else {
 				$method_to_call = 'manage_lti_course_map_form';
+			}
+		} elsif ($subDisplay eq 'manage_otp_secrets') {
+			if (defined $c->param('action')) {
+				if ($c->param('action') eq 'reset') {
+					$method_to_call = 'reset_otp_secrets_confirm';
+				} else {
+					$method_to_call = 'copy_otp_secrets_confirm';
+				}
+			} else {
+				$method_to_call = 'manage_otp_secrets_form';
 			}
 		} elsif ($subDisplay eq 'registration') {
 			if (defined($c->param('register_site'))) {
@@ -2375,6 +2384,208 @@ sub do_save_lti_course_map ($c) {
 
 	$c->addgoodmessage($c->maketext('Saved course map.'));
 	return $c->manage_lti_course_map_form;
+}
+
+# Form to copy or reset OTP secrets.
+sub manage_otp_secrets_form ($c) {
+	my $courses = {};
+	my $dbs     = {};
+
+	# Create course data first, since it is used in all cases and initializes course db references.
+	for my $courseID (listCourses($c->ce)) {
+		my $ce = WeBWorK::CourseEnvironment->new({ courseName => $courseID });
+		$dbs->{$courseID}     = WeBWorK::DB->new($ce->{dbLayouts}{ $ce->{dbLayoutName} });
+		$courses->{$courseID} = [ $dbs->{$courseID}->listUsers ];
+	}
+
+	# Process the confirmed rest or copy actions here.
+	if ($c->param('otp_confirm_reset')) {
+		my $total    = 0;
+		my $courseID = $c->param('sourceResetCourseID');
+		for my $user ($c->param('otp_reset_row')) {
+			my $password = $dbs->{$courseID}->getPassword($user);
+			if ($password && $password->otp_secret) {
+				$password->otp_secret('');
+				$dbs->{$courseID}->putPassword($password);
+				$total++;
+			}
+		}
+		if ($total) {
+			$c->addgoodmessage($c->maketext('[_1] OTP secrets reset.', $total));
+		} else {
+			$c->addbadmessage($c->maketext('No OTP secrets reset.'));
+		}
+	} elsif ($c->param('otp_confirm_copy')) {
+		my $total = 0;
+		for my $row ($c->param('otp_copy_row')) {
+			my ($s_course, $s_user, $d_course, $d_user) = split(':', $row);
+			my $s_password = $dbs->{$s_course}->getPassword($s_user);
+			if ($s_password && $s_password->otp_secret) {
+				# Password may not be defined if using external auth, so create new password record if not.
+				# Should we check $d_user is actually valid again (was checked on previous page)?
+				my $d_password = $dbs->{$d_course}->getPassword($d_user)
+					// $dbs->{$d_course}->newPassword(user_id => $d_user);
+				$d_password->otp_secret($s_password->otp_secret);
+				$dbs->{$d_course}->putPassword($d_password);
+				$total++;
+			}
+		}
+		if ($total) {
+			$c->addgoodmessage($c->maketext('[_1] OTP secrets copied.', $total));
+		} else {
+			$c->addbadmessage($c->maketext('No OTP secrets copied.'));
+		}
+	}
+
+	return $c->include('ContentGenerator/CourseAdmin/manage_otp_secrets_form', courses => $courses);
+}
+
+# Deals with both single and multiple copy confirmation.
+sub copy_otp_secrets_confirm ($c) {
+	my $action = $c->param('action');
+	my $source_course;
+	my @source_users;
+	my @dest_courses;
+	my $dest_user;
+
+	if ($action eq 'single') {
+		$source_course = $c->param('sourceSingleCourseID');
+		@source_users  = ($c->param('sourceSingleUserID'));
+		@dest_courses  = ($c->param('destSingleCourseID'));
+		$dest_user     = $c->param('destSingleUserID');
+	} elsif ($action eq 'multiple') {
+		$source_course = $c->param('sourceMultipleCourseID');
+		@source_users  = ($c->param('sourceMultipleUserID'));
+		@dest_courses  = ($c->param('destMultipleCourseID'));
+	} else {
+		$c->addbadmessage($c->maketext('Invalid action [_1].', $action));
+		return $c->manage_otp_secrets_form;
+	}
+
+	my @errors;
+	push(@errors, $c->maketext('Source course ID missing.')) unless (defined $source_course && $source_course ne '');
+	push(@errors, $c->maketext('Source user ID missing.'))   unless (@source_users          && $source_users[0] ne '');
+	push(@errors, $c->maketext('Destination course ID missing.')) unless (@dest_courses && $dest_courses[0] ne '');
+	push(@errors, $c->maketext('Destination user ID missing.'))
+		unless (
+			$action eq 'multiple'
+			|| (defined $dest_user
+				&& $dest_user ne '')
+		);
+	if (@errors) {
+		for (@errors) {
+			$c->addbadmessage($_);
+		}
+		return $c->manage_otp_secrets_form;
+	}
+	if ($action eq 'single' && $source_course eq $dest_courses[0] && $source_users[0] eq $dest_user) {
+		$c->addbadmessage(
+			$c->maketext('Destination user must be different than source user when copying from same course'));
+		return $c->manage_otp_secrets_form;
+	}
+	if ($action eq 'multiple' && @dest_courses == 1 && $source_course eq $dest_courses[0]) {
+		$c->addbadmessage($c->maketext('Destination course must be different than source course.'));
+		return $c->manage_otp_secrets_form;
+	}
+
+	my @rows;
+	my %dbs;
+	my $source_ce = WeBWorK::CourseEnvironment->new({ courseName => $source_course });
+	$dbs{$source_course} = WeBWorK::DB->new($source_ce->{dbLayouts}{ $source_ce->{dbLayoutName} });
+
+	for my $s_user (@source_users) {
+		my $s_user_password = $dbs{$source_course}->getPassword($s_user);
+		unless ($s_user_password && $s_user_password->otp_secret) {
+			push(
+				@rows,
+				{
+					source_course  => $source_course,
+					source_user    => $s_user,
+					source_message => $c->maketext('OTP secret is empty - Skipping'),
+					error          => 'warning',
+					skip           => 1,
+				}
+			);
+			next;
+		}
+
+		for my $d_course (@dest_courses) {
+			next if $action eq 'multiple' && $d_course eq $source_course;
+
+			my $d_user = $action eq 'single' ? $dest_user : $s_user;
+			my $skip   = 0;
+			my $error_message;
+			my $dest_error;
+
+			unless ($dbs{$d_course}) {
+				my $dest_ce = WeBWorK::CourseEnvironment->new({ courseName => $d_course });
+				$dbs{$d_course} = WeBWorK::DB->new($dest_ce->{dbLayouts}{ $dest_ce->{dbLayoutName} });
+			}
+
+			my $d_user_password = $dbs{$d_course}->getPassword($d_user);
+			if (!defined $d_user_password) {
+				# Just because there is no password record, the user could still exist when using external auth.
+				unless ($dbs{$d_course}->existsUser($d_user)) {
+					$dest_error    = 'warning';
+					$error_message = $c->maketext('User does not exist - Skipping');
+					$skip          = 1;
+				}
+			} elsif ($d_user_password->otp_secret) {
+				$dest_error    = 'danger';
+				$error_message = $c->maketext('OTP Secret is not empty - Overwritting');
+			}
+
+			push(
+				@rows,
+				{
+					source_course => $source_course,
+					source_user   => $s_user,
+					dest_course   => $d_course,
+					dest_user     => $d_user,
+					dest_message  => $error_message,
+					error         => $dest_error,
+					skip          => $skip
+				}
+			);
+		}
+	}
+
+	return $c->include('ContentGenerator/CourseAdmin/copy_otp_secrets_confirm', action_rows => \@rows);
+}
+
+sub reset_otp_secrets_confirm ($c) {
+	my $source_course = $c->param('sourceResetCourseID');
+	my @dest_users    = ($c->param('destResetUserID'));
+
+	my @errors;
+	push(@errors, $c->maketext('Source course ID missing.'))    unless (defined $source_course && $source_course ne '');
+	push(@errors, $c->maketext('Destination user ID missing.')) unless (@dest_users            && $dest_users[0] ne '');
+	if (@errors) {
+		for (@errors) {
+			$c->addbadmessage($_);
+		}
+		return $c->manage_otp_secrets_form;
+	}
+
+	my $ce = WeBWorK::CourseEnvironment->new({ courseName => $source_course });
+	my $db = WeBWorK::DB->new($ce->{dbLayouts}{ $ce->{dbLayoutName} });
+	my @rows;
+	for my $user (@dest_users) {
+		my $password = $db->getPassword($user);
+		my $error    = $password && $password->otp_secret ? '' : $c->maketext('OTP Secret is empty - Skipping');
+
+		push(
+			@rows,
+			{
+				user    => $user,
+				message => $error,
+				error   => $error ? 'warning' : '',
+				skip    => $error ? 1         : 0,
+			}
+		);
+	}
+
+	return $c->include('ContentGenerator/CourseAdmin/reset_otp_secrets_confirm', action_rows => \@rows);
 }
 
 sub do_registration ($c) {

--- a/templates/ContentGenerator/Base/admin_links.html.ep
+++ b/templates/ContentGenerator/Base/admin_links.html.ep
@@ -29,6 +29,7 @@
 			% [ 'hide_inactive_course',  maketext('Hide Courses') ],
 			% [ 'manage_locations',      maketext('Manage Locations') ],
 			% [ 'manage_lti_course_map', maketext('Manage LTI Course Map') ],
+			% [ 'manage_otp_secrets',    maketext('Manage OTP Secrets') ],
 		% ) {
 			<li class="list-group-item nav-item">
 				<%= $makelink->(

--- a/templates/ContentGenerator/CourseAdmin/copy_otp_secrets_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/copy_otp_secrets_confirm.html.ep
@@ -40,7 +40,7 @@
 			</tbody>
 		</table>
 	</div>
-	<%= $c->hidden_fields('subDisplay') =%>
+	<%= $c->hidden_fields('subDisplay', 'show_all_courses') =%>
 	% if ($total > 0) {
 		% my $skipped = @$action_rows - $total;
 		<%= content 'hidden-rows' %>

--- a/templates/ContentGenerator/CourseAdmin/copy_otp_secrets_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/copy_otp_secrets_confirm.html.ep
@@ -1,0 +1,62 @@
+% my $total             = 0;
+% my $overwrite_warning = 0;
+<h2><%= maketext('Copy OTP Secrets') %></h2>
+<%= form_for current_route, method => 'POST', begin %>
+	<div class="table-responsive">
+		<table class="table table-sm table-bordered font-sm">
+			<thead class="table-group-divider">
+				<tr>
+					<th scope="col"><%= maketext('Copy from (Course ID / User ID)') %></th>
+					<th scope="col"><%= maketext('Copy to (Course ID / User ID)') %></th>
+				</tr>
+			</thead>
+			<tbody>
+				% for my $row (@$action_rows) {
+					% unless ($row->{skip}) {
+						% $total++;
+						% $overwrite_warning = 1 if $row->{error} && $row->{error} eq 'danger';
+						% content_for 'hidden-rows' => begin
+							<%= hidden_field otp_copy_row => $row->{source_course} . ':' . $row->{source_user}
+								. ':' . $row->{dest_course} . ':' . $row->{dest_user} =%>
+						% end
+					% }
+					<tr class="<%= $row->{error} ? 'table-' . $row->{error} : '' %>">
+						<td>
+							<%= $row->{source_course} %> / <%= $row->{source_user} %>
+							% if ($row->{source_message}) {
+								<br/>(<%= $row->{source_message} %>)
+							% }
+						</td>
+						<td>
+							% unless ($row->{source_message}) {
+								<%= $row->{dest_course} %> / <%= $row->{dest_user} %>
+								% if ($row->{dest_message}) {
+									<br/>(<%= $row->{dest_message} %>)
+								% }
+							% }
+						</td>
+					</tr>
+				% }
+			</tbody>
+		</table>
+	</div>
+	<%= $c->hidden_fields('subDisplay') =%>
+	% if ($total > 0) {
+		% my $skipped = @$action_rows - $total;
+		<%= content 'hidden-rows' %>
+		% if ($skipped > 0) {
+			<p><%= maketext('Confirm copying the above [_1] OTP secrets ([_2] skipped).', $total, $skipped) %></p>
+		% } else {
+			<p><%= maketext('Confirm copying the above [_1] OTP secrets.', $total) %></p>
+		% }
+		% if ($overwrite_warning) {
+			<div class="alert alert-danger p-1">
+				<%= maketext('Warning! Overwriting OTP secrets cannot be undone.') %>
+			</div>
+		% }
+		<%= submit_button maketext('Confirm Copy'), name => 'otp_confirm_copy', class => 'btn btn-primary' %>
+	% } else {
+		<p><%= maketext('No valid OTP secrets to copy. Skipping all.') %></p>
+	% }
+	<%= submit_button maketext('Cancel Copy'), name => 'otp_cancel_copy', class => 'btn btn-primary' %>
+<%= end %>

--- a/templates/ContentGenerator/CourseAdmin/manage_otp_secrets_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/manage_otp_secrets_form.html.ep
@@ -1,0 +1,197 @@
+% content_for js => begin
+	<%= javascript getAssetURL($ce, 'js/ActionTabs/actiontabs.js'),          defer => undef =%>
+	<%= javascript getAssetURL($ce, 'js/CourseAdmin/manage_otp_secrets.js'), defer => undef =%>
+% end
+%
+% my @course_keys = sort keys %$courses;
+% my $active_tab  = param('action') ? param('action') : 'single';
+%
+<h2><%= maketext('Manage OTP Secrets') %> <%= $c->helpMacro('AdminManageOTPSecrets') %></h2>
+<%= form_for current_route, method => 'POST', begin =%>
+	<div>
+		<ul class="nav nav-tabs mb-2" role="tablist">
+			% for my $tab ('single', 'multiple', 'reset') {
+				% my $tab_name = $tab eq 'single' ? maketext('Copy Single Secret')
+					% : $tab eq 'multiple' ? maketext('Copy Multiple Secrets') : maketext('Reset Secrets');
+				<li class="nav-item" role="presentation">
+					<%= link_to $tab_name => "#$tab",
+						class           => 'nav-link action-link' . ($active_tab eq $tab ? ' active' : ''),
+						id              => "$tab-tab",
+						data            => { action => $tab, bs_toggle => 'tab', bs_target => "#$tab" },
+						role            => 'tab',
+						'aria-controls' => $tab,
+						'aria-selected' => $active_tab eq $tab ? 'true' : 'false' =%>
+				</li>
+			% }
+		</ul>
+		<div class="tab-content">
+			<div class="tab-pane fade mb-2<%= $active_tab eq 'single' ? ' show active' : '' %>"
+					id="single" role="tabpanel" aria-labelledby="single-tab">
+				<div class="row mb-3">
+					<%= label_for sourceSingleCourseID => maketext('Source Course ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field sourceSingleCourseID => [
+								[
+									maketext('Select Course ID') => '',
+									disabled                     => undef,
+									selected                     => undef,
+								],
+								map { [ $_ => $_, data => { users => join(':', @{ $courses->{$_} }) } ] } @course_keys
+							],
+							id    => 'sourceSingleCourseID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+				<div class="row mb-3">
+					<%= label_for sourceSingleUserID => maketext('Source User ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field sourceSingleUserID => [
+								[
+									maketext('Select User ID') => '',
+									disabled                   => undef,
+									selected                   => undef,
+								],
+								param('sourceSingleCourseID') ? @{ $courses->{param('sourceSingleCourseID')} } : ()
+							],
+							id    => 'sourceSingleUserID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+				<div class="row mb-3">
+					<%= label_for destSingleCourseID => maketext('Destination Course ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field destSingleCourseID => [
+								[
+									maketext('Select Course ID') => '',
+									disabled                     => undef,
+									selected                     => undef,
+								],
+								map { [ $_ => $_, data => { users => join(':', @{ $courses->{$_} }) } ] } @course_keys
+							],
+							id    => 'destSingleCourseID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+				<div class="row mb-3">
+					<%= label_for destSingleUserID => maketext('Destination User ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field destSingleUserID => [
+								[
+									maketext('Select User ID') => '',
+									disabled                   => undef,
+									selected                   => undef,
+								],
+								param('destSingleCourseID') ? @{ $courses->{param('destSingleCourseID')} } : ()
+							],
+							id    => 'destSingleUserID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+			</div>
+			<div class="tab-pane fade mb-2<%= $active_tab eq 'multiple' ? ' show active' : '' %>"
+					id="multiple" role="tabpanel" aria-labelledby="multiple-tab">
+				<div class="row mb-3">
+					<%= label_for sourceMultipleCourseID => maketext('Source Course ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field sourceMultipleCourseID => [
+								[
+									maketext('Select Course ID') => '',
+									disabled                     => undef,
+									selected                     => undef,
+								],
+								map { [ $_ => $_, data => { users => join(':', @{ $courses->{$_} }) } ] } @course_keys
+							],
+							id    => 'sourceMultipleCourseID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+				<div class="row mb-3">
+					<div class="col-auto">
+						<%= label_for sourceMultipleUserID => maketext('Source User IDs'),
+							class => 'col-form-label fw-bold' =%>
+						<%= select_field sourceMultipleUserID => [
+								[
+									maketext('Select User IDs') => '',
+									disabled                   => undef,
+									selected                   => undef,
+								],
+								param('sourceMultipleCourseID') ? @{ $courses->{param('sourceMultipleCourseID')} } : ()
+							],
+							id       => 'sourceMultipleUserID',
+							class    => 'form-select',
+							multiple => undef,
+							size     => 10 =%>
+					</div>
+					<div class="col-auto">
+						<%= label_for destMultipleCourseID => maketext('Destination Course IDs'),
+							class => 'col-form-label fw-bold' =%>
+						<%= select_field destMultipleCourseID => [
+								[
+									maketext('Select Course IDs') => '',
+									disabled                     => undef,
+									selected                     => undef,
+								],
+								@course_keys
+							],
+							id       => 'destMultipleCourseID',
+							class    => 'form-select',
+							multiple => undef,
+							size     => 10 =%>
+					</div>
+				</div>
+			</div>
+			<div class="tab-pane fade mb-2<%= $active_tab eq 'reset' ? ' show active' : '' %>"
+					id="reset" role="tabpanel" aria-labelledby="reset-tab">
+				<div class="row mb-3">
+					<%= label_for sourceResetCourseID => maketext('Source Course ID'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field sourceResetCourseID => [
+								[
+									maketext('Select Course ID') => '',
+									disabled                     => undef,
+									selected                     => undef,
+								],
+								map { [ $_ => $_, data => { users => join(':', @{ $courses->{$_} }) } ] } @course_keys
+							],
+							id    => 'sourceResetCourseID',
+							class => 'form-select' =%>
+					</div>
+				</div>
+				<div class="row mb-3">
+					<%= label_for destResetUserID => maketext('Reset User IDs'),
+						class => 'col-auto col-form-label fw-bold' =%>
+					<div class="col-auto">
+						<%= select_field destResetUserID => [
+								[
+									maketext('Select User IDs') => '',
+									disabled                   => undef,
+									selected                   => undef,
+								],
+								param('sourceResetCourseID') ? @{ $courses->{param('sourceResetCourseID')} } : ()
+							],
+							id       => 'destResetUserID',
+							class    => 'form-select',
+							multiple => undef,
+							size     => 10 =%>
+					</div>
+				</div>
+			</div>
+		</div>
+	</div>
+	<%= $c->hidden_fields('subDisplay') =%>
+	<%= hidden_field action => $active_tab, id => 'current_action' =%>
+	<div class="mb-3">
+		<%= submit_button $active_tab eq 'single'
+			? maketext('Copy Single Secret')
+			: $active_tab eq 'multiple'
+				? maketext('Copy Multiple Secrets')
+				: maketext('Reset Secrets'),
+			id => 'take_action', class => 'btn btn-primary' =%>
+	</div>
+<%= end %>

--- a/templates/ContentGenerator/CourseAdmin/manage_otp_secrets_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/manage_otp_secrets_form.html.ep
@@ -8,6 +8,17 @@
 %
 <h2><%= maketext('Manage OTP Secrets') %> <%= $c->helpMacro('AdminManageOTPSecrets') %></h2>
 <%= form_for current_route, method => 'POST', begin =%>
+	% if (@$skipped_courses) {
+		<div class="mb-3">
+			<div class="alert alert-warning mb-2">
+				<%= maketext('The following large courses are not shown: [_1]', join(', ', @$skipped_courses)); =%>
+			</div>
+			<p>
+				<%= submit_button maketext('Show All Courses'),
+					name => 'show_all_courses', class => 'btn btn-primary' =%>
+			</p>
+		</div>
+	% }
 	<div>
 		<ul class="nav nav-tabs mb-2" role="tablist">
 			% for my $tab ('single', 'multiple', 'reset') {
@@ -136,7 +147,7 @@
 									disabled                     => undef,
 									selected                     => undef,
 								],
-								@course_keys
+								sort (@course_keys, @$skipped_courses)
 							],
 							id       => 'destMultipleCourseID',
 							class    => 'form-select',
@@ -184,7 +195,7 @@
 			</div>
 		</div>
 	</div>
-	<%= $c->hidden_fields('subDisplay') =%>
+	<%= $c->hidden_fields('subDisplay', 'show_all_courses') =%>
 	<%= hidden_field action => $active_tab, id => 'current_action' =%>
 	<div class="mb-3">
 		<%= submit_button $active_tab eq 'single'
@@ -192,6 +203,6 @@
 			: $active_tab eq 'multiple'
 				? maketext('Copy Multiple Secrets')
 				: maketext('Reset Secrets'),
-			id => 'take_action', class => 'btn btn-primary' =%>
+			id => 'take_action', name => 'take_action', class => 'btn btn-primary' =%>
 	</div>
 <%= end %>

--- a/templates/ContentGenerator/CourseAdmin/reset_otp_secrets_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/reset_otp_secrets_confirm.html.ep
@@ -1,0 +1,46 @@
+% my $total = 0;
+<h2><%= maketext('Reset OTP Secrets') %></h2>
+<%= form_for current_route, method => 'POST', begin %>
+	<div class="table-responsive">
+		<table class="table table-sm table-bordered font-sm">
+			<thead class="table-group-divider">
+				<tr>
+					<th scope="col"><%= maketext('User ID') %></th>
+				</tr>
+			</thead>
+			<tbody>
+				% for my $row (@$action_rows) {
+					% unless ($row->{skip}) {
+						% $total++;
+						% content_for 'hidden-rows' => begin
+							<%= hidden_field otp_reset_row => $row->{user} %>
+						% end
+					% }
+					<tr class="<%= $row->{error} ? 'table-' . $row->{error} : '' %>">
+						<td>
+							<%= $row->{user} %>
+							% if ($row->{message}) {
+								<br/>(<%= $row->{message} %>)
+							% }
+						</td>
+					</tr>
+				% }
+			</tbody>
+		</table>
+	</div>
+	<%= $c->hidden_fields('subDisplay') =%>
+	<%= $c->hidden_fields('sourceResetCourseID') =%>
+	% if ($total > 0) {
+		% my $skipped = @$action_rows - $total;
+		<%= content 'hidden-rows' %>
+		% if ($skipped > 0) {
+			<p><%= maketext('Confirm resetting the above [_1] OTP secrets ([_2] skipped).', $total, $skipped) %></p>
+		% } else {
+			<p><%= maketext('Confirm resetting the above [_1] OTP secrets.', $total) %></p>
+		% }
+		<%= submit_button maketext('Confirm Reset'), name => 'otp_confirm_reset', class => 'btn btn-primary' %>
+	% } else {
+		<p><%= maketext('No valid OTP secrets to reset. Skipping all.') %></p>
+	% }
+	<%= submit_button maketext('Cancel Reset'), name => 'otp_cancel_reset', class => 'btn btn-primary' %>
+<%= end %>

--- a/templates/ContentGenerator/CourseAdmin/reset_otp_secrets_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/reset_otp_secrets_confirm.html.ep
@@ -28,8 +28,7 @@
 			</tbody>
 		</table>
 	</div>
-	<%= $c->hidden_fields('subDisplay') =%>
-	<%= $c->hidden_fields('sourceResetCourseID') =%>
+	<%= $c->hidden_fields('subDisplay', 'show_all_courses', 'sourceResetCourseID') =%>
 	% if ($total > 0) {
 		% my $skipped = @$action_rows - $total;
 		<%= content 'hidden-rows' %>

--- a/templates/HelpFiles/AdminManageOTPSecrets.html.ep
+++ b/templates/HelpFiles/AdminManageOTPSecrets.html.ep
@@ -1,0 +1,36 @@
+%################################################################################
+%# WeBWorK Online Homework Delivery System
+%# Copyright &copy; 2000-2024 The WeBWorK Project, https://github.com/openwebwork
+%#
+%# This program is free software; you can redistribute it and/or modify it under
+%# the terms of either: (a) the GNU General Public License as published by the
+%# Free Software Foundation; either version 2, or (at your option) any later
+%# version, or (b) the "Artistic License" which comes with this package.
+%#
+%# This program is distributed in the hope that it will be useful, but WITHOUT
+%# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+%# FOR A PARTICULAR PURPOSE.  See either the GNU General Public License or the
+%# Artistic License for more details.
+%################################################################################
+%
+% layout 'help_macro';
+% title maketext('Manage OTP Secrets Help');
+%
+<p>
+	<%= maketext('Use the tabs at top to choose between copying a single secret, copying multiple secrets, '
+		. ' or resting secrets.') =%>
+</p>
+<p>
+	<%= maketext('If copying a single secret, choose the source course ID and user ID to copy from and choose '
+		. 'the destination course ID and user ID to copy to. This can be used to copy secrets between different '
+		. 'users in the same course, or to copy the secret to a user in a different course.') =%>
+</p>
+<p>
+	<%= maketext('If copying multiple secrets, choose a source course ID to copy from, then chose one (or more) '
+		. 'source users to copy to one (or more) destination courses. This can be used to copy multiple secrets '
+		. 'at once, but the user IDs must be the same in the source and destination courses.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('If resetting secrets, choose a source course ID, then choose one (or more) users whose secrets '
+		. 'will be reset. Note, the user(s) will have to setup two factor authentication afterwards.') =%>
+</p>

--- a/templates/HelpFiles/AdminManageOTPSecrets.html.ep
+++ b/templates/HelpFiles/AdminManageOTPSecrets.html.ep
@@ -30,7 +30,12 @@
 		. 'source users to copy to one (or more) destination courses. This can be used to copy multiple secrets '
 		. 'at once, but the user IDs must be the same in the source and destination courses.') =%>
 </p>
-<p class="mb-0">
+<p>
 	<%= maketext('If resetting secrets, choose a source course ID, then choose one (or more) users whose secrets '
 		. 'will be reset. Note, the user(s) will have to setup two factor authentication afterwards.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('By default, courses larger than 200 users will not be shown, as this can cause extra CPU usage '
+		. 'when generating the user menus.  If any large course is skipped, a message will inform you of which '
+		. 'courses were skipped, and a button to show all courses can be used to include those courses.') =%>
 </p>

--- a/templates/HelpFiles/admin_links.html.ep
+++ b/templates/HelpFiles/admin_links.html.ep
@@ -50,6 +50,8 @@
 		<%= maketext('Set LMS context ids for courses to map LMS courses to WeBWorK '
 			. 'courses for content item selection.') =%>
 	</dd>
+	<dt><%= maketext('Manage OTP Secrets') %></dt>
+	<dd><%= maketext('Copy OTP secrets from one course/user to another, or reset OTP secrets.') =%></dd>
 	<dt><%= maketext('Accounts Manager') %></dt>
 	<dd>
 		<%= maketext('Manage users. Note, only admin users have access to the course administration tools.') =%>


### PR DESCRIPTION
Adds a page in the admin course that can be used to copy OTP secrets from one user to another or to reset OTP secrets. This allows copying an OTP secret from a single user in one course to a different user in the same or different course. Copying multiple secrets from users in a single course to one or more other courses, provided the user names are the same. Or to reset one or more OTP secrets for users in a single course.