### PR TITLE
Updates to adding users to newly created courses.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -293,7 +293,6 @@ sub do_add_course ($c) {
 	my $add_initial_firstName       = trim_spaces($c->param('add_initial_firstName'))       // '';
 	my $add_initial_lastName        = trim_spaces($c->param('add_initial_lastName'))        // '';
 	my $add_initial_email           = trim_spaces($c->param('add_initial_email'))           // '';
-	my $add_initial_studentID       = trim_spaces($c->param('add_initial_studentID'))       // '';
 	my $add_initial_user            = $c->param('add_initial_user')                         // 0;
 
 	my $copy_from_course = trim_spaces($c->param('copy_from_course')) // '';
@@ -337,7 +336,6 @@ sub do_add_course ($c) {
 			user_id       => $add_initial_userID,
 			first_name    => $add_initial_firstName,
 			last_name     => $add_initial_lastName,
-			student_id    => $add_initial_studentID,
 			email_address => $add_initial_email,
 			status        => 'O',
 		);

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -310,14 +310,14 @@ sub do_add_course ($c) {
 	for my $userID ($c->param('add-admin-users')) {
 		unless ($db->existsUser($userID)) {
 			$c->addbadmessage($c->maketext(
-				'User "[_1]" will not be copied from [_2] course as it does not exist.', $userID,
+				'User "[_1]" will not be copied from the [_2] course as it does not exist.', $userID,
 				$ce->{admin_course_id}
 			));
 			next;
 		}
 		if ($userID eq $add_initial_userID) {
 			$c->addbadmessage($c->maketext(
-				'User "[_1]" will not be copied from [_2] course as it is the initial instructor.', $userID,
+				'User "[_1]" will not be copied from the [_2] course as it is the initial instructor.', $userID,
 				$ce->{admin_course_id}
 			));
 			next;
@@ -355,7 +355,7 @@ sub do_add_course ($c) {
 		if ($add_initial_user) {
 			if ($db->existsUser($add_initial_userID)) {
 				$c->addbadmessage($c->maketext(
-					'User "[_1]" will not be added to [_2] course as it already exists.', $add_initial_userID,
+					'User "[_1]" will not be added to the [_2] course as it already exists.', $add_initial_userID,
 					$ce->{admin_course_id}
 				));
 			} else {

--- a/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SendMail.pm
@@ -113,8 +113,9 @@ sub initialize ($c) {
 		'user_id'
 	);
 
-	# Filter out users who don't get included in email
-	@Users = grep { $ce->status_abbrev_has_behavior($_->status, "include_in_email") } @Users;
+	# Filter out users who don't get included in email unless in the admin course.
+	@Users = grep { $ce->status_abbrev_has_behavior($_->status, "include_in_email") } @Users
+		unless $ce->{courseName} eq $ce->{admin_course_id};
 
 	# Cache the user records for later use.
 	$c->{ra_user_records} = \@Users;

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -201,7 +201,7 @@ boolean options:
 =cut
 
 sub addCourse {
-	my (%options) = (initial_userID => '', @_);
+	my (%options) = @_;
 
 	for my $key (keys(%options)) {
 		my $value = '####UNDEF###';
@@ -217,7 +217,7 @@ sub addCourse {
 
 	debug \@users;
 
-	my ($initialUser) = grep { $_->[0]{user_id} eq $options{initial_userID} } @users;
+	my @initialUsers = grep { $_->[2]->permission < $ce->{userRoles}{admin} } @users;
 
 	# get the database layout out of the options hash
 	my $dbLayoutName = $courseOptions{dbLayoutName};
@@ -407,7 +407,7 @@ sub addCourse {
 				assignSetsToUsers($db, $ce, \@user_sets, [$user_id]);
 			}
 		}
-		assignSetsToUsers($db, $ce, \@set_ids, [ $initialUser->[0]{user_id} ]) if $initialUser;
+		assignSetsToUsers($db, $ce, \@set_ids, [ map { $_->[0]{user_id} } @initialUsers ]) if @initialUsers;
 	}
 
 	# add achievements
@@ -416,9 +416,9 @@ sub addCourse {
 		for my $achievement_id (@achievement_ids) {
 			eval { $db->addAchievement($db0->getAchievement($achievement_id)) };
 			warn $@ if $@;
-			if ($initialUser) {
+			for (@initialUsers) {
 				my $userAchievement = $db->newUserAchievement();
-				$userAchievement->user_id($initialUser->[0]{user_id});
+				$userAchievement->user_id($_->[0]{user_id});
 				$userAchievement->achievement_id($achievement_id);
 				$db->addUserAchievement($userAchievement);
 			}

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -217,7 +217,8 @@ sub addCourse {
 
 	debug \@users;
 
-	my @initialUsers = grep { $_->[2]->permission < $ce->{userRoles}{admin} } @users;
+	my @initialUsers = @users;
+	my %user_args    = map { $_->[0]{user_id} => 1 } @users;
 
 	# get the database layout out of the options hash
 	my $dbLayoutName = $courseOptions{dbLayoutName};
@@ -359,7 +360,6 @@ sub addCourse {
 					{ '!=' => $options{copyConfig} ? $ce0->{userRoles}{student} : $ce->{userRoles}{student} },
 					user_id => { not_like => 'set_id:%' }
 				}));
-			my %user_args = map { $_->[0]{user_id} => 1 } @users;
 
 			for my $user_id (@non_student_ids) {
 				next if $user_args{$user_id};
@@ -402,7 +402,8 @@ sub addCourse {
 		}
 		if ($options{copyNonStudents}) {
 			foreach my $userTriple (@users) {
-				my $user_id   = $userTriple->[0]{user_id};
+				my $user_id = $userTriple->[0]{user_id};
+				next if $user_args{$user_id};    # Initial users will be assigned to everything below.
 				my @user_sets = $db0->listUserSets($user_id);
 				assignSetsToUsers($db, $ce, \@user_sets, [$user_id]);
 			}
@@ -425,7 +426,8 @@ sub addCourse {
 		}
 		if ($options{copyNonStudents}) {
 			foreach my $userTriple (@users) {
-				my $user_id           = $userTriple->[0]{user_id};
+				my $user_id = $userTriple->[0]{user_id};
+				next if $user_args{$user_id};    # Initial users were assigned to all achievements above.
 				my @user_achievements = $db0->listUserAchievements($user_id);
 				for my $achievement_id (@user_achievements) {
 					my $userAchievement = $db->newUserAchievement();

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -41,12 +41,18 @@
 			<%= maketext(
 				'Select admin course users to add to the new course (as the stated permission) below.') =%>
 		</div>
-		<div class="col-lg-4 col-md-5 col-sm-6">
-			<%= select_field 'add-admin-users' => [ map {
-				my $val   = $db->getPermissionLevel($_)->permission;
-				my $level = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
-				[ "$_ ($level)" => $_, $val == 20 ? (selected => undef) : () ] } $db->listUsers ],
-				size => 5, multiple => undef, class =>'form-select mb-1' =%>
+		<div class="col-lg-4 col-md-5 col-sm-6 overflow-scroll border rounded px-2" style="height: 100px;">
+			% for my $user ($db->listUsers) {
+				% my $val   = $db->getPermissionLevel($user)->permission;
+				% my $role = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
+				<div class="form-check">
+					<label class="form-check-label">
+						<%= check_box 'add-admin-users' => $user, class => 'form-check-input',
+							$val == 20 ? (checked => undef) : () =%>
+						<%= "$user ($role)" %>
+					</label>
+				</div>
+			% }
 		</div>
 	</div>
 	<div class="mb-2">

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -53,7 +53,7 @@
 	<div class="row mb-3">
 		<div class="mb-1">
 			<%= maketext(
-				'Select [_1] course users to add to the new course (as the stated permission) below.',
+				'Select users from the [_1] course to add to the new course with indicated permission.',
 				$ce->{admin_course_id}) =%>
 		</div>
 		<div class="col-lg-4 col-md-5 col-sm-6">

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -20,18 +20,22 @@
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields('subDisplay') =%>
 	%
-	<div class="mb-2"><%= maketext(
-		'Specify an ID, title, and institution for the new course. The course ID may contain only letters, '
-			. 'numbers, hyphens, and underscores, and may have at most [_1] characters.',
-		$ce->{maxCourseIdLength}) %>
-	</div>
-	<div class="row mb-3">
+	<div class="row my-3">
 		<div class="col-lg-8 col-md-10">
 			<div class="form-floating mb-1">
 				<%= text_field new_courseID => '',
 					id          => 'new_courseID',
 					placeholder => '',
-					class       => 'form-control' =%>
+					class       => 'form-control set-id-tooltip',
+					maxlength   => $ce->{maxCourseIdLength},
+					data        => {
+						'bs-placement' => 'top',
+						'bs-title'     => maketext(
+							'Course ID may contain only letters, numbers, hyphens, and underscores, '
+								. 'and may have at most [_1] characters.',
+							$ce->{maxCourseIdLength}
+						)
+					} =%>
 				<%= label_for new_courseID => maketext('Course ID') =%>
 			</div>
 			<div class="form-floating mb-1">
@@ -73,15 +77,9 @@
 		</div>
 	</div>
 	<div class="mb-2">
-		<%= maketext(
-			'To add additional instructor(s) to the new course, specify user information below. '
-				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas, and underscores.'
-		) =%>
-	</div>
-	<div class="mb-2">
 	% for (1 .. $number_of_additional_users) {
 		<div class="mb-2">
-			<%= maketext('Enter information for additional instructor number [_1].', $_) %>
+			<%= maketext('Enter information for additional user number [_1].', $_) %>
 		</div>
 		<div class="row mb-1">
 			<div class="col-lg-4 col-md-5 col-sm-6">
@@ -89,7 +87,13 @@
 					<%= text_field "add_initial_userID_$_" => '',
 						id          => "add_initial_userID_$_",
 						placeholder => '',
-						class       => 'form-control' =%>
+						class       => 'form-control set-id-tooltip',
+						data        => {
+							'bs-placement' => 'top',
+							'bs-title'     => maketext(
+								'User ID may contain only numbers, letters, hyphens, periods, and underscores.'
+							)
+						} =%>
 					<%= label_for "add_initial_userID_$_" => maketext('User ID') =%>
 				</div>
 				<div class="form-floating mb-1">
@@ -154,8 +158,8 @@
 	% }
 	</div>
 	<div class="mb-3">
-		<%= submit_button maketext('Add Another Instructor'), name => 'add_another_instructor',
-			class => 'btn btn-primary' =%>
+		<%= submit_button maketext('Add Additional User'), name => 'add_another_instructor',
+			class => 'btn btn-secondary' =%>
 	</div>
 	<div class="mb-1">
 		<%= maketext('To copy components from an existing course, '

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -39,9 +39,10 @@
 	<div class="mb-3">
 		<div class="mb-1">
 			<%= maketext(
-				'Select admin course users to add to the new course (as the stated permission) below.') =%>
+				'Select [_1] course users to add to the new course (as the stated permission) below.',
+				$ce->{admin_course_id}) =%>
 		</div>
-		<div class="col-lg-4 col-md-5 col-sm-6 overflow-scroll border rounded px-2" style="height: 100px;">
+		<div class="col-lg-4 col-md-5 col-sm-6 overflow-auto border rounded px-2" style="max-height: 100px;">
 			% for my $user ($db->listUsers) {
 				% my $val   = $db->getPermissionLevel($user)->permission;
 				% my $role = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
@@ -120,7 +121,7 @@
 	<div class="form-check mb-3">
 		<label class="form-check-label">
 			<%= check_box 'add_initial_user' => 1, class => 'form-check-input' =%>
-			<%= maketext('Add new user to admin course.') =%>
+			<%= maketext('Also add this user to the [_1] course.', $ce->{admin_course_id}) =%>
 		</label>
 	</div>
 	<div class="mb-1">

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -1,5 +1,19 @@
 % use WeBWorK::Utils::CourseManagement qw(listCourses);
 %
+% # Create an array of permission values for the permission selects.
+% my $permissionLevels = [];
+% for my $role (sort { $ce->{userRoles}{$a} <=> $ce->{userRoles}{$b} } keys %{ $ce->{userRoles} }) {
+	% next if $role eq 'nobody';
+	% push(
+		% @$permissionLevels,
+		% [
+			% $c->maketext($role) => $ce->{userRoles}{$role},
+			% $role eq 'professor' ? (selected => undef) : ()
+		% ]
+	% );
+% }
+% my $number_of_additional_users = $c->param('number_of_additional_users') || 0;
+%
 <h2><%= maketext('Add Course') %> <%= $c->helpMacro('AdminAddCourse') %></h2>
 %
 <%= form_for current_route, method => 'POST', begin =%>
@@ -60,64 +74,85 @@
 	</div>
 	<div class="mb-2">
 		<%= maketext(
-			'To add an additional instructor to the new course, specify user information below. '
-				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.'
+			'To add additional instructor(s) to the new course, specify user information below. '
+				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas, and underscores.'
 		) =%>
 	</div>
-	<div class="row mb-1">
-		<div class="col-lg-4 col-md-5 col-sm-6">
-			<div class="form-floating mb-1">
-				<%= text_field add_initial_userID => '',
-					id          => 'add_initial_userID',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_userID => maketext('User ID') =%>
+	<div class="mb-1">
+	% for (1 .. $number_of_additional_users) {
+		<div class="row mb-1">
+			<div class="col-lg-4 col-md-5 col-sm-6">
+				<div class="form-floating mb-1">
+					<%= text_field "add_initial_userID_$_" => '',
+						id          => "add_initial_userID_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_userID_$_" => maketext('User ID') =%>
+				</div>
+				<div class="form-floating mb-1">
+					<%= password_field "add_initial_password_$_",
+						id           => "add_initial_password_$_",
+						placeholder  => '',
+						class        => 'form-control',
+						autocomplete => 'new-password' =%>
+					<%= label_for "add_initial_password_$_" => maketext('Password') =%>
+				</div>
+				<div class="form-floating mb-1">
+					<%= password_field "add_initial_confirmPassword_$_",
+						id          => "add_initial_confirmPassword_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_confirmPassword_$_" => maketext('Confirm Password') =%>
+				</div>
+				<div class="form-floating mb-1">
+					<%= select_field "add_initial_permission_$_" => $permissionLevels,
+						id      => "add_initial_role_$_",
+						class   => 'form-select' =%>
+					<%= label_for "add_initial_permission_$_" => maketext('Permission Level') =%>
+				</div>
 			</div>
-			<div class="form-floating mb-1">
-				<%= password_field 'add_initial_password',
-					id           => 'add_initial_password',
-					placeholder  => '',
-					class        => 'form-control',
-					autocomplete => 'new-password' =%>
-				<%= label_for add_initial_password => maketext('Password') =%>
-			</div>
-			<div class="form-floating mb-1">
-				<%= password_field 'add_initial_confirmPassword',
-					id          => 'add_initial_confirmPassword',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_confirmPassword => maketext('Confirm Password') =%>
+			<div class="col-lg-4 col-md-5 col-sm-6">
+				<div class="form-floating mb-1">
+					<%= text_field "add_initial_firstName_$_" => '',
+						id          => "add_initial_firstName_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_firstName_$_" => maketext('First Name') =%>
+				</div>
+				<div class="form-floating mb-1">
+					<%= text_field "add_initial_lastName_$_" => '',
+						id          => "add_initial_lastName_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_lastName_$_" => maketext('Last Name') %>
+				</div>
+				<div class="form-floating mb-1">
+					<%= text_field "add_initial_email_$_" => '',
+						id          => "add_initial_email_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_email_$_" => maketext('Email Address') =%>
+				</div>
+				<div class="form-floating mb-1">
+					<%= text_field "add_initial_studentID_$_" => '',
+						id          => "add_initial_studentID_$_",
+						placeholder => '',
+						class       => 'form-control' =%>
+					<%= label_for "add_initial_studentID_$_" => maketext('Student ID') =%>
+				</div>
 			</div>
 		</div>
-		<div class="col-lg-4 col-md-5 col-sm-6">
-			<div class="form-floating mb-1">
-				<%= text_field add_initial_firstName => '',
-					id          => 'add_initial_firstName',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_firstName => maketext('First Name') =%>
-			</div>
-			<div class="form-floating mb-1">
-				<%= text_field add_initial_lastName => '',
-					id          => 'add_initial_lastName',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_lastName => maketext('Last Name') %>
-			</div>
-			<div class="form-floating mb-1">
-				<%= text_field add_initial_email => '',
-					id          => 'add_initial_email',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_email => maketext('Email Address') =%>
-			</div>
+		<div class="form-check mb-3">
+			<label class="form-check-label">
+				<%= check_box "add_initial_user_$_" => 1, class => 'form-check-input' =%>
+				<%= maketext('Also add this user to the [_1] course.', $ce->{admin_course_id}) =%>
+			</label>
 		</div>
+	% }
 	</div>
-	<div class="form-check mb-3">
-		<label class="form-check-label">
-			<%= check_box 'add_initial_user' => 1, class => 'form-check-input' =%>
-			<%= maketext('Also add this user to the [_1] course.', $ce->{admin_course_id}) =%>
-		</label>
+	<div class="mb-3">
+		<%= submit_button maketext('Add Another Instructor'), name => 'add_another_instructor',
+			class => 'btn btn-primary' =%>
 	</div>
 	<div class="mb-1">
 		<%= maketext('To copy components from an existing course, '
@@ -208,5 +243,6 @@
 	</fieldset>
 	<%= hidden_field add_dbLayout             => 'sql_single' =%>
 	<%= hidden_field last_page_was_add_course => 1 =%>
+	<%= $c->hidden_fields('number_of_additional_users') =%>
 	<%= submit_button maketext('Add Course'), name => 'add_course', class => 'btn btn-primary' =%>
 <% end =%>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -39,13 +39,14 @@
 	<div class="mb-3">
 		<div class="mb-1">
 			<%= maketext(
-				'To add the WeBWorK administrators to the new course (as administrators) check the box below.') =%>
+				'Select admin course users to add to the new course (as the stated permission) below.') =%>
 		</div>
-		<div class="form-check">
-			<label class="form-check-label">
-				<%= check_box 'add_admin_users' => 1, class => 'form-check-input' =%>
-				<%= maketext('Add WeBWorK administrators to new course') =%>
-			</label>
+		<div class="col-lg-4 col-md-5 col-sm-6">
+			<%= select_field 'add-admin-users' => [ map {
+				my $val   = $db->getPermissionLevel($_)->permission;
+				my $level = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
+				[ "$_ ($level)" => $_, $val == 20 ? (selected => undef) : () ] } $db->listUsers ],
+				size => 5, multiple => undef, class =>'form-select mb-1' =%>
 		</div>
 	</div>
 	<div class="mb-2">
@@ -54,7 +55,7 @@
 				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.'
 		) =%>
 	</div>
-	<div class="row mb-3">
+	<div class="row">
 		<div class="col-lg-4 col-md-5 col-sm-6">
 			<div class="form-floating mb-1">
 				<%= text_field add_initial_userID => '',
@@ -65,9 +66,10 @@
 			</div>
 			<div class="form-floating mb-1">
 				<%= password_field 'add_initial_password',
-					id          => 'add_initial_password',
-					placeholder => '',
-					class       => 'form-control' =%>
+					id           => 'add_initial_password',
+					placeholder  => '',
+					class        => 'form-control',
+					autocomplete => 'new-password' =%>
 				<%= label_for add_initial_password => maketext('Password') =%>
 			</div>
 			<div class="form-floating mb-1">
@@ -100,7 +102,20 @@
 					class       => 'form-control' =%>
 				<%= label_for add_initial_email => maketext('Email Address') =%>
 			</div>
+			<div class="form-floating mb-1">
+				<%= text_field add_initial_studentID => '',
+					id          => 'add_initial_studentID',
+					placeholder => '',
+					class       => 'form-control' =%>
+				<%= label_for add_initial_studentID => maketext('Student ID') =%>
+			</div>
 		</div>
+	</div>
+	<div class="form-check mb-3">
+		<label class="form-check-label">
+			<%= check_box 'add_initial_user' => 1, class => 'form-check-input' =%>
+			<%= maketext('Add new user to admin course.') =%>
+		</label>
 	</div>
 	<div class="mb-1">
 		<%= maketext('To copy components from an existing course, '

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -78,8 +78,11 @@
 				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas, and underscores.'
 		) =%>
 	</div>
-	<div class="mb-1">
+	<div class="mb-2">
 	% for (1 .. $number_of_additional_users) {
+		<div class="mb-2">
+			<%= maketext('Enter information for additional instructor number [_1].', $_) %>
+		</div>
 		<div class="row mb-1">
 			<div class="col-lg-4 col-md-5 col-sm-6">
 				<div class="form-floating mb-1">

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -109,13 +109,6 @@
 					class       => 'form-control' =%>
 				<%= label_for add_initial_email => maketext('Email Address') =%>
 			</div>
-			<div class="form-floating mb-1">
-				<%= text_field add_initial_studentID => '',
-					id          => 'add_initial_studentID',
-					placeholder => '',
-					class       => 'form-control' =%>
-				<%= label_for add_initial_studentID => maketext('Student ID') =%>
-			</div>
 		</div>
 	</div>
 	<div class="form-check mb-3">

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -36,24 +36,26 @@
 			</div>
 		</div>
 	</div>
-	<div class="mb-3">
+	<div class="row mb-3">
 		<div class="mb-1">
 			<%= maketext(
 				'Select [_1] course users to add to the new course (as the stated permission) below.',
 				$ce->{admin_course_id}) =%>
 		</div>
-		<div class="col-lg-4 col-md-5 col-sm-6 overflow-auto border rounded px-2" style="max-height: 100px;">
-			% for my $user ($db->listUsers) {
-				% my $val   = $db->getPermissionLevel($user)->permission;
-				% my $role = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
-				<div class="form-check">
-					<label class="form-check-label">
-						<%= check_box 'add-admin-users' => $user, class => 'form-check-input',
-							$val == 20 && !param('last_page_was_add_course') ? (checked => undef) : () =%>
-						<%= "$user ($role)" %>
-					</label>
-				</div>
-			% }
+		<div class="col-lg-4 col-md-5 col-sm-6">
+			<div class="overflow-auto border rounded px-2" style="max-height: 100px;">
+				% for my $user ($db->listUsers) {
+					% my $val   = $db->getPermissionLevel($user)->permission;
+					% my $role = maketext((grep { $ce->{userRoles}{$_} eq $val } keys %{ $ce->{userRoles} })[0]);
+					<div class="form-check">
+						<label class="form-check-label">
+							<%= check_box 'add-admin-users' => $user, class => 'form-check-input',
+								$val == 20 && !param('last_page_was_add_course') ? (checked => undef) : () =%>
+							<%= "$user ($role)" %>
+						</label>
+					</div>
+				% }
+			</div>
 		</div>
 	</div>
 	<div class="mb-2">
@@ -62,7 +64,7 @@
 				. 'The user ID may contain only numbers, letters, hyphens, periods (dots), commas,and underscores.'
 		) =%>
 	</div>
-	<div class="row">
+	<div class="row mb-1">
 		<div class="col-lg-4 col-md-5 col-sm-6">
 			<div class="form-floating mb-1">
 				<%= text_field add_initial_userID => '',

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -49,7 +49,7 @@
 				<div class="form-check">
 					<label class="form-check-label">
 						<%= check_box 'add-admin-users' => $user, class => 'form-check-input',
-							$val == 20 ? (checked => undef) : () =%>
+							$val == 20 && !param('last_page_was_add_course') ? (checked => undef) : () =%>
 						<%= "$user ($role)" %>
 					</label>
 				</div>
@@ -211,6 +211,7 @@
 			</label>
 		</div>
 	</fieldset>
-	<%= hidden_field add_dbLayout => 'sql_single' =%>
+	<%= hidden_field add_dbLayout             => 'sql_single' =%>
+	<%= hidden_field last_page_was_add_course => 1 =%>
 	<%= submit_button maketext('Add Course'), name => 'add_course', class => 'btn btn-primary' =%>
 <% end =%>

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -97,19 +97,11 @@
 					<%= label_for "add_initial_userID_$_" => maketext('User ID') =%>
 				</div>
 				<div class="form-floating mb-1">
-					<%= password_field "add_initial_password_$_",
+					<%= text_field "add_initial_password_$_" => '',
 						id           => "add_initial_password_$_",
 						placeholder  => '',
-						class        => 'form-control',
-						autocomplete => 'new-password' =%>
+						class        => 'form-control' =%>
 					<%= label_for "add_initial_password_$_" => maketext('Password') =%>
-				</div>
-				<div class="form-floating mb-1">
-					<%= password_field "add_initial_confirmPassword_$_",
-						id          => "add_initial_confirmPassword_$_",
-						placeholder => '',
-						class       => 'form-control' =%>
-					<%= label_for "add_initial_confirmPassword_$_" => maketext('Confirm Password') =%>
 				</div>
 				<div class="form-floating mb-1">
 					<%= select_field "add_initial_permission_$_" => $permissionLevels,
@@ -139,13 +131,6 @@
 						placeholder => '',
 						class       => 'form-control' =%>
 					<%= label_for "add_initial_email_$_" => maketext('Email Address') =%>
-				</div>
-				<div class="form-floating mb-1">
-					<%= text_field "add_initial_studentID_$_" => '',
-						id          => "add_initial_studentID_$_",
-						placeholder => '',
-						class       => 'form-control' =%>
-					<%= label_for "add_initial_studentID_$_" => maketext('Student ID') =%>
 				</div>
 			</div>
 		</div>

--- a/templates/ContentGenerator/Instructor/AddUsers.html.ep
+++ b/templates/ContentGenerator/Instructor/AddUsers.html.ep
@@ -148,9 +148,11 @@
 			</tbody>
 		</table>
 	</div>
-	<p class="my-2"><%= maketext('Select sets below to assign them to the newly-created users.') %></p>
-	% param('assignSets', undef);
-	<%= select_field assignSets => [ map { [ format_set_name_display($_) => $_ ] } $db->listGlobalSets ],
-		size => 10, multiple => undef, class => 'form-select w-auto mb-2' =%>
+	% unless ($ce->{courseName} eq $ce->{admin_course_id}) {
+		<p class="my-2"><%= maketext('Select sets below to assign them to the newly-created users.') %></p>
+		% param('assignSets', undef);
+		<%= select_field assignSets => [ map { [ format_set_name_display($_) => $_ ] } $db->listGlobalSets ],
+			size => 10, multiple => undef, class => 'form-select w-auto mb-2' =%>
+	% }
 	<p><%= submit_button maketext('Add Users'), name => 'addStudents', class => 'btn btn-primary' =%></p>
 <% end =%>

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -22,13 +22,15 @@
 		. 'on the course home page.') =%>
 </p>
 <p>
-	<%= maketext('The WeBWorK administrators need to be added to the course in order for them to access the course.  '
-		. 'Unchecking this option will make it so WeBWorK administrators cannot directly login to the course.') =%>
+	<%= maketext('Select which users in the admin course to copy over to the newly created course. The WeBWorK '
+		. 'administrators need to be added to the course in order for them to access the course. Unselecting '
+		. 'them will make it so WeBWorK administrators cannot directly login to the course.') =%>
 </p>
 <p>
-	<%= maketext('Enter the details of the course instructor to be added when the course is created.  This user '
-		. 'will also be added to the admin course with the username "userID_courseID" so you can manage and '
-		. 'email the instructors of the courses on the server.') =%>
+	<%= maketext('Enter the details of a new course instructor to be added when the course is created.  The only '
+		. 'required field is the user ID of the this user.  Optionally, you can add this user to the administration '
+		. 'course, so you can copy this user when creating future courses, or manage and email course instructors.  '
+		. 'The instructor will be added as a "Dropped" user so they cannot login to the administration course.') =%>
 </p>
 <p class="mb-0">
 	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -28,12 +28,14 @@
 		$ce->{admin_course_id}) =%>
 </p>
 <p>
-	<%= maketext('Enter the details of a new course instructor to be added when the course is created.  The only '
-		. 'required field is the user ID of the this user.  Optionally, you can add this user to the [_1] course, '
-		. 'so you can copy this user when creating future courses, or manage and email course instructors.  Note, '
-		. 'by default these new users will be "Dropped" and unable to login to the [_1] course.  You can change '
-		. 'this on the "Accounts Manager" page. Additionally you can control access to the [_1] course by setting '
-		. q/$permissionLevels{login}='admin' in course.conf./, $ce->{admin_course_id}) =%>
+	<%= maketext('Optionally, to add additional instructors click the "Add Another Instructor" button, then enter '
+		. 'the details of a new course instructor to be added when the course is created.  The only required field '
+		. 'is the user ID of the this user.  Optionally, you can add this user to the [_1] course, so you can copy '
+		. 'this user when creating future courses, or manage and email course instructors.  Click the "Add Another '
+		. 'Instructor" button again to add multiple additional users.  Note, by default these new users will be '
+		. '"Dropped" and unable to login to the [_1] course.  You can change this on the "Accounts Manager" page. '
+		. q/Additionally you can control access to the [_1] course by setting $permissionLevels{login}='admin' in /
+		. 'course.conf.', $ce->{admin_course_id}) =%>
 </p>
 <p class="mb-0">
 	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -22,15 +22,18 @@
 		. 'on the course home page.') =%>
 </p>
 <p>
-	<%= maketext('Select which users in the admin course to copy over to the newly created course. The WeBWorK '
+	<%= maketext('Select which users in the [_1] course to copy over to the newly created course. The WeBWorK '
 		. 'administrators need to be added to the course in order for them to access the course. Unselecting '
-		. 'them will make it so WeBWorK administrators cannot directly login to the course.') =%>
+		. 'them will make it so WeBWorK administrators cannot directly login to the course.',
+		$ce->{admin_course_id}) =%>
 </p>
 <p>
 	<%= maketext('Enter the details of a new course instructor to be added when the course is created.  The only '
-		. 'required field is the user ID of the this user.  Optionally, you can add this user to the administration '
-		. 'course, so you can copy this user when creating future courses, or manage and email course instructors.  '
-		. 'The instructor will be added as a "Dropped" user so they cannot login to the administration course.') =%>
+		. 'required field is the user ID of the this user.  Optionally, you can add this user to the [_1] course, '
+		. 'so you can copy this user when creating future courses, or manage and email course instructors.  Note, '
+		. 'by default these new users will be "Dropped" and unable to login to the [_1] course.  You can change '
+		. 'this on the "Accounts Manager" page. Additionally you can control access to the [_1] course by setting '
+		. q/$permissionLevels{login}='admin' in course.conf./, $ce->{admin_course_id}) =%>
 </p>
 <p class="mb-0">
 	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -28,14 +28,10 @@
 		$ce->{admin_course_id}) =%>
 </p>
 <p>
-	<%= maketext('Optionally, to add additional instructors click the "Add Another Instructor" button, then enter '
-		. 'the details of a new course instructor to be added when the course is created.  The only required field '
-		. 'is the user ID of the this user.  Optionally, you can add this user to the [_1] course, so you can copy '
-		. 'this user when creating future courses, or manage and email course instructors.  Click the "Add Another '
-		. 'Instructor" button again to add multiple additional users.  Note, by default these new users will be '
-		. '"Dropped" and unable to login to the [_1] course.  You can change this on the "Accounts Manager" page. '
-		. q/Additionally you can control access to the [_1] course by setting $permissionLevels{login}='admin' in /
-		. 'course.conf.', $ce->{admin_course_id}) =%>
+	<%= maketext('Click the "Add Additional User" button to add additional users to the course. The only required '
+		. 'field is the user ID.  You can also add this user to the [_1] course, so you can copy this user when '
+		. 'creating future courses, or manage and email course users.  Note, by default these new users will be '
+		. '"Dropped" and unable to login to the [_1] course.', $ce->{admin_course_id}) =%>
 </p>
 <p class="mb-0">
 	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '


### PR DESCRIPTION
When adding a course on the course admin page, list all users in the admin course and let the admin select which users to copy over to the new course (by default all admin users are selected). This way an admin can select an existing user to copy over which can include any password or OTP secrets setup for that use (currently the admin will have to copy that over to the admin course manually). This also allows only copying a subset of admins to a newly created course instead of all.

When creating a new user to add to a course, be consistent with adding a user on the accounts management page, which doesn't require a password (useful when using external auth), email, etc. Now the only required field is the new user ID.

Flag the new user password input as 'new-password', so webbrowsers don't try to auto fill it in. Add the student ID as a field they can fill out instead of making it equal to the user ID. Since users can be copied from the admin course, add an option to add the new user to the admin course (as a dropped user so they can't login) so admins can select the same user to add to future courses as needed.

Remove the empty list of sets to assign users to when adding new users on the accounts management page in the admin course.

Make it so all users are shown on the Email page in the admin course, since most instructors are "Dropped" to still allow sending them emails.