### PR TITLE
Make the student nav filter selector not split toggle.

### DIFF
--- a/templates/ContentGenerator/GatewayQuiz/nav.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz/nav.html.ep
@@ -80,7 +80,7 @@
 			<div class="btn-group student-nav-filter-selector">
 				<%= link_to $filter ? $filters->{$filter}[0] : maketext('Showing all tests') => '#',
 						id              => 'testSelectorFilter',
-						class           => 'btn btn-primary dropdown-toggle dropdown-toggle-split',
+						class           => 'btn btn-primary dropdown-toggle',
 						role            => 'button',
 						data            => { bs_toggle => 'dropdown' },
 						'aria-expanded' => 'false' =%>


### PR DESCRIPTION
A split toggle is implemented with two buttons.  A button with the text (in this case the filter name) and a button with the caret for the dropdown menu.  However, `student-nav-filter-selector` div only has one button and does not have the second button for the caret.  This causes issues with the border of the button.  Since the filter button has the `dropdown-toggle-split` class the `btn-group > .btn.dropdown-toggle-split` selector applies and the rounded borders on the right are removed.  That makes the button look wrong.

This just removes incorrect `dropdown-toggle-split` class that is causing the problem and makes it so the button is displayed correctly.