### PR TITLE
Fix the comment about the LTI 1.1 consumer key in the authen_LTI_1_1.conf.dist file.

### DIFF
--- a/conf/authen_LTI_1_1.conf.dist
+++ b/conf/authen_LTI_1_1.conf.dist
@@ -129,7 +129,7 @@ $LTI{v1p1}{BasicConsumerSecret} = '';
 # The consumer key is entered in the LMS request form, and needs to match the entry here if this
 # is set.  This is only used for content item selection requests from an LMS, and this does not
 # even need to be set for that unless there are multiple courses from different LMS's that have
-# the same LMS course id and both use a course on this webwork2 server.  In that case each LMS
+# the same LMS context id and both use a course on this webwork2 server.  In that case each LMS
 # must use a different consumer key, and the correct consumer keys should be set in the
 # course.conf file for each course. If this server is a tool provider for multiple LMS's, then
 # it is recommended that this be set. Usually it is not useful to set this here.  However, if


### PR DESCRIPTION
The LMS course ID is not the issue.  It is the LMS context id.  That can be the same for two courses from different LMS's.   So the `ConsumerKey` is used in that case to distinguish.  The course id could actually even be the same for two courses from the same LMS.  However, that isn't used for this at all.