### PR TITLE
Hotfix: Prevent error when adding new course.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -402,7 +402,8 @@ sub addCourse {
 		}
 		if ($options{copyNonStudents}) {
 			foreach my $userTriple (@users) {
-				my $user_id   = $userTriple->[0]{user_id};
+				my $user_id = $userTriple->[0]{user_id};
+				next if $user_id eq $initialUser->[0]{user_id};    # Skip, will be assigned to all sets below.
 				my @user_sets = $db0->listUserSets($user_id);
 				assignSetsToUsers($db, $ce, \@user_sets, [$user_id]);
 			}
@@ -425,7 +426,8 @@ sub addCourse {
 		}
 		if ($options{copyNonStudents}) {
 			foreach my $userTriple (@users) {
-				my $user_id           = $userTriple->[0]{user_id};
+				my $user_id = $userTriple->[0]{user_id};
+				next if $user_id eq $initialUser->[0]{user_id};    # Skip, was assigned to all achievements above.
 				my @user_achievements = $db0->listUserAchievements($user_id);
 				for my $achievement_id (@user_achievements) {
 					my $userAchievement = $db->newUserAchievement();


### PR DESCRIPTION
When adding a new course if the initial instructor entered into the add course form has the same user ID as a user in the course non-student users, sets, and achievements are being copied from, this user gets assigned to sets and achievements twice, causing an error.

This skips assigning the initial user to the original sets they may have been assigned to and will always assign the initial user to all sets and achievements, so no error occurs.

This will be fixed as part of #2619 in develop, so there is only a hotfix PR for main.