### PR TITLE
Minimal support for custom permission levels in Accounts Manager which are not provided in the userRoles hash

### DIFF
--- a/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
@@ -51,7 +51,7 @@
 			id => $fieldName . '_id', class => 'form-select form-select-sm w-auto flex-grow-0',
 			'aria-labelledby' => 'permission_header' =%>
 	% } else {
-		<%= maketext((grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0]) %>
+		<%= maketext((grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0] // "PermLevel$value") %>
 	% }
 % } elsif ($properties->{type} eq 'password') {
 	% # Note that this is only called if in editMode.


### PR DESCRIPTION
A minimal fix for https://github.com/openwebwork/webwork2/issues/2625.

This only prevents the error and allows the Accounts Manager to load. A fake permission level name "PermLevelN" will appear in the table. It is not a value which can be selected, and editing a user with such a value will force selecting a defined permission level.