### PR TITLE
Add hidden span labels for help links.

### DIFF
--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -135,7 +135,7 @@ sub getConfigValues ($ce) {
 			},
 			{
 				var  => 'perProblemLangAndDirSettingMode',
-				doc  => x('Mode in which the LANG and DIR settings for a single problem are determined.'),
+				doc  => x('Mode in which the LANG and DIR settings for a single problem are determined'),
 				doc2 => x(
 					'<p>Mode in which the LANG and DIR settings for a single problem are determined.</p><p>The '
 						. 'system will set the LANGuage attribute to either a value determined from the problem, a '
@@ -331,7 +331,7 @@ sub getConfigValues ($ce) {
 			},
 			{
 				var  => 'mail{achievementEmailFrom}',
-				doc  => x('Email address to use when sending Achievement notifications.'),
+				doc  => x('Email address to use when sending Achievement notifications'),
 				doc2 => x(
 					'This email address will be used as the sender for achievement notifications. '
 						. 'Achievement notifications will not be sent unless this is set.'
@@ -481,7 +481,7 @@ sub getConfigValues ($ce) {
 			},
 			{
 				var  => 'pg{options}{showCorrectOnRandomize}',
-				doc  => x('Show the correct answer to the current problem before re-randomization.'),
+				doc  => x('Show the correct answer to the current problem before re-randomization'),
 				doc2 => x(
 					'Show the correct answer to the current problem on the last attempt before a new version is '
 						. 'requested.'
@@ -648,7 +648,7 @@ sub getConfigValues ($ce) {
 			},
 			{
 				var  => 'pg{specialPGEnvironmentVars}{entryAssist}',
-				doc  => x('Assist with the student answer entry process.'),
+				doc  => x('Assist with the student answer entry process'),
 				doc2 => x(
 					'<p>MathQuill renders students answers in real-time as they type on the keyboard.</p><p>MathView '
 						. 'allows students to choose from a variety of common math structures (such as fractions and '
@@ -849,7 +849,7 @@ sub getConfigValues ($ce) {
 			},
 			{
 				var  => 'feedback_by_section',
-				doc  => x('Feedback by Section.'),
+				doc  => x('Feedback by Section'),
 				doc2 => x(
 					'By default, feedback is always sent to all users specified to receive feedback. This '
 						. 'variable sets the system to only email feedback to users who have the same section as '

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -957,10 +957,11 @@ This method outputs a link that opens a modal dialog containing the results of r
 HelpFiles template.  The template file that is rendered is $name.html.  If that file does not
 exist, then nothing is output.
 
-The optional argument $args is a hash that may contain the keys label, label_size, or class.
-$args->{label} is the displayed label, $args->{label_size} is a font awesome size class and is
-only used if $args->{label} is not set, and $args->{class} is added to the html class attribute
-if defined.
+The optional argument $args is a hash that may contain the keys label, label_size, help_label,
+or class. $args->{label} is the displayed label. $args->{label_size} is a font awesome size class
+and is only used if $args->{label} is not set. $args->{help_label} is the hidden description of
+the help button, "help_label help.", which defaults to the page title, and is only used if
+$args->{label} is not set. $args->{class} is added to the html class attribute if defined.
 
 =cut
 
@@ -972,11 +973,16 @@ sub helpMacro ($c, $name, $args = {}) {
 		'i',
 		class         => 'icon fa-solid fa-circle-question ' . ($args->{label_size} // ''),
 		'aria-hidden' => 'true',
-		data          => { alt => ' ? ' },
 		''
-	);
+		)
+		. $c->tag(
+			'span',
+			class => 'visually-hidden',
+			$c->maketext('[_1] help.', $args->{help_label} // $c->page_title)
+		);
 	delete $args->{label};
 	delete $args->{label_size};
+	delete $args->{help_label};
 
 	return $c->include("HelpFiles/$name", name => $name, label => $label, args => $args);
 }

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -14,7 +14,10 @@
 % }
 % my $number_of_additional_users = $c->param('number_of_additional_users') || 0;
 %
-<h2><%= maketext('Add Course') %> <%= $c->helpMacro('AdminAddCourse') %></h2>
+<h2>
+	<%= maketext('Add Course') %>
+	<%= $c->helpMacro('AdminAddCourse', { help_label => maketext('Add Course') }) %>
+</h2>
 %
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>

--- a/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Archive Course') %> <%= $c->helpMacro('AdminArchiveCourse') %></h2>
+<h2>
+	<%= maketext('Archive Course') %>
+	<%= $c->helpMacro('AdminArchiveCourse', { help_label => maketext('Archive Course') }) %>
+</h2>
 % # Report on databases
 <h3 class="my-3"><%= maketext('Report on database structure for course [_1]:', $archive_courseID) %></h3>
 % if (@$upgrade_report) {

--- a/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Archive Course') %> <%= $c->helpMacro('AdminArchiveCourse') %></h2>
+<h2>
+	<%= maketext('Archive Course') %>
+	<%= $c->helpMacro('AdminArchiveCourse', { help_label => maketext('Archive Course') }) %>
+</h2>
 %
 % if (@$courseIDs) {
 	<p>

--- a/templates/ContentGenerator/CourseAdmin/delete_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/delete_course_confirm.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Delete Course') %> <%= $c->helpMacro('AdminDeleteCourse') %></h2>
+<h2>
+	<%= maketext('Delete Course') %>
+	<%= $c->helpMacro('AdminDeleteCourse', { help_label => maketext('Delete Course') }) %>
+</h2>
 <p>
 	<%== maketext(
 		'Are you sure you want to delete the course [_1]? All course files and data will be destroyed. '

--- a/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Delete Course') %> <%= $c->helpMacro('AdminDeleteCourse') %></h2>
+<h2>
+	<%= maketext('Delete Course') %>
+	<%= $c->helpMacro('AdminDeleteCourse', { help_label => maketext('Delete Course') }) %>
+</h2>
 %
 % if (@$courseIDs) {
 	<%= form_for current_route, method => 'POST', begin =%>

--- a/templates/ContentGenerator/CourseAdmin/edit_location_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/edit_location_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Editing location [_1]', $locationID) %> <%= $c->helpMacro('AdminManageLocations') %></h2>
+<h2>
+	<%= maketext('Editing location [_1]', $locationID) %>
+	<%= $c->helpMacro('AdminManageLocations', { help_label => maketext('Manage Locations') }) %>
+</h2>
 <p>
 	<%= maketext(
 		'Edit the current value of the location description, if desired, then add and select addresses to delete, '

--- a/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Hide Courses') %> <%= $c->helpMacro('AdminHideCourses') %></h2>
+<h2>
+	<%= maketext('Hide Courses') %>
+	<%= $c->helpMacro('AdminHideCourses', { help_label => maketext('Hide Courses') }) %>
+</h2>
 <p>
 	<%= maketext(
 		'Select the course(s) you want to hide (or unhide) and then click "Hide Courses" (or "Unhide Courses"). '

--- a/templates/ContentGenerator/CourseAdmin/manage_location_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/manage_location_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Manage Locations') %> <%= $c->helpMacro('AdminManageLocations') %></h2>
+<h2>
+	<%= maketext('Manage Locations') %>
+	<%= $c->helpMacro('AdminManageLocations', { help_label => maketext('Manage Locations') }) %>
+</h2>
 <p><strong><%= maketext('Currently defined locations are listed below.') %></strong></p>
 <%= form_for current_route, method => 'POST', begin =%>
 	% my @locationIDs = map  { $_->location_id } @$locations;

--- a/templates/ContentGenerator/CourseAdmin/manage_lti_course_map_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/manage_lti_course_map_form.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Manage LTI Course Map') %> <%= $c->helpMacro('AdminManageLTICourseMap') %></h2>
+<h2>
+	<%= maketext('Manage LTI Course Map') %>
+	<%= $c->helpMacro('AdminManageLTICourseMap', { help_label => maketext('Manage LTI Course Map') }) %>
+</h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields('subDisplay') =%>

--- a/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
+<h2>
+	<%= maketext('Rename Course') %>
+	<%= $c->helpMacro('AdminRenameCourse', { help_label => maketext('Rename Course') }) %>
+</h2>
 % # Report on databases
 <h3 class="my-3"><%= maketext('Report on database structure for course [_1]:', $rename_oldCourseID) %></h3>
 % if (@$upgrade_report) {

--- a/templates/ContentGenerator/CourseAdmin/rename_course_confirm_short.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_confirm_short.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
+<h2>
+	<%= maketext('Rename Course') %>
+	<%= $c->helpMacro('AdminRenameCourse', { help_label => maketext('Rename Course') }) %>
+</h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<%= $c->hidden_authen_fields =%>
 	<%= $c->hidden_fields('subDisplay') =%>

--- a/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
@@ -1,6 +1,9 @@
 % use WeBWorK::Utils::CourseManagement qw(listCourses);
 %
-<h2><%= maketext('Rename Course') %> <%= $c->helpMacro('AdminRenameCourse') %></h2>
+<h2>
+	<%= maketext('Rename Course') %>
+	<%= $c->helpMacro('AdminRenameCourse', { help_label => maketext('Rename Course') }) %>
+</h2>
 %
 % my @courseIDs = sort { lc($a) cmp lc($b) } grep { $_ ne stash('courseID') } listCourses($ce);
 %

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_confirm.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
+<h2>
+	<%= maketext('Unarchive Course') %>
+	<%= $c->helpMacro('AdminUnarchiveCourse', { help_label => maketext('Unarchive Course') }) %>
+</h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<div class="row mb-2">
 		<%= label_for new_courseID => maketext('Unarchive [_1] to course:', $unarchive_courseID),

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -1,6 +1,9 @@
 % use WeBWorK::Utils::CourseManagement qw(listArchivedCourses);
 %
-<h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
+<h2>
+	<%= maketext('Unarchive Course') %>
+	<%= $c->helpMacro('AdminUnarchiveCourse', { help_label => maketext('Unarchive Course') }) %>
+</h2>
 %
 % # Find courses which have been archived.
 % my @courseIDs = sort { lc($a) cmp lc($b) } listArchivedCourses($ce);

--- a/templates/ContentGenerator/CourseAdmin/upgrade_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/upgrade_course_confirm.html.ep
@@ -1,4 +1,7 @@
-<h2><%= maketext('Upgrade Courses') %> <%= $c->helpMacro('AdminUpgradeCourses') %></h2>
+<h2>
+	<%= maketext('Upgrade Courses') %>
+	<%= $c->helpMacro('AdminUpgradeCourses', { help_label => maketext('Upgrade Courses') }) %>
+</h2>
 <%= form_for current_route, method => 'POST', begin =%>
 	<% my $checkALLs = begin =%>
 		% if ($extra_database_tables_exist) {

--- a/templates/ContentGenerator/CourseAdmin/upgrade_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/upgrade_course_form.html.ep
@@ -4,7 +4,10 @@
 %
 % my @courseIDs = sort { lc($a) cmp lc($b) } listCourses($ce);
 %
-<h2><%= maketext('Upgrade Courses') %> <%= $c->helpMacro('AdminUpgradeCourses') %></h2>
+<h2>
+	<%= maketext('Upgrade Courses') %>
+	<%= $c->helpMacro('AdminUpgradeCourses', { help_label => maketext('Upgrade Courses') }) %>
+</h2>
 <div class="mb-2"><%= maketext('Update the checked directories?') %></div>
 <%= form_for current_route, method => 'POST', id => 'courselist', name => 'courselist', begin =%>
 	<div class="mb-2">

--- a/templates/ContentGenerator/Instructor/Config/config_help.html.ep
+++ b/templates/ContentGenerator/Instructor/Config/config_help.html.ep
@@ -10,7 +10,10 @@
 	</div>
 	<div>
 		<%= link_to '#', data => { bs_toggle => 'modal', bs_target => "#$configObject->{name}_help_modal" }, begin =%>
-			<i class="icon fas fa-question-circle" aria-hidden="true" data-alt="help"></i>
+			<i class="icon fas fa-question-circle" aria-hidden="true"></i>
+			<span class="visually-hidden">
+				<%= maketext('[_1] help.', $configObject->{doc}) %>
+			</span>
 		<% end =%>
 		<% content_for 'modal-dialog-area', begin =%>
 			<div class="modal fade" id="<%= "$configObject->{name}_help_modal" %>" tabindex="-1"

--- a/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/browse_library_panel_advanced.html.ep
@@ -85,7 +85,7 @@
 								</label>
 							</div>
 						% }
-						<%= $c->helpMacro('Levels') =%>
+						<%= $c->helpMacro('Levels', { help_label => 'Levels' }) =%>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION
This adds a hidden span that gives a label for the help links for the main help link using the helpMacro and the help links on the course configuration page. There is now an aria-labelledby setting for this description which describes what the help link is for.

The page title is used for the description for the main help link. For the course configuration links, the setting short description is used for the title. A few of the short descriptions ended in a period, those were all removed to make the description "desc help." consistent and not have a period before the help statement.

I couldn't figure out a better label for the course configuration help statements than the short description. This seems a little long in some cases, but overall identifies what setting the help buttons is for.