### PR TITLE
Switch to using Perl::Tidy version 20240903 (the latest).

### DIFF
--- a/.github/workflows/check-formats.yml
+++ b/.github/workflows/check-formats.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy@20220613
+        run: cpanm -n Perl::Tidy@20240903
       - name: Run perltidy
         shell: bash
         run: |

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -20,4 +20,3 @@
 -nlop   # No logical padding (this causes mixed tabs and spaces)
 -wn     # Weld nested containers
 -xci    # Extended continuation indentation
--vxl='q' # No vertical alignment of qw quotes

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -165,7 +165,6 @@ my %moduleVersion = (
 	'LWP::Protocol::https' => 6.06,
 	'Mojolicious'          => 9.34,
 	'Net::SSLeay'          => 1.46,
-	'Perl::Tidy'           => 20220613,
 	'SQL::Abstract'        => 2.000000
 );
 

--- a/bin/crypt_passwords_in_classlist.pl
+++ b/bin/crypt_passwords_in_classlist.pl
@@ -13,7 +13,7 @@ BEGIN {
 
 use lib "$ENV{WEBWORK_ROOT}/lib";
 
-use WeBWorK::Utils qw(cryptPassword);
+use WeBWorK::Utils           qw(cryptPassword);
 use WeBWorK::File::Classlist qw(parse_classlist write_classlist);
 
 unless (@ARGV == 1) {

--- a/bin/dev_scripts/PODtoHTML.pm
+++ b/bin/dev_scripts/PODtoHTML.pm
@@ -23,8 +23,8 @@ use Pod::Simple::Search;
 use Mojo::Template;
 use Mojo::DOM;
 use Mojo::Collection qw(c);
-use File::Path qw(make_path);
-use File::Basename qw(dirname);
+use File::Path       qw(make_path);
+use File::Basename   qw(dirname);
 use IO::File;
 use POSIX qw(strftime);
 

--- a/bin/dev_scripts/generate-ww-pg-pod.pl
+++ b/bin/dev_scripts/generate-ww-pg-pod.pl
@@ -65,9 +65,9 @@ $base_url = "/" if !$base_url;
 use Mojo::Template;
 use IO::File;
 use File::Copy;
-use File::Path qw(make_path remove_tree);
+use File::Path     qw(make_path remove_tree);
 use File::Basename qw(dirname);
-use Cwd qw(abs_path);
+use Cwd            qw(abs_path);
 
 use lib dirname(dirname(dirname(__FILE__))) . '/lib';
 use lib dirname(__FILE__);

--- a/bin/dev_scripts/run-perltidy.pl
+++ b/bin/dev_scripts/run-perltidy.pl
@@ -63,9 +63,8 @@ use Mojo::File qw(curfile);
 
 my $webwork_root = curfile->dirname->dirname->dirname;
 
-die "Version 20220613 or newer of perltidy is required for this script.\n"
-	. "The installed version is $Perl::Tidy::VERSION.\n"
-	unless $Perl::Tidy::VERSION >= 20220613;
+die "Version 20240903 of perltidy is required for this script.\nThe installed version is $Perl::Tidy::VERSION.\n"
+	unless $Perl::Tidy::VERSION == 20240903;
 die "The .perltidyrc file in the webwork root directory is not readable.\n"
 	unless -r "$webwork_root/.perltidyrc";
 

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -15,7 +15,7 @@ use JSON;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/dump-OPL-tables.pl
+++ b/bin/dump-OPL-tables.pl
@@ -22,7 +22,7 @@ use strict;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/dump-past-answers.pl
+++ b/bin/dump-past-answers.pl
@@ -98,7 +98,7 @@ use feature 'say';
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }
 

--- a/bin/generate-OPL-set-def-lists.pl
+++ b/bin/generate-OPL-set-def-lists.pl
@@ -26,7 +26,7 @@ use File::Find;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/importClassList.pl
+++ b/bin/importClassList.pl
@@ -19,7 +19,7 @@ use warnings;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }
@@ -31,7 +31,7 @@ use WeBWorK::CourseEnvironment;
 
 use WeBWorK::DB qw(check_user_id);
 use WeBWorK::File::Classlist;
-use WeBWorK::Utils qw(cryptPassword);
+use WeBWorK::Utils           qw(cryptPassword);
 use WeBWorK::File::Classlist qw(parse_classlist);
 
 if ((scalar(@ARGV) != 2)) {

--- a/bin/load-OPL-global-statistics.pl
+++ b/bin/load-OPL-global-statistics.pl
@@ -21,7 +21,7 @@ use strict;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/restore-OPL-tables.pl
+++ b/bin/restore-OPL-tables.pl
@@ -22,7 +22,7 @@ use strict;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/test_library_build.pl
+++ b/bin/test_library_build.pl
@@ -2,7 +2,7 @@
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/update-OPL-statistics.pl
+++ b/bin/update-OPL-statistics.pl
@@ -19,7 +19,7 @@ use strict;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/updateOPLextras.pl
+++ b/bin/updateOPLextras.pl
@@ -71,7 +71,7 @@ pod2usage(2) unless ($textbooks || $directories || $subjects || $all);
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/upgrade-database-to-utf8mb4.pl
+++ b/bin/upgrade-database-to-utf8mb4.pl
@@ -126,7 +126,7 @@ use warnings;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/upgrade_admin_db.pl
+++ b/bin/upgrade_admin_db.pl
@@ -16,7 +16,7 @@
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/bin/upload-OPL-statistics.pl
+++ b/bin/upload-OPL-statistics.pl
@@ -19,7 +19,7 @@
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -26,10 +26,10 @@ use warnings;
 
 use JSON;
 use Digest::SHA qw(sha1_base64);
-use Mojo::Util qw(xml_escape);
+use Mojo::Util  qw(xml_escape);
 use Mojo::DOM;
 
-use WeBWorK::Utils qw(getAssetURL);
+use WeBWorK::Utils                       qw(getAssetURL);
 use WeBWorK::Utils::LanguageAndDirection qw(get_lang_and_dir get_problem_lang_and_dir);
 
 sub formatRenderedProblem {

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -29,7 +29,7 @@ use warnings;
 use File::Path;
 use String::ShellQuote;
 use Archive::Zip qw(:ERROR_CODES);
-use Mojo::File qw(path tempdir);
+use Mojo::File   qw(path tempdir);
 use XML::LibXML;
 
 sub hardcopyRenderedProblem {
@@ -265,8 +265,7 @@ sub write_problem_tex {
 				$correctTeX .=
 					"\\item\n\$\\displaystyle "
 					. ($rh_result->{answers}{$_}{correct_ans_latex_string}
-						|| "\\text{$rh_result->{answers}{$_}{correct_ans}}")
-					. "\$\n";
+						|| "\\text{$rh_result->{answers}{$_}{correct_ans}}") . "\$\n";
 			}
 
 			$correctTeX .= "\\end{itemize}}\\par\n";

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -28,7 +28,7 @@ use Mojo::JSON qw(encode_json);
 
 use WeBWorK;
 use WeBWorK::CourseEnvironment;
-use WeBWorK::Utils::Logs qw(writeTimingLogEntry);
+use WeBWorK::Utils::Logs   qw(writeTimingLogEntry);
 use WeBWorK::Utils::Routes qw(setup_content_generator_routes);
 
 sub startup ($app) {

--- a/lib/WeBWorK/AchievementEvaluator.pm
+++ b/lib/WeBWorK/AchievementEvaluator.pm
@@ -24,7 +24,7 @@ use Mojo::Base 'Exporter', -signatures;
 
 use DateTime;
 
-use WeBWorK::Utils qw(sortAchievements nfreeze_base64 thaw_base64);
+use WeBWorK::Utils                    qw(sortAchievements nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::ProblemProcessing qw(compute_unreduced_score);
 use WeBWorK::Utils::Tags;
 use WeBWorK::WWSafe;

--- a/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
+++ b/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to allow students to take an additional version of a test within its test version interval
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(before between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/DoubleProb.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleProb.pm
@@ -20,9 +20,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/DoubleSet.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleSet.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to make a homework set worth twice as much
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/DuplicateProb.pm
+++ b/lib/WeBWorK/AchievementItems/DuplicateProb.pm
@@ -20,9 +20,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to extend a close date by 24 hours.
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to extend the close date on a test
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/FullCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditProb.pm
@@ -20,9 +20,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to give half credit on all problems in a homework set.
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -20,9 +20,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to give half credit on all problems in a homework set.
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -19,9 +19,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend a close date by 24 hours for reduced credit
 # Reduced scoring needs to be enabled for this item to work.
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
+++ b/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
@@ -20,9 +20,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ResurrectGW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectGW.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to extend the due date on a gateway
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/ResurrectHW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectHW.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to resurrect a homework for 24 hours
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -18,9 +18,9 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 # Item to extend a close date by 48 hours.
 
-use WeBWorK::Utils qw(x nfreeze_base64 thaw_base64);
+use WeBWorK::Utils           qw(x nfreeze_base64 thaw_base64);
 use WeBWorK::Utils::DateTime qw(between);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets     qw(format_set_name_display);
 
 sub new ($class) {
 	return bless {

--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -52,10 +52,10 @@ use warnings;
 
 use Date::Format;
 use Scalar::Util qw(weaken);
-use Mojo::Util qw(b64_encode b64_decode);
+use Mojo::Util   qw(b64_encode b64_decode);
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(x runtime_use);
+use WeBWorK::Utils       qw(x runtime_use);
 use WeBWorK::Utils::Logs qw(writeCourseLog);
 use WeBWorK::Utils::TOTP;
 use WeBWorK::Localize;

--- a/lib/WeBWorK/Authen/LDAP.pm
+++ b/lib/WeBWorK/Authen/LDAP.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 
 use WeBWorK::Debug qw(debug);
-use Net::LDAP qw(LDAP_INVALID_CREDENTIALS);
+use Net::LDAP      qw(LDAP_INVALID_CREDENTIALS);
 
 sub checkPassword {
 	my ($self, $userID, $possibleClearPassword) = @_;

--- a/lib/WeBWorK/Authen/LTI/GradePassback.pm
+++ b/lib/WeBWorK/Authen/LTI/GradePassback.pm
@@ -23,7 +23,7 @@ WeBWorK::Authen::LTI::GradePassback - Grade passback utilities for LTI authentic
 =cut
 
 use WeBWorK::Utils::DateTime qw(after before);
-use WeBWorK::Utils::Sets qw(grade_set grade_gateway);
+use WeBWorK::Utils::Sets     qw(grade_set grade_gateway);
 
 our @EXPORT_OK = qw(massUpdate passbackGradeOnSubmit getSetPassbackScore);
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -33,7 +33,7 @@ use URI::Escape;
 use Net::OAuth;
 
 use WeBWorK::Debug;
-use WeBWorK::Utils::DateTime qw(formatDateTime);
+use WeBWorK::Utils::DateTime   qw(formatDateTime);
 use WeBWorK::Utils::Instructor qw(assignSetToUser);
 use WeBWorK::Localize;
 use WeBWorK::Authen::LTIAdvanced::Nonce;

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -29,8 +29,8 @@ use UUID::Tiny ':std';
 use Digest::SHA qw(sha1_base64);
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound);
-use WeBWorK::Utils::Sets qw(grade_all_sets);
+use WeBWorK::Utils                      qw(wwRound);
+use WeBWorK::Utils::Sets                qw(grade_all_sets);
 use WeBWorK::Authen::LTI::GradePassback qw(getSetPassbackScore);
 
 # This package contains utilities for submitting grades to the LMS

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -29,7 +29,7 @@ use experimental 'signatures';
 
 use WeBWorK::Debug;
 use WeBWorK::Localize;
-use WeBWorK::Utils::DateTime qw(formatDateTime);
+use WeBWorK::Utils::DateTime   qw(formatDateTime);
 use WeBWorK::Utils::Instructor qw(assignSetToUser);
 use WeBWorK::Authen::LTIAdvantage::SubmitGrade;
 
@@ -323,8 +323,7 @@ sub authenticate ($self) {
 				"Account creation blocked by block_lti_create_user setting. Did not create user $self->{user_id}.";
 			if ($ce->{debug_lti_parameters}) {
 				warn $c->maketext('Account creation is currently disabled in this course.  '
-						. 'Please speak to your instructor or system administrator.')
-					. "\n";
+						. 'Please speak to your instructor or system administrator.') . "\n";
 			}
 			return 0;
 		} else {

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -34,12 +34,12 @@ use Mojo::IOLoop;
 use Crypt::JWT qw(encode_jwt);
 use Crypt::PK::RSA;
 use Math::Random::Secure qw(irand);
-use Digest::SHA qw(sha256_hex);
+use Digest::SHA          qw(sha256_hex);
 use Time::HiRes;
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound);
-use WeBWorK::Utils::Sets qw(grade_all_sets);
+use WeBWorK::Utils                      qw(wwRound);
+use WeBWorK::Utils::Sets                qw(grade_all_sets);
 use WeBWorK::Authen::LTI::GradePassback qw(getSetPassbackScore);
 
 # This package contains utilities for submitting grades to the LMS via LTI 1.3.

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -25,7 +25,7 @@ WeBWorK::Authen::Proctor - Authenticate gateway test proctors.
 use strict;
 use warnings;
 
-use WeBWorK::Utils qw(x);
+use WeBWorK::Utils     qw(x);
 use WeBWorK::DB::Utils qw(grok_vsetID);
 
 use constant GENERIC_ERROR_MESSAGE => x('Invalid user ID or password.');

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -61,7 +61,7 @@ use warnings;
 use Carp qw/croak/;
 
 use WeBWorK::Utils::DateTime qw(before);
-use WeBWorK::Utils::Sets qw(is_restricted);
+use WeBWorK::Utils::Sets     qw(is_restricted);
 use WeBWorK::Authen::Proctor;
 use Net::IP;
 use Scalar::Util qw(weaken);

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -1202,7 +1202,7 @@ sub getConfigValues ($ce) {
 			@$configValues,
 			[
 				x('LTI'),
-				map      { $LTIConfigValues->{$_} }
+				map { $LTIConfigValues->{$_} }
 					grep { defined $LTIConfigValues->{$_} } @{ $ce->{LTIConfigVariables} }
 			]
 		);

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -50,13 +50,13 @@ use Encode;
 
 use WeBWorK::File::Scoring qw(parse_scoring_file);
 use WeBWorK::Localize;
-use WeBWorK::Utils qw(fetchEmailRecipients generateURLs getAssetURL);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
+use WeBWorK::Utils                       qw(fetchEmailRecipients generateURLs getAssetURL);
+use WeBWorK::Utils::JITAR                qw(jitar_id_to_seq);
 use WeBWorK::Utils::LanguageAndDirection qw(get_lang_and_dir);
-use WeBWorK::Utils::Logs qw(writeCourseLog);
-use WeBWorK::Utils::Routes qw(route_title route_navigation_is_restricted);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
-use WeBWorK::Authen::LTI::GradePassback qw(massUpdate);
+use WeBWorK::Utils::Logs                 qw(writeCourseLog);
+use WeBWorK::Utils::Routes               qw(route_title route_navigation_is_restricted);
+use WeBWorK::Utils::Sets                 qw(format_set_name_display);
+use WeBWorK::Authen::LTI::GradePassback  qw(massUpdate);
 
 =head1 INVOCATION
 

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -26,15 +26,15 @@ deal with versioning sets
 use Mojo::Promise;
 use Mojo::JSON qw(encode_json decode_json);
 
-use WeBWorK::Utils qw(encodeAnswers decodeAnswers wwRound);
-use WeBWorK::Utils::DateTime qw(before between after);
-use WeBWorK::Utils::Files qw(path_is_subdir);
-use WeBWorK::Utils::Instructor qw(assignSetVersionToUser);
-use WeBWorK::Utils::Logs qw(writeLog writeCourseLog);
+use WeBWorK::Utils                    qw(encodeAnswers decodeAnswers wwRound);
+use WeBWorK::Utils::DateTime          qw(before between after);
+use WeBWorK::Utils::Files             qw(path_is_subdir);
+use WeBWorK::Utils::Instructor        qw(assignSetVersionToUser);
+use WeBWorK::Utils::Logs              qw(writeLog writeCourseLog);
 use WeBWorK::Utils::ProblemProcessing qw/create_ans_str_from_responses compute_reduced_score/;
-use WeBWorK::Utils::Rendering qw(getTranslatorDebuggingOptions renderPG);
-use WeBWorK::Utils::Sets qw(is_restricted);
-use WeBWorK::DB::Utils qw(global2user fake_set fake_set_version fake_problem);
+use WeBWorK::Utils::Rendering         qw(getTranslatorDebuggingOptions renderPG);
+use WeBWorK::Utils::Sets              qw(is_restricted);
+use WeBWorK::DB::Utils                qw(global2user fake_set fake_set_version fake_problem);
 use WeBWorK::Debug;
 use PGrandom;
 use WeBWorK::Authen::LTI::GradePassback qw(passbackGradeOnSubmit);
@@ -498,7 +498,7 @@ async sub pre_header_initialize ($c) {
 
 	if ($setVersionNumber && !$c->{invalidSet} && $setID ne 'Undefined_Set') {
 		my @setVersionIDs = $db->listSetVersions($effectiveUserID, $setID);
-		my @setVersions   = $db->getSetVersions(map { [ $effectiveUserID, $setID,, $_ ] } @setVersionIDs);
+		my @setVersions   = $db->getSetVersions(map { [ $effectiveUserID, $setID, $_ ] } @setVersionIDs);
 		for (@setVersions) {
 			$totalNumVersions++;
 			$currentNumVersions++

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -22,10 +22,10 @@ WeBWorK::ContentGenerator::Grades - Display statistics by user.
 
 =cut
 
-use WeBWorK::Utils qw(wwRound);
-use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(grade_set format_set_name_display);
+use WeBWorK::Utils                    qw(wwRound);
+use WeBWorK::Utils::DateTime          qw(after);
+use WeBWorK::Utils::JITAR             qw(jitar_id_to_seq);
+use WeBWorK::Utils::Sets              qw(grade_set format_set_name_display);
 use WeBWorK::Utils::ProblemProcessing qw(compute_unreduced_score);
 use WeBWorK::Localize;
 

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -29,13 +29,13 @@ use String::ShellQuote;
 use Archive::Zip qw(:ERROR_CODES);
 use XML::LibXML;
 
-use WeBWorK::DB::Utils qw/user2global/;
-use WeBWorK::Utils qw(decodeAnswers x);
-use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Files qw(readFile);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
+use WeBWorK::DB::Utils        qw/user2global/;
+use WeBWorK::Utils            qw(decodeAnswers x);
+use WeBWorK::Utils::DateTime  qw(after);
+use WeBWorK::Utils::Files     qw(readFile);
+use WeBWorK::Utils::JITAR     qw(jitar_id_to_seq);
 use WeBWorK::Utils::Rendering qw(renderPG);
-use WeBWorK::Utils::Sets qw(is_restricted);
+use WeBWorK::Utils::Sets      qw(is_restricted);
 use PGrandom;
 
 =head1 CONFIGURATION VARIABLES
@@ -1007,8 +1007,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
 			. ($c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) =~
-				s/\x{202f}/ /gr)
-			. "}%\n";
+				s/\x{202f}/ /gr) . "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)
@@ -1181,10 +1180,10 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 				problemID => $MergedProblem->problem_id,
 			),
 			$MergedProblem->problem_id == 0
-				# link for a fake problem (like a header file)
+			# link for a fake problem (like a header file)
 			? (params =>
 					{ sourceFilePath => $MergedProblem->source_file, problemSeed => $MergedProblem->problem_seed })
-				# link for a real problem
+			# link for a real problem
 			: (),
 		);
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -25,7 +25,7 @@ WeBWorK::ContentGenerator::Instructor::AchievementEditor - edit an achevement ev
 use HTML::Entities;
 use File::Copy;
 
-use WeBWorK::Utils qw(fix_newlines not_blank x);
+use WeBWorK::Utils        qw(fix_newlines not_blank x);
 use WeBWorK::Utils::Files qw(surePathToFile readFile path_is_subdir);
 
 use constant ACTION_FORMS => [qw(save save_as)];

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -47,7 +47,7 @@ links to edit the evaluator and the individual user data.
 use Mojo::File;
 use Text::CSV;
 
-use WeBWorK::Utils qw(sortAchievements x);
+use WeBWorK::Utils        qw(sortAchievements x);
 use WeBWorK::Utils::Files qw(surePathToFile);
 
 # Forms

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
@@ -22,7 +22,7 @@ WeBWorK::ContentGenerator::Instructor::AchievementNotificationEditor - edit the 
 
 =cut
 
-use WeBWorK::Utils qw(fix_newlines not_blank x);
+use WeBWorK::Utils        qw(fix_newlines not_blank x);
 use WeBWorK::Utils::Files qw(surePathToFile readFile path_is_subdir);
 
 use constant ACTION_FORMS => [qw(save save_as existing disable)];

--- a/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AddUsers.pm
@@ -22,7 +22,7 @@ WeBWorK::ContentGenerator::Instructor::AddUsers - Menu interface for adding user
 
 =cut
 
-use WeBWorK::Utils qw/cryptPassword trim_spaces/;
+use WeBWorK::Utils             qw/cryptPassword trim_spaces/;
 use WeBWorK::Utils::Instructor qw(assignSetsToUsers);
 
 sub initialize ($c) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -28,12 +28,12 @@ use File::Copy;
 use File::Spec;
 use String::ShellQuote;
 use Archive::Tar;
-use Archive::Zip qw(:ERROR_CODES);
+use Archive::Zip            qw(:ERROR_CODES);
 use Archive::Zip::SimpleZip qw($SimpleZipError);
 
-use WeBWorK::Utils qw(sortByName min);
+use WeBWorK::Utils                   qw(sortByName min);
 use WeBWorK::Utils::CourseManagement qw(archiveCourse);
-use WeBWorK::Utils::Files qw(readFile);
+use WeBWorK::Utils::Files            qw(readFile);
 use WeBWorK::Upload;
 
 use constant HOME => 'templates';

--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -23,9 +23,9 @@ pages
 
 =cut
 
-use WeBWorK::Utils qw(x);
+use WeBWorK::Utils        qw(x);
 use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(format_set_name_internal);
+use WeBWorK::Utils::Sets  qw(format_set_name_internal);
 
 use constant E_MAX_ONE_SET  => x('Please select at most one set.');
 use constant E_ONE_USER     => x('Please select exactly one user.');

--- a/lib/WeBWorK/ContentGenerator/Instructor/LTIUpdate.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/LTIUpdate.pm
@@ -18,7 +18,7 @@
 package WeBWorK::ContentGenerator::Instructor::LTIUpdate;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets                qw(format_set_name_display);
 use WeBWorK::Authen::LTI::GradePassback qw(massUpdate);
 
 sub initialize ($c) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -118,11 +118,11 @@ not exist.  The path to the actual file being edited is stored in inputFilePath.
 use Mojo::File;
 use XML::LibXML;
 
-use WeBWorK::Utils qw(not_blank x max);
-use WeBWorK::Utils::Files qw(surePathToFile readFile path_is_subdir);
+use WeBWorK::Utils             qw(not_blank x max);
+use WeBWorK::Utils::Files      qw(surePathToFile readFile path_is_subdir);
 use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
-use WeBWorK::Utils::JITAR qw(seq_to_jitar_id jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::JITAR      qw(seq_to_jitar_id jitar_id_to_seq);
+use WeBWorK::Utils::Sets       qw(format_set_name_display);
 
 use constant DEFAULT_SEED => 123456;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -25,9 +25,9 @@ manually grading webwork problems.
 
 use HTML::Entities;
 
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
+use WeBWorK::Utils::JITAR     qw(jitar_id_to_seq);
 use WeBWorK::Utils::Rendering qw(renderPG);
-use WeBWorK::Utils::Sets qw(get_test_problem_position format_set_name_display);
+use WeBWorK::Utils::Sets      qw(get_test_problem_position format_set_name_display);
 
 async sub initialize ($c) {
 	my $authz      = $c->authz;

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -25,11 +25,11 @@ specific user/set information as well as problem information
 
 use Exporter qw(import);
 
-use WeBWorK::Utils qw(cryptPassword x);
-use WeBWorK::Utils::Files qw(surePathToFile readFile);
+use WeBWorK::Utils             qw(cryptPassword x);
+use WeBWorK::Utils::Files      qw(surePathToFile readFile);
 use WeBWorK::Utils::Instructor qw(assignProblemToAllSetUsers addProblemToSet);
-use WeBWorK::Utils::JITAR qw(seq_to_jitar_id jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(format_set_name_internal format_set_name_display);
+use WeBWorK::Utils::JITAR      qw(seq_to_jitar_id jitar_id_to_seq);
+use WeBWorK::Utils::Sets       qw(format_set_name_internal format_set_name_display);
 require WeBWorK::PG;
 
 our @EXPORT_OK = qw(FIELD_PROPERTIES);

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -79,11 +79,11 @@ Delete sets:
 use Mojo::File;
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(x);
-use WeBWorK::Utils::DateTime qw(getDefaultSetDueDate);
+use WeBWorK::Utils             qw(x);
+use WeBWorK::Utils::DateTime   qw(getDefaultSetDueDate);
 use WeBWorK::Utils::Instructor qw(assignSetToUser);
-use WeBWorK::Utils::Sets qw(format_set_name_internal format_set_name_display);
-use WeBWorK::File::SetDef qw(importSetsFromDef exportSetsToDef);
+use WeBWorK::Utils::Sets       qw(format_set_name_internal format_set_name_display);
+use WeBWorK::File::SetDef      qw(importSetsFromDef exportSetsToDef);
 
 use constant HIDE_SETS_THRESHOLD => 500;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -23,7 +23,7 @@ WeBWorK::ContentGenerator::Instructor::Scoring - Generate scoring data files
 =cut
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound x);
+use WeBWorK::Utils        qw(wwRound x);
 use WeBWorK::Utils::Files qw(readFile);
 use WeBWorK::Utils::JITAR qw(jitar_id_to_seq jitar_problem_adjusted_status);
 use WeBWorK::ContentGenerator::Instructor::FileManager;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -25,12 +25,12 @@ WeBWorK::ContentGenerator::Instructor::SetMaker - Make homework sets.
 use Mojo::File;
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(sortByName x);
-use WeBWorK::Utils::DateTime qw(getDefaultSetDueDate);
+use WeBWorK::Utils             qw(sortByName x);
+use WeBWorK::Utils::DateTime   qw(getDefaultSetDueDate);
 use WeBWorK::Utils::Instructor qw(assignSetToUser assignProblemToAllSetUsers addProblemToSet);
 use WeBWorK::Utils::LibraryStats;
 use WeBWorK::Utils::ListingDB qw(getDBListings);
-use WeBWorK::Utils::Sets qw(format_set_name_internal);
+use WeBWorK::Utils::Sets      qw(format_set_name_internal);
 use WeBWorK::Utils::Tags;
 
 # Use x to mark strings for maketext

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -25,7 +25,7 @@ WeBWorK::ContentGenerator::Instructor::ShowAnswers.pm  -- display past answers o
 use Text::CSV;
 use Mojo::File;
 
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq prob_id_sort);
+use WeBWorK::Utils::JITAR     qw(jitar_id_to_seq prob_id_sort);
 use WeBWorK::Utils::Rendering qw(renderPG);
 
 use constant PAST_ANSWERS_FILENAME => 'past_answers';

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -26,8 +26,8 @@ homework set (including sv graphs).
 use SVG;
 
 use WeBWorK::Utils::FilterRecords qw(getFiltersForClass filterRecords);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq jitar_problem_adjusted_status);
-use WeBWorK::Utils::Sets qw(grade_set format_set_name_display);
+use WeBWorK::Utils::JITAR         qw(jitar_id_to_seq jitar_problem_adjusted_status);
+use WeBWorK::Utils::Sets          qw(grade_set format_set_name_display);
 
 sub initialize ($c) {
 	my $db   = $c->db;

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -22,10 +22,10 @@ WeBWorK::ContentGenerator::Instructor::StudentProgress - Display Student Progres
 
 =cut
 
-use WeBWorK::Utils qw(wwRound);
+use WeBWorK::Utils                qw(wwRound);
 use WeBWorK::Utils::FilterRecords qw(getFiltersForClass filterRecords);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(grade_set list_set_versions format_set_name_display);
+use WeBWorK::Utils::JITAR         qw(jitar_id_to_seq);
+use WeBWorK::Utils::Sets          qw(grade_set list_set_versions format_set_name_display);
 
 sub initialize ($c) {
 	my $db   = $c->db;
@@ -219,7 +219,7 @@ sub displaySets ($c) {
 				@user_set_list,
 				{
 					record             => $studentRecord,
-					score              => 0,
+					score              =>  0,
 					total              => -1,
 					date               => '',
 					testtime           => '',

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -22,8 +22,8 @@ WeBWorK::ContentGenerator::Instructor::UserDetail - Detailed User specific infor
 
 =cut
 
-use WeBWorK::DB::Utils qw(grok_versionID_from_vsetID_sql);
-use WeBWorK::Utils qw(x);
+use WeBWorK::DB::Utils         qw(grok_versionID_from_vsetID_sql);
+use WeBWorK::Utils             qw(x);
 use WeBWorK::Utils::Instructor qw(assignSetToUser);
 use WeBWorK::Debug;
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -63,7 +63,7 @@ Export users:
 use Mojo::File;
 
 use WeBWorK::File::Classlist qw(parse_classlist write_classlist);
-use WeBWorK::Utils qw(cryptPassword x);
+use WeBWorK::Utils           qw(cryptPassword x);
 
 use constant HIDE_USERS_THRESHHOLD => 200;
 use constant EDIT_FORMS            => [qw(save_edit cancel_edit)];
@@ -237,15 +237,15 @@ sub pre_header_initialize ($c) {
 	# Always have a definite sort order in case the first three sorts don't determine things.
 	$c->{sortedUserIDs} = [
 		map { $_->user_id }
-			sort {
-				$primarySortSub->()
+		sort {
+			$primarySortSub->()
 				|| $secondarySortSub->()
 				|| $ternarySortSub->()
 				|| byLastName()
 				|| byFirstName()
 				|| byUserID()
 		}
-			grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
+		grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
 	];
 
 	return;

--- a/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UsersAssignedToSet.pm
@@ -25,7 +25,7 @@ users to which sets are assigned.
 
 use WeBWorK::Debug;
 use WeBWorK::Utils::Instructor qw(assignSetToAllUsers assignSetToGivenUsers);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets       qw(format_set_name_display);
 
 sub initialize ($c) {
 	my $authz = $c->authz;

--- a/lib/WeBWorK/ContentGenerator/LTIAdvanced.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvanced.pm
@@ -20,7 +20,7 @@ use Net::OAuth;
 use UUID::Tiny ':std';
 use Mojo::JSON qw(encode_json);
 
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets             qw(format_set_name_display);
 use WeBWorK::Utils::CourseManagement qw(listCourses);
 use WeBWorK::DB;
 

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -17,15 +17,15 @@ package WeBWorK::ContentGenerator::LTIAdvantage;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
 use Mojo::UserAgent;
-use Mojo::JSON qw(decode_json);
-use Crypt::JWT qw(decode_jwt encode_jwt);
+use Mojo::JSON           qw(decode_json);
+use Crypt::JWT           qw(decode_jwt encode_jwt);
 use Math::Random::Secure qw(irand);
-use Digest::SHA qw(sha256_hex);
+use Digest::SHA          qw(sha256_hex);
 
 use WeBWorK::Debug qw(debug);
 use WeBWorK::Authen::LTIAdvantage::SubmitGrade;
 use WeBWorK::Utils::CourseManagement qw(listCourses);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets             qw(format_set_name_display);
 
 sub initializeRoute ($c, $routeCaptures) {
 	# If this is the login phase of an LTI 1.3 login, then extract the courseID from the target_link_uri.  If this is a

--- a/lib/WeBWorK/ContentGenerator/Login.pm
+++ b/lib/WeBWorK/ContentGenerator/Login.pm
@@ -24,7 +24,7 @@ WeBWorK::ContentGenerator::Login - display a login form.
 
 use WeBWorK::Utils::Files qw(readFile);
 use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets  qw(format_set_name_display);
 
 sub page_title ($c) {
 	# If the url is for a problem page, then the title is the set and problem id.

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -24,7 +24,7 @@ GatewayQuiz proctored tests.
 =cut
 
 use WeBWorK::Utils::Rendering qw(renderPG);
-use WeBWorK::DB::Utils qw(grok_vsetID);
+use WeBWorK::DB::Utils        qw(grok_vsetID);
 
 async sub initialize ($c) {
 	my $ce = $c->ce;

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -24,18 +24,18 @@ WeBWorK::ContentGenerator::Problem - Allow a student to interact with a problem.
 
 use WeBWorK::HTML::SingleProblemGrader;
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(decodeAnswers wwRound);
+use WeBWorK::Utils           qw(decodeAnswers wwRound);
 use WeBWorK::Utils::DateTime qw(before between after);
-use WeBWorK::Utils::Files qw(path_is_subdir);
-use WeBWorK::Utils::JITAR qw(seq_to_jitar_id jitar_id_to_seq is_jitar_problem_hidden is_jitar_problem_closed
+use WeBWorK::Utils::Files    qw(path_is_subdir);
+use WeBWorK::Utils::JITAR    qw(seq_to_jitar_id jitar_id_to_seq is_jitar_problem_hidden is_jitar_problem_closed
 	jitar_problem_finished jitar_problem_adjusted_status);
 use WeBWorK::Utils::LanguageAndDirection qw(get_problem_lang_and_dir);
-use WeBWorK::Utils::ProblemProcessing qw(process_and_log_answer jitar_send_warning_email compute_reduced_score
+use WeBWorK::Utils::ProblemProcessing    qw(process_and_log_answer jitar_send_warning_email compute_reduced_score
 	compute_unreduced_score);
-use WeBWorK::Utils::Rendering qw(getTranslatorDebuggingOptions renderPG);
-use WeBWorK::Utils::Sets qw(is_restricted format_set_name_display);
+use WeBWorK::Utils::Rendering     qw(getTranslatorDebuggingOptions renderPG);
+use WeBWorK::Utils::Sets          qw(is_restricted format_set_name_display);
 use WeBWorK::AchievementEvaluator qw(checkForAchievements);
-use WeBWorK::DB::Utils qw(global2user fake_set fake_problem);
+use WeBWorK::DB::Utils            qw(global2user fake_set fake_problem);
 use WeBWorK::Localize;
 use WeBWorK::AchievementEvaluator;
 

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -24,12 +24,12 @@ problem set.
 =cut
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(wwRound);
-use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Files qw(path_is_subdir);
+use WeBWorK::Utils            qw(wwRound);
+use WeBWorK::Utils::DateTime  qw(after);
+use WeBWorK::Utils::Files     qw(path_is_subdir);
 use WeBWorK::Utils::Rendering qw(renderPG);
-use WeBWorK::Utils::Sets qw(is_restricted grade_set format_set_name_display);
-use WeBWorK::DB::Utils qw(grok_versionID_from_vsetID_sql);
+use WeBWorK::Utils::Sets      qw(is_restricted grade_set format_set_name_display);
+use WeBWorK::DB::Utils        qw(grok_versionID_from_vsetID_sql);
 use WeBWorK::Localize;
 
 async sub initialize ($c) {

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -23,10 +23,10 @@ WeBWorK::ContentGenerator::ProblemSets - Display a list of built problem sets.
 =cut
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(sortByName);
+use WeBWorK::Utils           qw(sortByName);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::Files qw(readFile path_is_subdir);
-use WeBWorK::Utils::Sets qw(is_restricted format_set_name_display);
+use WeBWorK::Utils::Files    qw(readFile path_is_subdir);
+use WeBWorK::Utils::Sets     qw(is_restricted format_set_name_display);
 use WeBWorK::Localize;
 
 # The "default" data in the course_info.txt file.

--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -23,9 +23,9 @@ WeBWorK::ContentGenerator::ShowMeAnother - Show students alternate versions of c
 =cut
 
 use WeBWorK::Debug;
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
+use WeBWorK::Utils::JITAR     qw(jitar_id_to_seq);
 use WeBWorK::Utils::Rendering qw(getTranslatorDebuggingOptions renderPG);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::Sets      qw(format_set_name_display);
 
 async sub pre_header_initialize ($c) {
 	my $ce = $c->ce;

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -97,9 +97,9 @@ use warnings;
 
 use Carp;
 use Data::Dumper;
-use Scalar::Util qw/blessed/;
+use Scalar::Util   qw/blessed/;
 use HTML::Entities qw( encode_entities );
-use Mojo::JSON qw(encode_json decode_json);
+use Mojo::JSON     qw(encode_json decode_json);
 
 use WeBWorK::DB::Schema;
 use WeBWorK::DB::Utils qw/make_vsetID grok_vsetID grok_setID_from_vsetID_sql

--- a/lib/WeBWorK/DB/Schema/NewSQL.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL.pm
@@ -24,7 +24,7 @@ WeBWorK::DB::Schema::NewSQL - base class for SQL access.
 
 use strict;
 use warnings;
-use Carp qw(croak);
+use Carp           qw(croak);
 use WeBWorK::Utils qw/undefstr/;
 
 use constant TABLES => qw(*);

--- a/lib/WeBWorK/Debug.pm
+++ b/lib/WeBWorK/Debug.pm
@@ -20,7 +20,7 @@ use strict;
 use warnings;
 
 use Date::Format;
-use Time::HiRes qw/gettimeofday/;
+use Time::HiRes    qw/gettimeofday/;
 use WeBWorK::Utils qw/undefstr/;
 
 our @EXPORT = qw(debug);

--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -25,12 +25,12 @@ WeBWorK::File::SetDef - utilities for dealing with set definition files.
 use Carp;
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(x);
-use WeBWorK::Utils::DateTime qw(formatDateTime getDefaultSetDueDate parseDateTime timeToSec);
-use WeBWorK::Utils::Files qw(surePathToFile);
+use WeBWorK::Utils             qw(x);
+use WeBWorK::Utils::DateTime   qw(formatDateTime getDefaultSetDueDate parseDateTime timeToSec);
+use WeBWorK::Utils::Files      qw(surePathToFile);
 use WeBWorK::Utils::Instructor qw(assignSetToUser assignSetToAllUsers addProblemToSet);
-use WeBWorK::Utils::JITAR qw(seq_to_jitar_id jitar_id_to_seq);
-use WeBWorK::Utils::Sets qw(format_set_name_display);
+use WeBWorK::Utils::JITAR      qw(seq_to_jitar_id jitar_id_to_seq);
+use WeBWorK::Utils::Sets       qw(format_set_name_display);
 
 our @EXPORT_OK = qw(importSetsFromDef readSetDef exportSetsToDef);
 

--- a/lib/WeBWorK/HTML/ScrollingRecordList.pm
+++ b/lib/WeBWorK/HTML/ScrollingRecordList.pm
@@ -26,7 +26,7 @@ records.
 use Carp;
 
 use WeBWorK::Utils::FormatRecords qw(getFormatsForClass formatRecords);
-use WeBWorK::Utils::SortRecords qw(getSortsForClass sortRecords);
+use WeBWorK::Utils::SortRecords   qw(getSortsForClass sortRecords);
 use WeBWorK::Utils::FilterRecords qw(getFiltersForClass filterRecords);
 
 our @EXPORT_OK = qw(scrollingRecordList);

--- a/lib/WeBWorK/Upload.pm
+++ b/lib/WeBWorK/Upload.pm
@@ -61,7 +61,7 @@ use warnings;
 use Carp qw(croak);
 use Data::UUID;    # this is probably overkill ;)
 use Digest::MD5 qw(md5_hex);
-use File::Copy qw(copy move);
+use File::Copy  qw(copy move);
 
 =head1 STORING UPLOADS
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -19,7 +19,7 @@ use Mojo::Base 'Exporter', -signatures;
 use Email::Sender::Transport::SMTP;
 use Mojo::JSON qw(from_json to_json);
 use Mojo::Util qw(b64_encode b64_decode encode decode);
-use Storable qw(nfreeze thaw);
+use Storable   qw(nfreeze thaw);
 
 our @EXPORT_OK = qw(
 	runtime_use

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -28,8 +28,8 @@ use warnings;
 use Carp;
 use DBI;
 use String::ShellQuote;
-use UUID::Tiny qw(create_uuid_as_string);
-use Mojo::File qw(path);
+use UUID::Tiny            qw(create_uuid_as_string);
+use Mojo::File            qw(path);
 use File::Copy::Recursive qw(dircopy);
 use File::Spec;
 use Archive::Tar;
@@ -37,8 +37,8 @@ use Archive::Tar;
 use WeBWorK::Debug;
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
-use WeBWorK::Utils qw(runtime_use);
-use WeBWorK::Utils::Files qw(surePathToFile);
+use WeBWorK::Utils             qw(runtime_use);
+use WeBWorK::Utils::Files      qw(surePathToFile);
 use WeBWorK::Utils::Instructor qw(assignSetsToUsers);
 
 our @EXPORT_OK = qw(

--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -47,7 +47,7 @@ use warnings;
 
 use Carp;
 
-use WeBWorK::Utils qw(sortByName);
+use WeBWorK::Utils                                          qw(sortByName);
 use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw(FIELD_PROPERTIES);
 
 our @EXPORT_OK = qw(

--- a/lib/WeBWorK/Utils/FormatRecords.pm
+++ b/lib/WeBWorK/Utils/FormatRecords.pm
@@ -55,7 +55,7 @@ use warnings;
 
 use Carp;
 
-use WeBWorK::Utils::Sets qw/format_set_name_display/;
+use WeBWorK::Utils::Sets                                    qw/format_set_name_display/;
 use WeBWorK::ContentGenerator::Instructor::ProblemSetDetail qw/FIELD_PROPERTIES/;
 
 our @EXPORT_OK = qw(

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -29,10 +29,10 @@ use Try::Tiny;
 use Mojo::JSON qw(encode_json decode_json);
 
 use WeBWorK::Debug;
-use WeBWorK::Utils qw(encodeAnswers createEmailSenderTransportSMTP);
-use WeBWorK::Utils::DateTime qw(before after);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq jitar_problem_adjusted_status);
-use WeBWorK::Utils::Logs qw(writeLog writeCourseLog);
+use WeBWorK::Utils                      qw(encodeAnswers createEmailSenderTransportSMTP);
+use WeBWorK::Utils::DateTime            qw(before after);
+use WeBWorK::Utils::JITAR               qw(jitar_id_to_seq jitar_problem_adjusted_status);
+use WeBWorK::Utils::Logs                qw(writeLog writeCourseLog);
 use WeBWorK::Authen::LTI::GradePassback qw(passbackGradeOnSubmit);
 use Caliper::Sensor;
 use Caliper::Entity;

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -23,12 +23,12 @@ WeBWorK::Utils::Rendering - utilities for rendering problems.
 =cut
 
 use Mojo::IOLoop;
-use Mojo::JSON qw(decode_json);
+use Mojo::JSON            qw(decode_json);
 use Data::Structure::Util qw(unbless);
-use Digest::MD5 qw(md5_hex);
-use Encode qw(encode_utf8);
+use Digest::MD5           qw(md5_hex);
+use Encode                qw(encode_utf8);
 
-use WeBWorK::Utils::DateTime qw(formatDateTime);
+use WeBWorK::Utils::DateTime          qw(formatDateTime);
 use WeBWorK::Utils::ProblemProcessing qw(compute_unreduced_score);
 use WeBWorK::PG;
 

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -124,7 +124,7 @@ use strict;
 use warnings;
 
 use WeBWorK::Localize;
-use WeBWorK::Utils qw(x);
+use WeBWorK::Utils       qw(x);
 use WeBWorK::Utils::Sets qw(format_set_name_display);
 
 our @EXPORT_OK = qw(setup_content_generator_routes route_title route_navigation_is_restricted);

--- a/lib/WeBWorK/Utils/Sets.pm
+++ b/lib/WeBWorK/Utils/Sets.pm
@@ -19,9 +19,9 @@ use Mojo::Base 'Exporter', -signatures;
 use Carp;
 
 use PGrandom;
-use WeBWorK::Utils qw(wwRound);
+use WeBWorK::Utils           qw(wwRound);
 use WeBWorK::Utils::DateTime qw(after);
-use WeBWorK::Utils::JITAR qw(jitar_id_to_seq jitar_problem_adjusted_status);
+use WeBWorK::Utils::JITAR    qw(jitar_id_to_seq jitar_problem_adjusted_status);
 
 our @EXPORT_OK = qw(
 	format_set_name_internal

--- a/lib/WeBWorK/Utils/TOTP.pm
+++ b/lib/WeBWorK/Utils/TOTP.pm
@@ -4,8 +4,8 @@ use strict;
 use warnings;
 use utf8;
 
-use Digest::SHA qw(hmac_sha512_hex hmac_sha256_hex hmac_sha1_hex);
-use MIME::Base32 qw(encode_base32);
+use Digest::SHA          qw(hmac_sha512_hex hmac_sha256_hex hmac_sha1_hex);
+use MIME::Base32         qw(encode_base32);
 use Math::Random::Secure qw(irand);
 
 sub new {

--- a/lib/WebworkWebservice/CourseActions.pm
+++ b/lib/WebworkWebservice/CourseActions.pm
@@ -24,11 +24,11 @@ use Date::Format;
 use Data::Structure::Util qw(unbless);
 
 use WeBWorK::DB;
-use WeBWorK::DB::Utils qw(initializeUserProblem);
-use WeBWorK::Utils qw(cryptPassword);
+use WeBWorK::DB::Utils               qw(initializeUserProblem);
+use WeBWorK::Utils                   qw(cryptPassword);
 use WeBWorK::Utils::CourseManagement qw(addCourse);
-use WeBWorK::Utils::Files qw(surePathToFile path_is_subdir);
-use WeBWorK::ConfigValues qw(getConfigValues);
+use WeBWorK::Utils::Files            qw(surePathToFile path_is_subdir);
+use WeBWorK::ConfigValues            qw(getConfigValues);
 use WeBWorK::Debug;
 
 sub createCourse {

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -21,7 +21,7 @@ use warnings;
 
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::PG::Tidy qw(pgtidy);
+use WeBWorK::PG::Tidy          qw(pgtidy);
 use WeBWorK::PG::ConvertToPGML qw(convertToPGML);
 
 sub getUserProblem {

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -25,9 +25,9 @@ use Mojo::Util qw(url_unescape);
 use WeBWorK::Debug;
 use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
-use WeBWorK::DB::Utils qw(global2user fake_set fake_problem);
-use WeBWorK::Utils qw(decode_utf8_base64);
-use WeBWorK::Utils::Files qw(readFile);
+use WeBWorK::DB::Utils        qw(global2user fake_set fake_problem);
+use WeBWorK::Utils            qw(decode_utf8_base64);
+use WeBWorK::Utils::Files     qw(readFile);
 use WeBWorK::Utils::Rendering qw(renderPG);
 
 our $UNIT_TESTS_ON = 0;

--- a/lib/WebworkWebservice/SetActions.pm
+++ b/lib/WebworkWebservice/SetActions.pm
@@ -23,9 +23,9 @@ use Carp;
 use JSON;
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::Utils qw(max);
+use WeBWorK::Utils             qw(max);
 use WeBWorK::Utils::Instructor qw(assignSetToGivenUsers assignMultipleProblemsToGivenUsers);
-use WeBWorK::Utils::JITAR qw(seq_to_jitar_id jitar_id_to_seq);
+use WeBWorK::Utils::JITAR      qw(seq_to_jitar_id jitar_id_to_seq);
 use WeBWorK::Debug;
 use WeBWorK::DB::Utils qw(initializeUserProblem);
 


### PR DESCRIPTION
Note that the `-vxl='q'` option has been removed.  This option disables vertical alignment of qw quotes.  Alignment of qw quotes was added in version 20220613 (the previous version), and this option to disable that was added to the webwork2 (and pg) perltidy configuration to avoid the alignment because it changes so many files. However, I don't think that alignment is bad, and I am tired of adding new options to prevent code changes.  With this newer version another option would be needed to prevent the new signed number alignment (although that affects PG much more than webwork2).

The `bin/dev_scripts/run-perltidy.pl` script now insists on this specific version of perltidy instead of this version or newer.  This is because every time a new version of perltidy comes out, it changes things.  So developers really need to be using the same version or it will not be consistent with the github workflow result.

Also, the version requirement in the check_modules.pl script has been removed.  Only developers need a specific version of perltidy.  Those running webwork2 can use other versions.  This is only used for formatting problems in the PG problem editor, and using other versions may result in slightly different formatting there, but that is not so consequential that we need to require a specific version. Note that this change depends on the corresponding pg pull request (https://github.com/openwebwork/pg/pull/1145), because in that pull request the `-vxl='q'` option has been removed.  Otherwise version 20220613 or newer of perltidy would still be needed.

The first commit makes the changes for the switch to the new version, and the second commit is merely the result of running `perltidy` with the new version and rules.