### PR TITLE
Switch to using the latest Perl::Tidy (version 20240903) alternate approach.

### DIFF
--- a/.github/workflows/check-formats.yml
+++ b/.github/workflows/check-formats.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Install dependencies
-        run: cpanm -n Perl::Tidy@20220613
+        run: cpanm -n Perl::Tidy@20240903
       - name: Run perltidy
         shell: bash
         run: |

--- a/.perltidyrc
+++ b/.perltidyrc
@@ -1,23 +1,24 @@
 # PBP .perltidyrc file
--l=120  # Max line width is 120 cols
--et=4   # Use tabs instead of spaces.
--i=4    # Indent level is 4 cols
--ci=4   # Continuation indent is 4 cols
--b      # Write the file inline and create a .bak file
--vt=0   # Minimal vertical tightness
--cti=0  # No extra indentation for closing brackets
--pt=2   # Maximum parenthesis tightness
--bt=1   # Medium brace tightness
--sbt=1  # Medium square bracket tightness
--bbt=1  # Medium block brace tightness
--nsfs   # No space before semicolons
--nolq   # Don't outdent long quoted strings
--mbl=1  # Do not allow multiple empty lines
--ce     # Cuddled else
--cb     # Cuddled blocks
--nbbc   # Do not add blank lines before full length comments
--nbot   # No line break on ternary
--nlop   # No logical padding (this causes mixed tabs and spaces)
--wn     # Weld nested containers
--xci    # Extended continuation indentation
+-l=120   # Max line width is 120 cols
+-et=4    # Use tabs instead of spaces.
+-i=4     # Indent level is 4 cols
+-ci=4    # Continuation indent is 4 cols
+-b       # Write the file inline and create a .bak file
+-vt=0    # Minimal vertical tightness
+-cti=0   # No extra indentation for closing brackets
+-pt=2    # Maximum parenthesis tightness
+-bt=1    # Medium brace tightness
+-sbt=1   # Medium square bracket tightness
+-bbt=1   # Medium block brace tightness
+-nsfs    # No space before semicolons
+-nolq    # Don't outdent long quoted strings
+-mbl=1   # Do not allow multiple empty lines
+-ce      # Cuddled else
+-cb      # Cuddled blocks
+-nbbc    # Do not add blank lines before full length comments
+-nbot    # No line break on ternary
+-nlop    # No logical padding (this causes mixed tabs and spaces)
+-wn      # Weld nested containers
+-xci     # Extended continuation indentation
 -vxl='q' # No vertical alignment of qw quotes
+-nvsn    # No vertical alignment of signed numbers

--- a/bin/dev_scripts/run-perltidy.pl
+++ b/bin/dev_scripts/run-perltidy.pl
@@ -63,9 +63,8 @@ use Mojo::File qw(curfile);
 
 my $webwork_root = curfile->dirname->dirname->dirname;
 
-die "Version 20220613 or newer of perltidy is required for this script.\n"
-	. "The installed version is $Perl::Tidy::VERSION.\n"
-	unless $Perl::Tidy::VERSION >= 20220613;
+die "Version 20240903 of perltidy is required for this script.\nThe installed version is $Perl::Tidy::VERSION.\n"
+	unless $Perl::Tidy::VERSION == 20240903;
 die "The .perltidyrc file in the webwork root directory is not readable.\n"
 	unless -r "$webwork_root/.perltidyrc";
 

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -265,8 +265,7 @@ sub write_problem_tex {
 				$correctTeX .=
 					"\\item\n\$\\displaystyle "
 					. ($rh_result->{answers}{$_}{correct_ans_latex_string}
-						|| "\\text{$rh_result->{answers}{$_}{correct_ans}}")
-					. "\$\n";
+						|| "\\text{$rh_result->{answers}{$_}{correct_ans}}") . "\$\n";
 			}
 
 			$correctTeX .= "\\end{itemize}}\\par\n";

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -323,8 +323,7 @@ sub authenticate ($self) {
 				"Account creation blocked by block_lti_create_user setting. Did not create user $self->{user_id}.";
 			if ($ce->{debug_lti_parameters}) {
 				warn $c->maketext('Account creation is currently disabled in this course.  '
-						. 'Please speak to your instructor or system administrator.')
-					. "\n";
+						. 'Please speak to your instructor or system administrator.') . "\n";
 			}
 			return 0;
 		} else {

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -1202,7 +1202,7 @@ sub getConfigValues ($ce) {
 			@$configValues,
 			[
 				x('LTI'),
-				map      { $LTIConfigValues->{$_} }
+				map { $LTIConfigValues->{$_} }
 					grep { defined $LTIConfigValues->{$_} } @{ $ce->{LTIConfigVariables} }
 			]
 		);

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -498,7 +498,7 @@ async sub pre_header_initialize ($c) {
 
 	if ($setVersionNumber && !$c->{invalidSet} && $setID ne 'Undefined_Set') {
 		my @setVersionIDs = $db->listSetVersions($effectiveUserID, $setID);
-		my @setVersions   = $db->getSetVersions(map { [ $effectiveUserID, $setID,, $_ ] } @setVersionIDs);
+		my @setVersions   = $db->getSetVersions(map { [ $effectiveUserID, $setID, $_ ] } @setVersionIDs);
 		for (@setVersions) {
 			$totalNumVersions++;
 			$currentNumVersions++

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -1007,8 +1007,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
 			. ($c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) =~
-				s/\x{202f}/ /gr)
-			. "}%\n";
+				s/\x{202f}/ /gr) . "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)
@@ -1181,10 +1180,10 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 				problemID => $MergedProblem->problem_id,
 			),
 			$MergedProblem->problem_id == 0
-				# link for a fake problem (like a header file)
+			# link for a fake problem (like a header file)
 			? (params =>
 					{ sourceFilePath => $MergedProblem->source_file, problemSeed => $MergedProblem->problem_seed })
-				# link for a real problem
+			# link for a real problem
 			: (),
 		);
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -237,15 +237,15 @@ sub pre_header_initialize ($c) {
 	# Always have a definite sort order in case the first three sorts don't determine things.
 	$c->{sortedUserIDs} = [
 		map { $_->user_id }
-			sort {
-				$primarySortSub->()
+		sort {
+			$primarySortSub->()
 				|| $secondarySortSub->()
 				|| $ternarySortSub->()
 				|| byLastName()
 				|| byFirstName()
 				|| byUserID()
 		}
-			grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
+		grep { $c->{visibleUserIDs}{ $_->user_id } } (values %allUsers)
 	];
 
 	return;


### PR DESCRIPTION
A new `--valign-signed-numbers` option has been added in the version of Perl::Tidy and is the default.  That option has been disabled to reduce the number of code changes.  Although it only changes one line of the webwork2 code. It changes a lot more in the pg code.

The `bin/dev_scripts/run-perltidy.pl` script now insists on this specific version of perltidy instead of this version or newer.  This is because every time a new version of perltidy comes out, it changes things.  So developers really need to be using the same version or it will not be consistent with the github workflow result.

Also, the version requirement in the check_modules.pl script has been removed.  Only developers need a specific version of perltidy.  Those running webwork2 can use other versions.  This is only used for formatting problems in the PG problem editor, and using other versions may result in slightly different formatting there, but that is not so consequential that we need to require a specific version. Note that this change depends on the corresponding pg pull request (https://github.com/openwebwork/pg/pull/1146), because in that pull request the `-vxl='q'` option has been removed.  Otherwise version 20220613 or newer of perltidy would still be needed.

The first commit makes the changes for the switch to the new version, and the second commit is merely the result of running `perltidy` with the new version and rules.