### PR TITLE
Fix PGML Emphasis in the PG CodeMirror editor.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
             "license": "GPL-2.0+",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.5.2",
-                "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.20",
+                "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.25",
                 "bootstrap": "~5.3.3",
                 "flatpickr": "^4.6.13",
                 "iframe-resizer": "^4.3.11",
@@ -178,20 +178,20 @@
             }
         },
         "node_modules/@codemirror/lint": {
-            "version": "6.8.2",
-            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.2.tgz",
-            "integrity": "sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==",
+            "version": "6.8.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.3.tgz",
+            "integrity": "sha512-GSGfKxCo867P7EX1k2LoCrjuQFeqVgPGRRsSl4J4c0KMkD+k1y6WYvTQkzv0iZ8JhLJDujEvlnMchv4CZQLh3Q==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0",
+                "@codemirror/view": "^6.35.0",
                 "crelt": "^1.0.5"
             }
         },
         "node_modules/@codemirror/search": {
-            "version": "6.5.7",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.7.tgz",
-            "integrity": "sha512-6+iLsXvITWKHYlkgHPCs/qiX4dNzn8N78YfhOFvPtPYCkuXqZq10rAfsUMhOq7O/1VjJqdXRflyExlfVcu/9VQ==",
+            "version": "6.5.8",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
+            "integrity": "sha512-PoWtZvo7c1XFeZWmmyaOp2G0XVbOnm+fJzvghqGAktBW3cufwJUWvSCcNG0ppXiBEM05mZu6RhMtXPv2hpllig==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -218,9 +218,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.34.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.34.3.tgz",
-            "integrity": "sha512-Ph5d+u8DxIeSgssXEakaakImkzBV4+slwIbcxl9oc9evexJhImeu/G8TK7+zp+IFK9KuJ0BdSn6kTBJeH2CHvA==",
+            "version": "6.35.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.0.tgz",
+            "integrity": "sha512-I0tYy63q5XkaWsJ8QRv5h6ves7kvtrBWjBcnf/bzohFJQc5c14a1AQRdE8QpPF9eMp5Mq2FMm59TCj1gDfE7kw==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.4.0",
@@ -364,9 +364,9 @@
             }
         },
         "node_modules/@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.14",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.14.tgz",
-            "integrity": "sha512-OGFBmoZlH+IbjnEF0b7K9QVXW1MdSYWDV8DpFYK5X5fSF0W+d8xkO3f7IdhkZ3RWrchdUecXNw2wDhgBien5jQ==",
+            "version": "0.0.1-beta.18",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.18.tgz",
+            "integrity": "sha512-HmMq3lRscxGo5BmPFWnrdj13UyKQdj6Rc0iGQjOEAcUwSg3i0/IOjN8OpzEAJ01oEZnOpe+XO4fWr4ZKYwHx7Q==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.10.2",
@@ -375,15 +375,15 @@
             }
         },
         "node_modules/@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.20",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.20.tgz",
-            "integrity": "sha512-l3/R7F3haQR6V9WgeMKNfbnTM7tD38H/8u6fFYgBa3FX16J/Um4X25Y3Ld4YS/zFNFjgV54dmksGBRXuPD8Nsg==",
+            "version": "0.0.1-beta.25",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.25.tgz",
+            "integrity": "sha512-3SajSiabBlRF6tuCfz/angik+Dphl0fQ2olZP+dCe1LK8xVQ4zgcA7RLKZNyUn5NWuqhplwWdHslqVh6E56A4w==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.14",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.18",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.2.1",
                 "cm6-theme-basic-dark": "^0.2.0",
@@ -2266,19 +2266,19 @@
             }
         },
         "@codemirror/lint": {
-            "version": "6.8.2",
-            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.2.tgz",
-            "integrity": "sha512-PDFG5DjHxSEjOXk9TQYYVjZDqlZTFaDBfhQixHnQOEVDDNHUbEh/hstAjcQJaA6FQdZTD1hquXTK0rVBLADR1g==",
+            "version": "6.8.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.3.tgz",
+            "integrity": "sha512-GSGfKxCo867P7EX1k2LoCrjuQFeqVgPGRRsSl4J4c0KMkD+k1y6WYvTQkzv0iZ8JhLJDujEvlnMchv4CZQLh3Q==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0",
+                "@codemirror/view": "^6.35.0",
                 "crelt": "^1.0.5"
             }
         },
         "@codemirror/search": {
-            "version": "6.5.7",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.7.tgz",
-            "integrity": "sha512-6+iLsXvITWKHYlkgHPCs/qiX4dNzn8N78YfhOFvPtPYCkuXqZq10rAfsUMhOq7O/1VjJqdXRflyExlfVcu/9VQ==",
+            "version": "6.5.8",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
+            "integrity": "sha512-PoWtZvo7c1XFeZWmmyaOp2G0XVbOnm+fJzvghqGAktBW3cufwJUWvSCcNG0ppXiBEM05mZu6RhMtXPv2hpllig==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
@@ -2302,9 +2302,9 @@
             }
         },
         "@codemirror/view": {
-            "version": "6.34.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.34.3.tgz",
-            "integrity": "sha512-Ph5d+u8DxIeSgssXEakaakImkzBV4+slwIbcxl9oc9evexJhImeu/G8TK7+zp+IFK9KuJ0BdSn6kTBJeH2CHvA==",
+            "version": "6.35.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.0.tgz",
+            "integrity": "sha512-I0tYy63q5XkaWsJ8QRv5h6ves7kvtrBWjBcnf/bzohFJQc5c14a1AQRdE8QpPF9eMp5Mq2FMm59TCj1gDfE7kw==",
             "requires": {
                 "@codemirror/state": "^6.4.0",
                 "style-mod": "^4.1.0",
@@ -2427,9 +2427,9 @@
             }
         },
         "@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.14",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.14.tgz",
-            "integrity": "sha512-OGFBmoZlH+IbjnEF0b7K9QVXW1MdSYWDV8DpFYK5X5fSF0W+d8xkO3f7IdhkZ3RWrchdUecXNw2wDhgBien5jQ==",
+            "version": "0.0.1-beta.18",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.18.tgz",
+            "integrity": "sha512-HmMq3lRscxGo5BmPFWnrdj13UyKQdj6Rc0iGQjOEAcUwSg3i0/IOjN8OpzEAJ01oEZnOpe+XO4fWr4ZKYwHx7Q==",
             "requires": {
                 "@codemirror/language": "^6.10.2",
                 "@lezer/highlight": "^1.2.1",
@@ -2437,14 +2437,14 @@
             }
         },
         "@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.20",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.20.tgz",
-            "integrity": "sha512-l3/R7F3haQR6V9WgeMKNfbnTM7tD38H/8u6fFYgBa3FX16J/Um4X25Y3Ld4YS/zFNFjgV54dmksGBRXuPD8Nsg==",
+            "version": "0.0.1-beta.25",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.25.tgz",
+            "integrity": "sha512-3SajSiabBlRF6tuCfz/angik+Dphl0fQ2olZP+dCe1LK8xVQ4zgcA7RLKZNyUn5NWuqhplwWdHslqVh6E56A4w==",
             "requires": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.14",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.18",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.2.1",
                 "cm6-theme-basic-dark": "^0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
-        "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.20",
+        "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.25",
         "bootstrap": "~5.3.3",
         "flatpickr": "^4.6.13",
         "iframe-resizer": "^4.3.11",


### PR DESCRIPTION
Really, the fix has been published in an updated pg-codemirror-editor package (actually the bug was in the codemirror-lang-pg package).  This just updates the version in the package.json file.

This was observed by @somiaj in #2595 (see https://github.com/openwebwork/webwork2/pull/2595#issuecomment-2495203173).  It turns out the problem was an error in converting from the Perl `substr` method to the JavaScript `substring` method.  The code actually uses the JavaScript `slice` method now.