### PR TITLE
Fix invalid regex by moving hyphen to last character.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -270,7 +270,7 @@ sub add_course_validate ($c) {
 	for (1 .. $number_of_additional_users) {
 		my $userID = trim_spaces($c->param("add_initial_userID_$_")) || '';
 
-		unless ($userID =~ /^[\w-.,]*$/) {
+		unless ($userID =~ /^[\w.,-]*$/) {
 			push @errors,
 				$c->maketext(
 					'User ID number [_1] may only contain letters, numbers, hyphens, periods, commas, '


### PR DESCRIPTION
Spotted as an error in the recently merged #2619.