### PR TITLE
Remove a local link in the `package-lock.json` file.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -31,49 +31,6 @@
                 "yargs": "^17.7.2"
             }
         },
-        "../../../../home/rice/Projects/Javascript/CodeMirror/pg-codemirror-editor": {
-            "name": "@openwebwork/pg-codemirror-editor",
-            "version": "0.0.1-beta.1",
-            "extraneous": true,
-            "license": "MIT",
-            "dependencies": {
-                "@codemirror/lang-html": "^6.4.9",
-                "@codemirror/lang-xml": "^6.1.0",
-                "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.2",
-                "@replit/codemirror-emacs": "^6.1.0",
-                "@replit/codemirror-vim": "^6.2.1",
-                "cm6-theme-basic-dark": "^0.2.0",
-                "cm6-theme-basic-light": "^0.2.0",
-                "cm6-theme-gruvbox-dark": "^0.2.0",
-                "cm6-theme-gruvbox-light": "^0.2.0",
-                "cm6-theme-material-dark": "^0.2.0",
-                "cm6-theme-nord": "^0.2.0",
-                "cm6-theme-solarized-dark": "^0.2.0",
-                "cm6-theme-solarized-light": "^0.2.0",
-                "codemirror": "^6.0.1",
-                "codemirror-lang-perl": "^0.1.3",
-                "thememirror": "^2.0.1"
-            },
-            "devDependencies": {
-                "@awmottaz/prettier-plugin-void-html": "^1.6.1",
-                "@stylistic/eslint-plugin": "^2.7.2",
-                "css-loader": "^7.1.2",
-                "eslint": "^9.9.1",
-                "eslint-config-prettier": "^9.1.0",
-                "eslint-webpack-plugin": "^4.2.0",
-                "prettier": "^3.3.3",
-                "sass": "^1.78.0",
-                "sass-loader": "^16.0.1",
-                "style-loader": "^4.0.0",
-                "ts-loader": "^9.5.1",
-                "typescript": "^5.5.4",
-                "typescript-eslint": "^8.4.0",
-                "webpack": "^5.94.0",
-                "webpack-cli": "^5.1.4",
-                "webpack-dev-server": "^5.1.0"
-            }
-        },
         "node_modules/@codemirror/autocomplete": {
             "version": "6.18.3",
             "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.3.tgz",


### PR DESCRIPTION
This is a remnant from testing the CodeMirror 6 stuff locally, that seems to have stayed there even after uninstalling the local link. This was never supposed to have been committed.