### PR TITLE
Fix the invalid set "You must use your LMS to access this set" message.

### DIFF
--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -500,11 +500,12 @@ sub checkSet {
 			$ce->{LTI}{ $ce->{LTIVersion} }{LMS_url}
 			? $c->link_to($ce->{LTI}{ $ce->{LTIVersion} }{LMS_name} => $ce->{LTI}{ $ce->{LTIVersion} }{LMS_url})
 			: $ce->{LTI}{ $ce->{LTIVersion} }{LMS_name};
-		return $c->maketext(
+		return $c->b($c->maketext(
 			'You must use your Learning Management System ([_1]) to access this set.  '
 				. 'Try logging in to the Learning Management System and visiting the set from there.',
 			$LMS
-		) unless $set->lis_source_did;
+		))
+			unless $set->lis_source_did;
 	}
 
 	return 0;


### PR DESCRIPTION
This was broken in #2485.  In that pull request line 16 of `templates/ContentGenerator/ProblemSet.html.ep` was changed from `<p class="mb-0"><%== $c->{invalidSet} %></p>` to `<p class="mb-0"><%= $c->{invalidSet} %></p>` which means that the invalid set message is now HTML escaped.  That was necessary as almost all `invalidSet` messages include the set ID taken directly from the URL, and that is a cross-site scripting vulnerability. However, there is one message that does not use the set id from the URL, but does add HTML that needs to not be escaped.  That is the message, `You must use your Learning Management System ([_1]) to access this set. Try logging in to the Learning Management System and visiting the set from there.` where the `[_1]` may be the LMS URL.  That now displays as `You must use your Learning Management System (<a
href="https://myschool.edu/lms/">the LMS</a>) to access this set. Try logging in to the Learning Management System and visiting the set from there.`

`<%=` can certainly not be changed back to `<%==` because of the cross-site scripting vulnerability issue.  However, there is another way to prevent HTML escaping.  That is by using a `Mojo::Bytestream` object. So this message which is the only one that needs to not be HTML escaped (and is safe to do this with) is set in that way via the `b` method of a `Mojolicious::Controller`.