### PR TITLE
Updates to grading tests for other users.

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.js
+++ b/htdocs/js/GatewayQuiz/gateway.js
@@ -158,22 +158,20 @@
 
 		const remainingTime = serverDueTime - browserTime + timeDelta;
 
-		if (!timerDiv.dataset.acting) {
-			if (remainingTime <= 10 - gracePeriod) {
-				if (sessionStorage.getItem('gatewayAlertStatus')) {
-					sessionStorage.removeItem('gatewayAlertStatus');
+		if (!timerDiv.dataset.acting && remainingTime <= 10 - gracePeriod) {
+			if (sessionStorage.getItem('gatewayAlertStatus')) {
+				sessionStorage.removeItem('gatewayAlertStatus');
 
-					// Submit the test if time is expired and near the end of grace period.
-					actuallySubmit = true;
-					submitAnswers.click();
-				}
-			} else {
-				// Set the timer text and check alerts at page load.
-				updateTimer();
-
-				// Start the timer.
-				setInterval(updateTimer, 1000);
+				// Submit the test if time is expired and near the end of grace period.
+				actuallySubmit = true;
+				submitAnswers.click();
 			}
+		} else {
+			// Set the timer text and check alerts at page load.
+			updateTimer();
+
+			// Start the timer.
+			setInterval(updateTimer, 1000);
 		}
 	}
 

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -217,6 +217,7 @@ async sub dispatch ($c) {
 				# current server time during a gateway quiz, and that definitely should not revoke proctor
 				# authorization.
 				delete $c->authen->session->{proctor_authorization_granted};
+				delete $c->authen->session->{acting_proctor};
 			}
 			return 1;
 		} else {

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -96,10 +96,17 @@ sub verify_normal_user {
 	# is 'No', then the verify method will have returned 1, and this never happens.  For an ongoing login session, only
 	# a key with versioned set information is accepted, and that version must match the requested set version.  The set
 	# id will not have a version when opening a new version. For that new proctor credentials are required.
-	if ($self->{login_type} eq 'proctor_login'
-		&& $c->stash('setID') =~ /,v\d+$/
+	if (
+		$self->{login_type} eq 'proctor_login'
 		&& $c->authen->session('proctor_authorization_granted')
-		&& $c->authen->session('proctor_authorization_granted') eq $c->stash('setID'))
+		&& (
+			(
+				$c->stash('setID') =~ /,v\d+$/
+				&& $c->authen->session('proctor_authorization_granted') eq $c->stash('setID')
+			)
+			|| $c->authen->session('acting_proctor')
+		)
+		)
 	{
 		return 1;
 	} else {

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -529,7 +529,14 @@ sub getConfigValues ($ce) {
 				var  => 'permissionLevels{record_answers_when_acting_as_student}',
 				doc  => x('Can submit answers for a student'),
 				doc2 => x(
-					'When acting as a student, this permission level and higher can submit answers for that student.'),
+					'When acting as a student, this permission level and higher can submit answers for that student, '
+						. 'which includes starting and grading test versions.  This permission should only be turned '
+						. 'on temporarily and set back to "nobody" after you are done submitting answers for a '
+						. 'student, as it can interfere with tests.  If you have this permission and are viewing a '
+						. 'test version for a student that is also working on that version, your answers will be '
+						. 'saved for that student when moving between pages, which could reset or change the answers '
+						. 'entered in by the student.'
+				),
 				type => 'permission'
 			},
 			{

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -532,10 +532,10 @@ sub getConfigValues ($ce) {
 					'When acting as a student, this permission level and higher can submit answers for that student, '
 						. 'which includes starting and grading test versions.  This permission should only be turned '
 						. 'on temporarily and set back to "nobody" after you are done submitting answers for a '
-						. 'student, as it can interfere with tests.  If you have this permission and are viewing a '
-						. 'test version for a student that is also working on that version, your answers will be '
-						. 'saved for that student when moving between pages, which could reset or change the answers '
-						. 'entered in by the student.'
+						. 'student.  Leaving this permission on is dangerous, as you could unintentionally submit '
+						. 'answers for a student, which can use up their total number of attempts.  Further, if you '
+						. 'are viewing an open test version, your answers on each page will be saved when you move '
+						. q/between pages, which will overwrite the student's saved answers./
 				),
 				type => 'permission'
 			},

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -233,7 +233,7 @@
 % # Remaining output of test headers.
 % # Display timer or information about elapsed time, output link, and information about any recorded score if not
 % # submitAnswers or checkAnswers.
-% if ($c->{can}{recordAnswersNextTime} || $c->{can}{gradeUnsubmittedTest}) {
+% if ($c->{can}{recordAnswersNextTime} && before($c->{set}->due_date + $ce->{gatewayGracePeriod}, $submitTime)) {
 	% my $timeLeft = $c->{set}->due_date - int($submitTime);    # This is in seconds
 	%
 	% # Print the timer if there is less than 24 hours left.
@@ -657,7 +657,7 @@
 					% && (!$c->{can}{recordAnswersNextTime} || $c->{can}{showProblemGrader})) {
 				<%= submit_button maketext('Check Test'), name => 'checkAnswers', class => 'btn btn-primary mb-1' =%>
 			% }
-			% if ($c->{can}{recordAnswersNextTime} || $c->{can}{gradeUnsubmittedTest}) {
+			% if ($c->{can}{recordAnswersNextTime}) {
 				<%= tag('input',
 					type  => 'submit',
 					name  => 'submitAnswers',

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -68,30 +68,33 @@
 % # If the set or problem is invalid, then show that information and exit.
 % if ($c->{invalidSet}) {
 	<div class="alert alert-danger mb-2">
-		<div class="mb-2">
-			% if ($c->{invalidVersionCreation}) {
-				<%= maketext(
-					'The selected test ([_1]) is not a valid test for [_2] (acted as by [_3]).',
-					$setID, $effectiveUserID, $userID
-				) =%>
-			% } else {
-				<%= maketext(
-					'The selected test ([_1]) is not a valid test for [_2].',
-					$setID, $effectiveUserID
-				) =%>
-			% }
-		</div>
+		% if (!$c->{confirmSubmitForStudent} || $c->{invalidVersionCreation}) {
+			<div class="mb-2">
+				% if ($c->{invalidVersionCreation}) {
+					<%= maketext(
+						'The selected test ([_1]) is not a valid test for [_2] (acted as by [_3]).',
+						$setID, $effectiveUserID, $userID
+					) =%>
+				% } else {
+					<%= maketext(
+						'The selected test ([_1]) is not a valid test for [_2].',
+						$setID, $effectiveUserID
+					) =%>
+				% }
+			</div>
+		% }
 		<div><%= $c->{invalidSet} %></div>
-		% if ($c->{invalidVersionCreation} && $c->{invalidVersionCreation} == 1) {
+		% if ($c->{confirmSubmitForStudent}) {
 			<div class="mt-3">
-				<%= link_to maketext('Create New Test Version') => $c->systemLink(
+				<%= link_to $c->{invalidVersionCreation}
+					? maketext('Create New Test Version') : maketext('View Test Version') => $c->systemLink(
 						url_for,
-						params => { effectiveUser => $effectiveUserID, user => $userID, createnew_ok => 1 }
+						params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
 					),
 					class => 'btn btn-primary'
 				=%>
 				<%= link_to maketext('Cancel') => $c->systemLink(
-						url_for('problem_list', setID => $setID),
+						url_for('problem_list', setID => $setID =~ s/,v\d+$//r),
 						params => { effectiveUser => $effectiveUserID, user => $userID }
 					),
 					class => 'btn btn-primary'
@@ -409,6 +412,10 @@
 		% if ($numProbPerPage && $numPages > 1) {
 			<%= hidden_field newPage => '' =%>
 			<%= hidden_field currentPage => $pageNumber =%>
+		% }
+		% # Keep track that a user has confirmed it is okay to submit for a student.
+		% if (param('submit_for_student_ok')) {
+			<%= hidden_field submit_for_student_ok => 1 =%>
 		% }
 		%
 		% # Set up links between problems and, for multi-page tests, pages.

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -65,42 +65,46 @@
 % my $userID          = param('user');
 % my $effectiveUserID = param('effectiveUser');
 %
-% # If the set or problem is invalid, then show that information and exit.
+% # If the set is invalid, then show that information and exit.
 % if ($c->{invalidSet}) {
 	<div class="alert alert-danger mb-2">
-		% if (!$c->{confirmSubmitForStudent} || $c->{invalidVersionCreation}) {
-			<div class="mb-2">
-				% if ($c->{invalidVersionCreation}) {
-					<%= maketext(
-						'The selected test ([_1]) is not a valid test for [_2] (acted as by [_3]).',
-						$setID, $effectiveUserID, $userID
-					) =%>
-				% } else {
-					<%= maketext(
-						'The selected test ([_1]) is not a valid test for [_2].',
-						$setID, $effectiveUserID
-					) =%>
-				% }
-			</div>
-		% }
+		<div class="mb-2">
+			<%= maketext('The selected test ([_1]) is not a valid test for [_2].', $setID, $effectiveUserID) =%>
+		</div>
 		<div><%= $c->{invalidSet} %></div>
-		% if ($c->{confirmSubmitForStudent}) {
-			<div class="mt-3">
-				<%= link_to $c->{invalidVersionCreation}
-					? maketext('Create New Test Version') : maketext('View Test Version') => $c->systemLink(
-						url_for,
-						params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
-					),
-					class => 'btn btn-primary'
-				=%>
-				<%= link_to maketext('Cancel') => $c->systemLink(
-						url_for('problem_list', setID => $setID =~ s/,v\d+$//r),
-						params => { effectiveUser => $effectiveUserID, user => $userID }
-					),
-					class => 'btn btn-primary'
-				=%>
-			</div>
-		% }
+	</div>
+	% last;
+% }
+% # If user tried to create a test version for another user without correct permissions, show message and exit.
+% if ($c->{actingCreationError}) {
+	<div class="alert alert-danger mb-2">
+		<%= maketext(
+			'You are acting as user [_1] and do not have the permission to create a new test version when acting '
+				. 'as another user.',
+			$effectiveUserID
+		) =%>
+	</div>
+	% last;
+% }
+% # Get confirmation before creating new test version or working on an open test for another user.
+% if ($c->{actingConformation}) {
+	<div class="alert alert-danger mb-2">
+		<div class="mb-2"><%= $c->{actingConformation} =%></div>
+		<div>
+			<%= link_to $c->{actingConformationCreate}
+				? maketext('Create New Test Version') : maketext('View Test Version') => $c->systemLink(
+					url_for,
+					params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
+				),
+				class => 'btn btn-primary'
+			=%>
+			<%= link_to maketext('Cancel') => $c->systemLink(
+					url_for('problem_list', setID => $setID =~ s/,v\d+$//r),
+					params => { effectiveUser => $effectiveUserID, user => $userID }
+				),
+				class => 'btn btn-primary'
+			=%>
+		</div>
 	</div>
 	%
 	% last;

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -87,11 +87,11 @@
 	% last;
 % }
 % # Get confirmation before creating new test version or working on an open test for another user.
-% if ($actingConfirmation) {
+% if (stash->{actingConfirmation}) {
 	<div class="alert alert-danger mb-2">
-		<div class="mb-2"><%= $actingConfirmation =%></div>
+		<div class="mb-2"><%= stash->{actingConfirmation} =%></div>
 		<div>
-			<%= link_to $actingConfirmationButton => $c->systemLink(
+			<%= link_to stash->{actingConfirmationButton} => $c->systemLink(
 					url_for,
 					params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
 				),

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -87,12 +87,11 @@
 	% last;
 % }
 % # Get confirmation before creating new test version or working on an open test for another user.
-% if ($c->{actingConformation}) {
+% if ($actingConfirmation) {
 	<div class="alert alert-danger mb-2">
-		<div class="mb-2"><%= $c->{actingConformation} =%></div>
+		<div class="mb-2"><%= $actingConfirmation =%></div>
 		<div>
-			<%= link_to $c->{actingConformationCreate}
-				? maketext('Create New Test Version') : maketext('View Test Version') => $c->systemLink(
+			<%= link_to $actingConfirmationButton => $c->systemLink(
 					url_for,
 					params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
 				),

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -233,7 +233,7 @@
 % # Remaining output of test headers.
 % # Display timer or information about elapsed time, output link, and information about any recorded score if not
 % # submitAnswers or checkAnswers.
-% if ($c->{can}{recordAnswersNextTime}) {
+% if ($c->{can}{recordAnswersNextTime} || $c->{can}{gradeUnsubmittedTest}) {
 	% my $timeLeft = $c->{set}->due_date - int($submitTime);    # This is in seconds
 	%
 	% # Print the timer if there is less than 24 hours left.
@@ -267,11 +267,13 @@
 		) =%>
 	% }
 	%
-	% if ($timeLeft < 60 && $timeLeft > 0 && !$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')) {
+	% if ($timeLeft < 60 && $timeLeft > 0 && !$c->{can}{gradeUnsubmittedTest}
+			% && !$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')) {
 		<div class="alert alert-danger d-inline-block mb-2 p-1">
 			<strong><%= maketext('You have less than 1 minute to complete this test.') %></strong>
 		</div>
-	% } elsif ($timeLeft <= 0 && !$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')) {
+	% } elsif ($timeLeft <= 0 && !$c->{can}{gradeUnsubmittedTest} &&
+			% !$authz->hasPermissions($userID, 'record_answers_when_acting_as_student')) {
 		<div class="alert alert-danger d-inline-block mb-2 p-1">
 			<strong>
 				<%= maketext('You are out of time!')
@@ -651,11 +653,16 @@
 		%
 		<div class="submit-buttons-container col-12 mb-2">
 			<%= submit_button maketext('Preview Test'), name => 'previewAnswers', class => 'btn btn-primary mb-1' =%>
-			% if ($c->{can}{recordAnswersNextTime}) {
+			% if ($c->{can}{checkAnswersNextTime}
+					% && (!$c->{can}{recordAnswersNextTime} || $c->{can}{showProblemGrader})) {
+				<%= submit_button maketext('Check Test'), name => 'checkAnswers', class => 'btn btn-primary mb-1' =%>
+			% }
+			% if ($c->{can}{recordAnswersNextTime} || $c->{can}{gradeUnsubmittedTest}) {
 				<%= tag('input',
 					type  => 'submit',
 					name  => 'submitAnswers',
-					value => maketext('Grade Test'),
+					value => $effectiveUserID ne $userID
+						? maketext('Grade Test for [_1]', $effectiveUserID) : maketext('Grade Test'),
 					class => 'btn btn-primary mb-1',
 					$c->{set}->attempts_per_version
 					? (
@@ -684,9 +691,6 @@
 						)
 					: ()
 				) =%>
-			% }
-			% if ($c->{can}{checkAnswersNextTime} && !$c->{can}{recordAnswersNextTime}) {
-				<%= submit_button maketext('Check Test'), name => 'checkAnswers', class => 'btn btn-primary mb-1' =%>
 			% }
 		</div>
 		% if ($numProbPerPage && $numPages > 1 && $c->{can}{recordAnswersNextTime}) {


### PR DESCRIPTION
When able to grade a test of another user, change the "Grade Test" button to "Grade Test for UserID" to make it clear the test is being graded for another user.

Show the "Check Test" button along side the "Grade Test" button for instructor who can use the problem grader but also have the permission to submit the past due test.

Allow instructors who can use the problem grader to grade unsubmitted tests for that user without needing the permission to submit test versions or answers for another user. This way if for some reason a student's test doesn't get submitted correctly (such as a user closing their browser without grading the test or after reaching a grade proctor screen), it can still be graded with their saved answers.

Update the timer when acting as another user if it is being shown, just only suppress warnings about running out of time in this case.

Update description of record_answers_when_acting_as_student to state that it can also start and grade test versions. Also include a warning about that permission should be disabled (set back to "nobody") after using it as it can interfere with tests, and should probably only be used temporarily.

Note this is just hopefully a good start to improving being able to grade tests that didn't get submitted and grading tests for other users, there are probably tweaks that need to be made.

I also initially wanted to only allow submitting an unsubmitted testing using a students saved answers, but due to how the GatewayQuiz module works, found this to be difficult to implement (or at least I didn't see an easy way to do that), so for now an instructor could change answers before submitting the unsubmitted test even if they don't have permission to record student answers. I suspect most instructors will just use the students saved answers in this case anyways.