### PR TITLE
When sorting achievements, make level achievements last.

### DIFF
--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -225,15 +225,21 @@ sub sortAchievements (@achievements) {
 	# Next sort by number.
 	@achievements = sort { ($a->number || 0) <=> ($b->number || 0) } @achievements;
 
-	# Finally sort by category.
+	# Finally sort by category. Always place level achievements last.
 	@achievements = sort {
-		if ($a->number && $b->number) {
+		if ($a->{category} eq 'level' && $b->{category} eq 'level') {
+			return 0;
+		} elsif ($a->{category} eq 'level') {
+			return 1;
+		} elsif ($b->{category} eq 'level') {
+			return -1;
+		} elsif ($a->number && $b->number) {
 			return $a->number <=> $b->number;
 		} elsif ($a->{category} eq $b->{category}) {
 			return 0;
-		} elsif ($a->{category} eq 'secret' or $b->{category} eq 'level') {
+		} elsif ($a->{category} eq 'secret') {
 			return -1;
-		} elsif ($a->{category} eq 'level' or $b->{category} eq 'secret') {
+		} elsif ($b->{category} eq 'secret') {
 			return 1;
 		} else {
 			return $a->{category} cmp $b->{category};

--- a/templates/HelpFiles/InstructorAchievementList.html.ep
+++ b/templates/HelpFiles/InstructorAchievementList.html.ep
@@ -24,7 +24,7 @@
 </p>
 <p>
 	<%= maketext('Achievements are evaluated in the order shown below, with the exception of "level" achievements.  '
-		. 'Achievements in the "level" category are evaluated first and control the XP thresholds and rewards '
+		. 'Achievements in the "level" category are evaluated last and control the XP thresholds and rewards '
 		. '(achievement items) for reaching each level. Achievements in the "secret" category are not shown to '
 		. 'students until they earn the achievement, and is used for fun/surprise achievements.') =%>
 </p>

--- a/templates/HelpFiles/InstructorAchievementList.html.ep
+++ b/templates/HelpFiles/InstructorAchievementList.html.ep
@@ -20,7 +20,7 @@
 	<%= maketext('Manage achievements for the course.  The actions allow one to edit, assign, import, export, score, '
 		. 'create, or delete achievements.  The action form is at the top to select the desired action and options to '
 		. 'perform when the submit button is pressed.  Below the action form is the list of all the '
-		. 'achievements, ordered by their achievement "Number".') =%>
+		. 'achievements, ordered by their achievement "Number", with "level" achievements listed last.') =%>
 </p>
 <p>
 	<%= maketext('Achievements are evaluated in the order shown below, with the exception of "level" achievements.  '
@@ -52,7 +52,8 @@
 	</li>
 	<li>
 		<strong><%= maketext('Number:') %></strong>
-		<%= maketext('Sets the order in which achievements are listed and evaluated.') =%>
+		<%= maketext('Sets the order in which achievements are listed and evaluated. Achievements in the "level" '
+			. 'category are always listed and evaluated after all other achievements.') =%>
 	</li>
 	<li>
 		<strong><%= maketext('Enabled:') %></strong>


### PR DESCRIPTION
Level achievements need to be processed last, and currently an instructor can edit achievement numbers which could place some achievements after the level achievements.

Update the sortAchievements utility method to always place level achievements at the end of the list.

This was brought up in the review of #2579.