### PR TITLE
Change the `timestamp` column in the past answer table to `BIGINT`.

### DIFF
--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -32,7 +32,7 @@ BEGIN {
 		set_id         => { type => "VARCHAR(100) NOT NULL", key => 1 },
 		problem_id     => { type => "INT NOT NULL",          key => 1 },
 		source_file    => { type => "TEXT" },
-		timestamp      => { type => "INT" },
+		timestamp      => { type => "BIGINT" },
 		scores         => { type => "TINYTEXT" },
 		answer_string  => { type => "VARCHAR(5012)" },
 		comment_string => { type => "VARCHAR(5012)" },


### PR DESCRIPTION
Currently this column is of `INT` type.  The `INT` type is a 4 bit integer, and so a timestamp stored in this column that is after the year 2038 will not work.  A `BIGINT` is large enough for my lifetime at least (and then another 292 billion years or so).

There is no need to update databases since the INT and BIGINT types are compatible.  However, at some point you will need to make sure that the type of the column in all courses is updated.  You can run the `upgrade-database-to-utf8mb4.pl` script to do this. For example, running `upgrade-database-to-utf8mb4.pl -c courseId` will update the past answer table for the named course.  Perhaps that script should be renamed?  Although it does have special handling for converting the database to utf8mb4, it also generally makes sure that the database columns are the same as specified in the webwork2 schema.  Or perhaps that part of the script should be separated into another script?

This fixes issue #952.