### PR TITLE
Make JITAR disabled problems disabled without javascript.

### DIFF
--- a/htdocs/js/Problem/problem.js
+++ b/htdocs/js/Problem/problem.js
@@ -4,9 +4,4 @@
 		const bsToast = new bootstrap.Toast(toast, { delay: 5000 });
 		bsToast.show();
 	});
-
-	// Prevent problems which are disabled from acting as links
-	$('.problem-list .disabled-problem')
-		.addClass('disabled')
-		.on('click', (e) => e.preventDefault());
 })();

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -797,9 +797,10 @@ sub siblings ($c) {
 			{
 				push(
 					@items,
-					$c->link_to(
-						$c->maketext('Problem [_1]', join('.', @seq)) => '#',
-						class                                         => $class . ' disabled-problem',
+					$c->tag(
+						'a',
+						class => $class . ' disabled',
+						$c->maketext('Problem [_1]', join('.', @seq))
 					)
 				);
 			} else {

--- a/templates/ContentGenerator/ProblemSet/problem_list_row.html.ep
+++ b/templates/ContentGenerator/ProblemSet/problem_list_row.html.ep
@@ -37,7 +37,7 @@
 			% )
 			% {
 				% # If the problem is jitar restricted, then show it greyed out.
-				<span class="<%= $linkClasses %> disabled-problem text-nowrap">
+				<span class="<%= $linkClasses %> text-nowrap">
 					<%= maketext('Problem [_1]', $problemNumber) %>
 				</span>
 			% } else {


### PR DESCRIPTION
There is no reason to use javascript for this.  Just make the links disabled to begin with.  Furthermore, there is no reason to use jQuery for this.  I thought all webwork2 jQuery usage had already been removed, but this was missed.

To test this create a JITAR set with two or more problems (or really two or more nested sets of problems), and set "Restrict Problem Progression" to "Yes".  Assign the set to a student user, and then log in as that student user.  On the problem list page the latter prolems in the set should be grayed out, and clicking on them does nothing (that already works without javascript because these aren't even `a` tags, they are `span` tags).  If you open the first problem, then the latter problems in the prroblems list in the site menu should be grayed out, and clicking on them does nothing. Currently, that uses jQuery javascript to disable those links.  With this pull request, they are just disabled to begin with.