### PR TITLE
Change the default value of `$CookieSecure` to 1.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -981,8 +981,7 @@ $session_management_via = "session_cookie";
 $CookieSameSite = "Lax";
 
 # Set the value of the secure cookie attribute.
-# The default is 0, as 1 will not work without https.
-$CookieSecure = 0;
+$CookieSecure = 1;
 
 # If $useSessionCookie is set to 1, then a "session" cookie will be used. This
 # means that the cookie will be deleted when the browser session ends.

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -595,8 +595,8 @@ $mail{feedbackRecipients}    = [
 #$CookieSameSite = "Lax";
 
 # Set the value of the secure cookie attribute.
-# The default is 0, as 1 will not work without https.
-#$CookieSecure = 1;
+# The default is 1, so if you are serving without https then set this to 0.
+#$CookieSecure = 0;
 
 # If $useSessionCookie is set to 1, then a "session" cookie will be used. This
 # means that the cookie will be deleted when the browser session ends.


### PR DESCRIPTION
There is really no production scenario where this should be anything but 1.  If you are really serving without https, then you can change this. And good luck dealing with your users having to click through the warnings to get to your site.

Note that this just works if you are using `localhost` in development also.  Browsers have a built in exception for `localhost` and consider it secure without actual certificates.

I am tired of seeing forum issues because system administrators forget or don't know to change this.