### PR TITLE
Support for custom permission levels not in the userRoles hash (replacement of #2629)

### DIFF
--- a/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
@@ -51,7 +51,7 @@
 			id => $fieldName . '_id', class => 'form-select form-select-sm w-auto flex-grow-0',
 			'aria-labelledby' => 'permission_header' =%>
 	% } else {
-		<%= maketext((grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0]) %>
+		<%= maketext((grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0] // "PermLevel$value") %>
 	% }
 % } elsif ($properties->{type} eq 'password') {
 	% # Note that this is only called if in editMode.

--- a/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list_field.html.ep
@@ -50,8 +50,10 @@
 		<%= select_field $fieldName => \@values,
 			id => $fieldName . '_id', class => 'form-select form-select-sm w-auto flex-grow-0',
 			'aria-labelledby' => 'permission_header' =%>
+	% } elsif (my $roleName = (grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0]) {
+		<%= maketext($roleName) %>
 	% } else {
-		<%= maketext((grep { $ce->{userRoles}{$_} eq $value } keys %{ $ce->{userRoles} })[0] // "PermLevel$value") %>
+		<%= maketext('Unknown: [_1]', $value) %>
 	% }
 % } elsif ($properties->{type} eq 'password') {
 	% # Note that this is only called if in editMode.


### PR DESCRIPTION
This replaces #2629 and makes the changes requested for that pull request.

Currently an permission level that is not in the userRoles hash causes an exception to be thrown if the accounts manager is loaded.  This shows "Unknown: n" (where n is the unknown level) in that case and no exception is thrown.

The requested change is that the `maketext` call in #2629 was not valid.