### PR TITLE
Switch the problem editor to use the debug format.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -396,7 +396,7 @@
 					sourceFilePath: document.getElementsByName('edit_file_path')[0]?.value,
 					rawProblemSource:
 						webworkConfig?.pgCodeMirror?.source ?? document.getElementById('problemContents')?.value ?? '',
-					outputformat: 'simple',
+					outputformat: 'debug',
 					showAnswerNumbers: 0,
 					// The set id is really only needed by set headers to get the correct dates for the set.
 					set_id: document.getElementsByName('hidden_set_id')[0]?.value ?? 'Unknown Set',


### PR DESCRIPTION
This is as discussed in #2661, #2662 and the developer meeting.  The PG problem editor is switched to the debug format from the simple format. The only difference for the problem editor page is that if there are debug messages they are now shown.  Usually there aren't any such messages, and so there isn't a difference.  But if something is enabled like the MathObject diagnostics cmp flag, then those debug messages are shown.