### PR TITLE
Don't show the "This problem uses the same source file as number N." message for grouping sets.

### DIFF
--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -419,7 +419,7 @@
 					% $prettyID   = join('.', jitar_id_to_seq($prettyID)) if $isJitarSet;
 					% $repeatFile = maketext('This problem uses the same source file as number [_1].', $prettyID);
 				% } else {
-					% $shownYet{$problemFile} = $problemID;
+					% $shownYet{$problemFile} = $problemID unless $problemFile =~ /^group:/;
 					% $repeatFile = '';
 				% }
 				%


### PR DESCRIPTION
This is the message on the problem set detail instructor page that warns of a problem source being used multiple times in the same set.  This message should never be shown for grouping sets.  Grouping sets are allowed to be repeated.

This has bugged me for a long time.