### PR TITLE
Copy set level proctors when adding a course and copying sets.

### DIFF
--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -166,7 +166,7 @@
 		</div>
 	</div>
 	<fieldset class="mb-3">
-		<legend class="fw-bold fs-6">Copy These Components:</legend>
+		<legend class="fw-bold fs-6"><%= maketext('Copy These Components:') %></legend>
 		<div class="form-check">
 			<label class="form-check-label">
 				<%= check_box select_all => 1, class => 'select-all form-check-input',


### PR DESCRIPTION
If sets are copied then everything for that set should be copied.  These set level proctor users belong to the set.

This fixes issue #2652.

Also add a missing `maketext` call in the related template.

Also fix some database list/get usage that I missed when these copy options were implemented.  Never list all database records if you are going to subsequently get all records anyway.  Listing records is the equivalent of calling `SELECT id from table` and getting all records is the equivalent of calling `SELECT * from table`.  Why would you inneficiently first list to get id's and then select everything separately?  Note that you can get always get all records by using the webwork2 db `Where` methods with no where clause.

Note that the copying of sets that is done here is still highly inneficient.  The current approach gets all sets, and then loops through those sets, then gets the problems for that set and loops through those adding one at a time, then gets set locations and loops through adding one of those at a time, and now adds the set level proctor (of which there can be only one).  Instead since all sets are being copyied all sets could be fetched and added at once, then all problems for all sets fetched and added at once, then all set level proctors for all sets fetched and added at once.  However, adding all at once like that takes for effort because there aren't convenience database methods for doing that.  This is now done when assigning sets to multiple users (I helped @taniwallach implement that) and the same could be done here.  Note that for a course with a large number of sets and a lot of problems the current approach is quite slow.