### PR TITLE
Make the Library Browser "Hints", "Solutions", and "Include Contrib" check boxes checked by default.

### DIFF
--- a/templates/ContentGenerator/Instructor/SetMaker/library-include-checks.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/library-include-checks.html.ep
@@ -6,8 +6,10 @@
 		<%= hidden_field includeOPL => 0 =%>
 	</div>
 	<div class="form-check font-sm">
+		% param('includeContrib', 'on') unless defined param('includeContrib');
 		<%= check_box includeContrib => 'on', id => 'includeContrib', class => 'form-check-input' =%>
 		<%= label_for includeContrib => maketext('Include Contrib'), class => 'form-check-label' =%>
+		<%= hidden_field includeContrib => 0 =%>
 	</div>
 % } else {
 	<%= hidden_field includeOPL => 1 =%>

--- a/templates/ContentGenerator/Instructor/SetMaker/view_problems_line.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/view_problems_line.html.ep
@@ -28,14 +28,18 @@
 	<div class="d-inline-block ms-2 mb-2">
 		<div class="form-check form-check-inline ms-2">
 			<label class="form-check-label col-form-label-sm">
+				% param('showHints', 'on') unless defined param('showHints');
 				<%= check_box showHints => 'on', class => 'form-check-input me-1' =%>
 				<%= maketext('Hints') =%>
+				<%= hidden_field showHints => 0 =%>
 			</label>
 		</div>
 		<div class="form-check form-check-inline ms-2">
 			<label class="form-check-label col-form-label-sm">
+				% param('showSolutions', 'on') unless defined param('showSolutions');
 				<%= check_box showSolutions => 'on', class => 'form-check-input me-1' =%>
 				<%= maketext('Solutions') =%>
+				<%= hidden_field showSolutions => 0 =%>
 			</label>
 		</div>
 	</div>


### PR DESCRIPTION
This was requested in #2668 for "Hints" and "Solutions", and in the developer meeting for "Include Contrib".