### PR TITLE
Add the "Grader" header back to the Assignments when the "Grade Problem" link is shown.

### DIFF
--- a/templates/ContentGenerator/ProblemSet/problem_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/problem_list.html.ep
@@ -35,7 +35,8 @@
 						</th>
 						<th><%= maketext('Counts for Parent') %></th>
 					% }
-					% if ($c->{canScoreProblems}) {
+					% if ($authz->hasPermissions(param('user'), 'access_instructor_tools')
+						% && $authz->hasPermissions(param('user'), 'problem_grader')) {
 						<th><%= maketext('Grader') %></th>
 					% }
 				</tr>


### PR DESCRIPTION
I removed the `canScoreProblems` flag in #1884, but forgot to remove the instance that is used for the header of the table.  As such the header row ends up having one less column than the entries of the table for those that have permission to use the problem graders.