### PR TITLE
Switch the feedback emails to HTML.

### DIFF
--- a/templates/ContentGenerator/Feedback.html.ep
+++ b/templates/ContentGenerator/Feedback.html.ep
@@ -1,5 +1,3 @@
-% use Text::Wrap qw(wrap);
-%
 % unless ($authz->hasPermissions(param('user'), 'submit_feedback')) {
 	<p><%= maketext('You are not allowed to send email.') %></p>
 	<p><%= link_to maketext('Cancel E-Mail') => $returnURL %></p>
@@ -15,7 +13,15 @@
 % if (defined param('sendFeedback') && !stash('send_error')) {
 	<p><%= maketext('Your message was sent successfully.') %></p>
 	<p><%= link_to maketext('Return to your work') => $returnURL =%></p>
-	<pre><%= wrap('', '', param('feedback')) =%></pre>
+	<div class="border border-dark rounded mb-1 p-3">
+		% for (split /\n\r?/, param('feedback')) {
+			% if ($_) {
+				<p class="m-0" style="white-space: pre-wrap;"><%= $_ %></p>
+			% } else {
+				<div class="mt-3"></div>
+			% }
+		% }
+	</div>
 % } else {
 	<%= form_for current_route, method => 'POST', enctype => 'multipart/form-data', begin =%>
 		<%= $c->hidden_authen_fields =%>

--- a/templates/ContentGenerator/Feedback/feedback_email.html.ep
+++ b/templates/ContentGenerator/Feedback/feedback_email.html.ep
@@ -101,7 +101,7 @@
 					<tr><th>Section:</th><td><%= $user->section %></td></tr>
 					<tr><th>Recitation:</th><td><%= $user->recitation %></td></tr>
 					<tr><th>Comment:</th><td><%= $user->comment %></td></tr>
-					<tr><th>IP Address:</th><td><%= $remote_host %>:<%= $c->tx->remote_port || 'UNKNOWN' %></td></tr>
+					<tr><th>IP Address:</th><td><%= $remote_host %>:<%= $remote_port %></td></tr>
 				</tbody>
 			</table>
 		% }

--- a/templates/ContentGenerator/Feedback/feedback_email.html.ep
+++ b/templates/ContentGenerator/Feedback/feedback_email.html.ep
@@ -1,0 +1,186 @@
+% use WeBWorK::Utils qw(decodeAnswers);
+%
+<html>
+	<head>
+		<%= stylesheet begin =%>
+			.data-table td, .data-table th {
+				text-align: left;
+				padding: 0.25rem;
+			}
+			.data-table.bordered {
+				border-collapse: collapse;
+			}
+			.data-table.bordered > * > tr > td, .data-table.bordered > * > tr > th {
+				border: 1px solid black;
+			}
+			.data-table.bordered thead tr:first-child th {
+				border-bottom-width: 2px;
+			}
+			.mb-1 {
+				margin-bottom: 1rem
+			}
+			.user-message {
+				border: 1px solid black;
+				border-radius: 0.375rem;
+				padding: 1rem;
+			}
+			.user-message-line {
+				margin: 0;
+				white-space: pre-wrap;
+			}
+		<% end =%>
+	</head>
+	<body>
+		<p>
+			Message from <%= $user->full_name %> (<%= $user->user_id %>) via WeBWorK at <%= url_for('root')->to_abs %>
+		</p>
+		<p>
+			To visit the page from which <%= $user->first_name %> sent feedback,
+		   	<%= link_to 'click here' => $emailableURL %>.
+		</p>
+		% if ($feedback) {
+			<p><%= $user->full_name %> (<%= $user->user_id %>) wrote:</p>
+			<div class="user-message mb-1">
+				% for (split /\n\r?/, $feedback) {
+					% if ($_) {
+						<p class="user-message-line"><%= $_ %></p>
+					% } else {
+						<div style="margin-top: 1em"></div>
+					% }
+				% }
+			</div>
+		% }
+		% if ($problem && $verbosity >= 1) {
+			<table class="data-table bordered mb-1">
+				<thead>
+					<tr><th colspan="2">Data about the problem processor</th></tr>
+				</thead>
+				<tbody>
+					<tr>
+						<th>Display Mode:</th>
+						<td><%= param('displayMode') %></td>
+					</tr>
+					<tr>
+						<th>Show Old Answers:</th>
+						<td><%= param('showOldAnswers') ? 'yes' : 'no' %></td>
+					</tr>
+					<tr>
+						<th>Show Correct Answers:</th>
+						<td><%= param('showCorrectAnswers') ? 'yes' : 'no' %></td>
+					</tr>
+					<tr>
+						<th>Show Hints:</th>
+						<td><%= param('showHints') ? 'yes' : 'no' %></td>
+					</tr>
+					<tr>
+						<th>Show Solutions:</th>
+						<td><%= param('showSolutions') ? 'yes' : 'no' %></td>
+					</tr>
+				</tbody>
+			</table>
+		% }
+		%
+		% if ($user && $verbosity >= 1) {
+			<table class="data-table bordered mb-1">
+				<thead>
+					<tr><th colspan="2">Data about the user</th></tr>
+				</thead>
+				<tbody>
+					<tr><th>User ID:</th><td><%= $user->user_id %></td></tr>
+					<tr><th>Name:</th><td><%= $user->full_name %></td></tr>
+					<tr><th>Email:</th><td><%= $user->email_address %></td></tr>
+					% unless ($ce->{blockStudentIDinFeedback}) {
+						<tr><th>Student ID:</th><td><%= $user->student_id %></td></tr>
+					% }
+					% my $status_name = $ce->status_abbrev_to_name($user->status);
+					%my $status_string =
+						% defined $status_name
+						% ? "$status_name ('" . $user->status . q{')}
+						% : $user->status . ' (unknown status abbreviation)';
+					<tr><th>Status:</th><td><%= $status_string %></td></tr>
+					<tr><th>Section:</th><td><%= $user->section %></td></tr>
+					<tr><th>Recitation:</th><td><%= $user->recitation %></td></tr>
+					<tr><th>Comment:</th><td><%= $user->comment %></td></tr>
+					<tr><th>IP Address:</th><td><%= $remote_host %>:<%= $c->tx->remote_port || 'UNKNOWN' %></td></tr>
+				</tbody>
+			</table>
+		% }
+		% if ($problem && $verbosity >= 1) {
+			<table class="data-table bordered mb-1">
+				<thead>
+					<tr><th colspan="2">Data about the problem</th></tr>
+				</thead>
+				<tbody>
+					<tr><th>Problem ID:</th><td><%= $problem->problem_id %></td></tr>
+					<tr><th>Source file:</th><td><%= $problem->source_file %></td></tr>
+					<tr><th>Value:</th><td><%= $problem->value %></td></tr>
+					<tr>
+						<th>Max attempts</th>
+						<td><%= $problem->max_attempts == -1 ? 'unlimited' : $problem->max_attempts %></td>
+					</tr>
+					<tr><th>Random seed:</th><td><%= $problem->problem_seed %></td></tr>
+					<tr><th>Status:</th><td><%= $problem->status %></td></tr>
+					<tr><th>Attempted:</th><td><%= $problem->attempted ? 'yes' : 'no' %></td></tr>
+					% my %last_answer = decodeAnswers($problem->last_answer);
+					<tr>
+						<th>Last answer:</th>
+						% if (%last_answer) {
+							<td>
+								<table class="data-table">
+									% for my $key (sort keys %last_answer) {
+										% if ($last_answer{$key}) {
+											<tr><td><%= $key %>:</td><td><%= $last_answer{$key} %></td></tr>
+										% }
+									% }
+								</table>
+							</td>
+						% } else {
+							<td>none</td>
+						% }
+					</tr>
+					<tr><th>Number of correct attempts:</th><td><%= $problem->num_correct %></td></tr>
+					<tr><th>Number of incorrect attempts:</th><td><%= $problem->num_incorrect %></td></tr>
+				</tbody>
+			</table>
+		% }
+		% if ($set && $verbosity >= 1) {
+			<table class="data-table bordered mb-1">
+				<thead>
+					<tr><th colspan="2">Data about the homework set</th></tr>
+				</thead>
+				<tbody>
+					<tr><th>Set ID:</th><td><%= $set->set_id %></td></tr>
+					<tr><th>Set header file:</th><td><%= $set->set_header %></td></tr>
+					<tr><th>Hardcopy header file:</th><td><%= $set->hardcopy_header %></td></tr>
+					<tr><th>Open date:</th><td><%= $c->formatDateTime($set->open_date) %></td></tr>
+					<tr><th>Due date:</th><td><%= $c->formatDateTime($set->due_date) %></td></tr>
+					<tr><th>Answer date:</th><td><%= $c->formatDateTime($set->answer_date) %></td></tr>
+					<tr><th>Visible:</th><td><%= $set->visible ? 'yes' : 'no' %></td></tr>
+					<tr><th>Assignment type:</th><td><%= $set->assignment_type %></td></tr>
+					% if ($set->assignment_type =~ /gateway/) {
+						<tr><th>Attempts per version:</th><td><%= $set->assignment_type %></td></tr>
+						<tr><th>Time interval:</th><td><%= $set->time_interval %></td></tr>
+						<tr><th>Versions per interval:</th><td><%= $set->versions_per_interval %></td></tr>
+						<tr><th>Version time limit:</th><td><%= $set->version_time_limit %></td></tr>
+						<tr>
+							<th>Version creation time:</th>
+							<td><%= $c->formatDateTime($set->version_creation_time) %></td>
+						</tr>
+						<tr><th>Problem randorder:</th><td><%= $set->problem_randorder %></td></tr>
+						<tr><th>Version last attempt time:</th><td><%= $set->version_last_attempt_time %></td></tr>
+					% }
+				</tbody>
+			</table>
+		% }
+		% if ($verbosity >= 2) {
+			<table class="data-table bordered">
+				<thead>
+					<tr><th colspan="2">Data about the environment</th></tr>
+				</thead>
+				<tbody>
+					<tr><td><pre><%= dumper($ce) %></pre></td></tr>
+				</tbody>
+			</table>
+		% }
+	</body>
+</html>

--- a/templates/ContentGenerator/Feedback/feedback_email.html.ep
+++ b/templates/ContentGenerator/Feedback/feedback_email.html.ep
@@ -35,8 +35,7 @@
 			Message from <%= $user->full_name %> (<%= $user->user_id %>) via WeBWorK at <%= url_for('root')->to_abs %>
 		</p>
 		<p>
-			To visit the page from which <%= $user->first_name %> sent feedback,
-		   	<%= link_to 'click here' => $emailableURL %>.
+			<%= $user->first_name %> sent feedback from <%= link_to 'this page' => $emailableURL %>.
 		</p>
 		% if ($feedback) {
 			<p><%= $user->full_name %> (<%= $user->user_id %>) wrote:</p>

--- a/templates/ContentGenerator/Feedback/feedback_email.txt.ep
+++ b/templates/ContentGenerator/Feedback/feedback_email.txt.ep
@@ -1,0 +1,99 @@
+% use WeBWorK::Utils qw(decodeAnswers);
+%
+Message from <%== $user->full_name %> (<%== $user->user_id %>) via WeBWorK at
+<%== url_for('root')->to_abs %>
+
+To visit the page from which <%== $user->first_name %> sent feedback, go to:
+<%== $emailableURL %>
+
+% if ($feedback) {
+<%== $user->full_name %> (<%== $user->user_id %>) wrote:
+
+
+<%== $feedback %>
+
+% }
+% if ($problem && $verbosity >= 1) {
+
+***** Data about the problem processor: *****
+
+Display Mode:         <%== param('displayMode') %>
+Show Old Answers:     <%== param('showOldAnswers') ? 'yes' : 'no' %>
+Show Correct Answers: <%== param('showCorrectAnswers') ? 'yes' : 'no' %>
+Show Hints:           <%== param('showHints') ? 'yes' : 'no' %>
+Show Solutions:       <%== param('showSolutions') ? 'yes' : 'no' %>
+% }
+% if ($user && $verbosity >= 1) {
+
+***** Data about the user: *****
+
+User ID:    <%== $user->user_id %>
+Name:       <%== $user->full_name %>
+Email:      <%== $user->email_address %>
+	% unless ($ce->{blockStudentIDinFeedback}) {
+Student ID: <%== $user->student_id %>
+	% }
+% my $status_name = $ce->status_abbrev_to_name($user->status);
+	%my $status_string =
+		% defined $status_name
+			% ? "$status_name ('" . $user->status . q{')}
+			% : $user->status . ' (unknown status abbreviation)';
+Status:     <%== $status_string %>
+Section:    <%== $user->section %>
+Recitation: <%== $user->recitation %>
+Comment:    <%== $user->comment %>
+IP Address: <%== $remote_host %>:<%== $c->tx->remote_port || 'UNKNOWN' %>
+% }
+% if ($problem && $verbosity >= 1) {
+
+***** Data about the problem: *****
+
+Problem ID:                   <%== $problem->problem_id %>
+Source file:                  <%== $problem->source_file %>
+Value:                        <%== $problem->value %>
+Max attempts                  <%== $problem->max_attempts == -1 ? 'unlimited' : $problem->max_attempts %>
+Random seed:                  <%== $problem->problem_seed %>
+Status:                       <%== $problem->status %>
+Attempted:                    <%== $problem->attempted ? 'yes' : 'no' %>
+	% my %last_answer = decodeAnswers($problem->last_answer);
+	% if (%last_answer) {
+Last answer:
+	% for my $key (sort keys %last_answer) {
+		% if ($last_answer{$key}) {
+	<%== $key %>: <%== $last_answer{$key} %>
+		% }
+	% }
+	% } else {
+Last answer:                  none
+	% }
+Number of correct attempts:   <%== $problem->num_correct %>
+Number of incorrect attempts: <%== $problem->num_incorrect %>
+% }
+% if ($set && $verbosity >= 1) {
+
+***** Data about the homework set: *****
+
+Set ID:                    <%== $set->set_id %>
+Set header file:           <%== $set->set_header %>
+Hardcopy header file:      <%== $set->hardcopy_header %>
+Open date:                 <%== $c->formatDateTime($set->open_date) %>
+Due date:                  <%== $c->formatDateTime($set->due_date) %>
+Answer date:               <%== $c->formatDateTime($set->answer_date) %>
+Visible:                   <%== $set->visible ? 'yes' : 'no' %>
+Assignment type:           <%== $set->assignment_type %>
+	% if ($set->assignment_type =~ /gateway/) {
+Attempts per version:      <%== $set->assignment_type %>
+Time interval:             <%== $set->time_interval %>
+Versions per interval:     <%== $set->versions_per_interval %>
+Version time limit:        <%== $set->version_time_limit %>
+Version creation time:     <%== $c->formatDateTime($set->version_creation_time) %>
+Problem randorder:         <%== $set->problem_randorder %>
+Version last attempt time: <%== $set->version_last_attempt_time %>
+	% }
+% }
+% if ($verbosity >= 2) {
+
+Data about the environment
+
+<%== dumper($ce) %>
+% }


### PR DESCRIPTION
The email content is generated by the `templates/ContentGenerator/Feedback/feedback_email.html.ep` template. All of the same content is there, just arranged nicely into tables and such. The link to the page the user sent the email from is of course an `a href`.  For now it reads "To visit the page from which (user name) sent feedback, click here." where "click here" is the link. Note that it used to read "To visit the page from which the user sent feedback, long link."  We have the user name so why not use it here?

Also, when the sent message is displayed for the user in the browser, the message is formated much the same as it now is in the email.  That is it is not wrapped and placed in a `pre` tag.  Instead it is in a bordered `div` formatted with essentially the same style as in the email.

Here is a screen shot of the email with the default verbosity of 1.  At least what I could fit in.  Below what is show are the tables for "Data about the problem" and "Data about the homework set".  They look much the same as the tables shown.
![feedback-email](https://github.com/user-attachments/assets/d6ed6197-c799-4708-9caa-283531ed7b66)

I would like to reorder the tables.  I would like to have "Data about the problem" first (assuming the email is sent from a problem page) since that is the information that is most useful in the case that a user is asking about a problem.  Then "Data about the homework set" next.  Then "Data about the user".  The user data is almost all shown above in the other content or the subject anyway, so it doesn't need to be so high.  Then the "Data about the problem processor" last.  I generally consider that information mostly useless.  It definitely should not be at the top, and I would even vote for not even including it in the default verbosity.
