### PR TITLE
Catch network errors that result from a keyset URL not working properly.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -323,7 +323,11 @@ sub get_lms_public_keyset ($c, $ce, $db, $renew = 0) {
 	}
 
 	# Get public keyset from the LMS.
-	my $response = Mojo::UserAgent->new->get($ce->{LTI}{v1p3}{PublicKeysetURL})->result;
+	my $response = eval { Mojo::UserAgent->new->get($ce->{LTI}{v1p3}{PublicKeysetURL})->result };
+	if ($@) {
+		$c->stash->{LTIAuthenError} = "Failed to obtain public key from LMS due to a network error: $@";
+		return;
+	}
 	unless ($response->is_success) {
 		$c->stash->{LTIAuthenError} = 'Failed to obtain public key from LMS: ' . $response->message;
 		return;


### PR DESCRIPTION
This should fix #2663.