### PR TITLE
Update the pg-codemirror-editor to pull in a bugfix.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
             "license": "GPL-2.0+",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.5.2",
-                "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.28",
+                "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.29",
                 "bootstrap": "~5.3.3",
                 "flatpickr": "^4.6.13",
                 "iframe-resizer": "^4.3.11",
@@ -32,27 +32,21 @@
             }
         },
         "node_modules/@codemirror/autocomplete": {
-            "version": "6.18.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.3.tgz",
-            "integrity": "sha512-1dNIOmiM0z4BIBwxmxEfA1yoxh1MF/6KPBbh20a5vphGV0ictKlgQsbJs6D6SkR6iJpGbpwRsa6PFMNlg9T9pQ==",
+            "version": "6.18.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+            "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.17.0",
                 "@lezer/common": "^1.0.0"
-            },
-            "peerDependencies": {
-                "@codemirror/language": "^6.0.0",
-                "@codemirror/state": "^6.0.0",
-                "@codemirror/view": "^6.0.0",
-                "@lezer/common": "^1.0.0"
             }
         },
         "node_modules/@codemirror/commands": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.7.1.tgz",
-            "integrity": "sha512-llTrboQYw5H4THfhN4U3qCnSZ1SOJ60ohhz+SzU0ADGtwlc533DtklQP0vSFaQuCPDn3BPpOd1GbbnUtwNjsrw==",
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
+            "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.0.0",
@@ -92,9 +86,9 @@
             }
         },
         "node_modules/@codemirror/lang-javascript": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
-            "integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
+            "integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.0.0",
@@ -121,9 +115,9 @@
             }
         },
         "node_modules/@codemirror/language": {
-            "version": "6.10.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.6.tgz",
-            "integrity": "sha512-KrsbdCnxEztLVbB5PycWXFxas4EOyk/fPAfruSOnDDppevQgid2XZ+KbJ9u+fDikP/e7MW7HPBTvTb8JlZK9vA==",
+            "version": "6.10.8",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
+            "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -146,9 +140,9 @@
             }
         },
         "node_modules/@codemirror/search": {
-            "version": "6.5.8",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
-            "integrity": "sha512-PoWtZvo7c1XFeZWmmyaOp2G0XVbOnm+fJzvghqGAktBW3cufwJUWvSCcNG0ppXiBEM05mZu6RhMtXPv2hpllig==",
+            "version": "6.5.10",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
+            "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -157,9 +151,9 @@
             }
         },
         "node_modules/@codemirror/state": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-            "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+            "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
             "license": "MIT",
             "dependencies": {
                 "@marijn/find-cluster-break": "^1.0.0"
@@ -178,9 +172,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.35.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.3.tgz",
-            "integrity": "sha512-ScY7L8+EGdPl4QtoBiOzE4FELp7JmNUsBvgBcCakXWM2uiv/K89VAzU3BMDscf0DsACLvTKePbd5+cFDTcei6g==",
+            "version": "6.36.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
+            "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
@@ -262,9 +256,9 @@
             "license": "MIT"
         },
         "node_modules/@lezer/css": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.9.tgz",
-            "integrity": "sha512-TYwgljcDv+YrV0MZFFvYFQHCfGgbPMR6nuqLabBdmZoFH3EP1gvw8t0vae326Ne3PszQkbXfVBjCnf3ZVCr0bA==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.10.tgz",
+            "integrity": "sha512-V5/89eDapjeAkWPBpWEfQjZ1Hag3aYUUJOL8213X0dFRuXJ4BXa5NKl9USzOnaLod4AOpmVCkduir2oKwZYZtg==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.2.0",
@@ -313,9 +307,9 @@
             }
         },
         "node_modules/@lezer/xml": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.5.tgz",
-            "integrity": "sha512-VFouqOzmUWfIg+tfmpcdV33ewtK+NSwd4ngSe1aG7HFb4BN0ExyY1b8msp+ndFrnlG4V4iC8yXacjFtrwERnaw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+            "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.2.0",
@@ -330,9 +324,9 @@
             "license": "MIT"
         },
         "node_modules/@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.20",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.20.tgz",
-            "integrity": "sha512-X4eXaSyyby9fYKz5iGJIB44xqXDYa5/uEWUsSMHUvczB0a/+XtU2BzE5lGfPZPVyUCSXPwLyB0aWdLS3dfQdDg==",
+            "version": "0.0.1-beta.21",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.21.tgz",
+            "integrity": "sha512-ERKpLNa/hOmzlCjBQsbQ5XWEUdoI3hyuByhtqPCeTL3gHCM4MTh431EXm89lwF3xK4CBORfEjD84+vEJMhHz7Q==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.10.2",
@@ -341,15 +335,15 @@
             }
         },
         "node_modules/@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.28",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.28.tgz",
-            "integrity": "sha512-1u7rqJLfzpsBBQKJol0dsdlPcClZJjG4pfCGBc+fhLonD5fA8XBxGvVhm5PytegSkGBJHDDXhtQR65DGev/GuQ==",
+            "version": "0.0.1-beta.29",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.29.tgz",
+            "integrity": "sha512-BEM3hX4g2b5WLtZwM/E+ZSPams7G9v2mDxLsj6iWbXt9RPfh9IgXPAp6ZFHnNVHd416pTMt9IoEioPdYvZVakg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.20",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.21",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.2.1",
                 "cm6-theme-basic-dark": "^0.2.0",
@@ -2145,9 +2139,9 @@
     },
     "dependencies": {
         "@codemirror/autocomplete": {
-            "version": "6.18.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.3.tgz",
-            "integrity": "sha512-1dNIOmiM0z4BIBwxmxEfA1yoxh1MF/6KPBbh20a5vphGV0ictKlgQsbJs6D6SkR6iJpGbpwRsa6PFMNlg9T9pQ==",
+            "version": "6.18.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
+            "integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
@@ -2156,9 +2150,9 @@
             }
         },
         "@codemirror/commands": {
-            "version": "6.7.1",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.7.1.tgz",
-            "integrity": "sha512-llTrboQYw5H4THfhN4U3qCnSZ1SOJ60ohhz+SzU0ADGtwlc533DtklQP0vSFaQuCPDn3BPpOd1GbbnUtwNjsrw==",
+            "version": "6.8.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
+            "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.4.0",
@@ -2195,9 +2189,9 @@
             }
         },
         "@codemirror/lang-javascript": {
-            "version": "6.2.2",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.2.tgz",
-            "integrity": "sha512-VGQfY+FCc285AhWuwjYxQyUQcYurWlxdKYT4bqwr3Twnd5wP5WSeu52t4tvvuWmljT4EmgEgZCqSieokhtY8hg==",
+            "version": "6.2.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
+            "integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
             "requires": {
                 "@codemirror/autocomplete": "^6.0.0",
                 "@codemirror/language": "^6.6.0",
@@ -2222,9 +2216,9 @@
             }
         },
         "@codemirror/language": {
-            "version": "6.10.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.6.tgz",
-            "integrity": "sha512-KrsbdCnxEztLVbB5PycWXFxas4EOyk/fPAfruSOnDDppevQgid2XZ+KbJ9u+fDikP/e7MW7HPBTvTb8JlZK9vA==",
+            "version": "6.10.8",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
+            "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.23.0",
@@ -2245,9 +2239,9 @@
             }
         },
         "@codemirror/search": {
-            "version": "6.5.8",
-            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.8.tgz",
-            "integrity": "sha512-PoWtZvo7c1XFeZWmmyaOp2G0XVbOnm+fJzvghqGAktBW3cufwJUWvSCcNG0ppXiBEM05mZu6RhMtXPv2hpllig==",
+            "version": "6.5.10",
+            "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
+            "integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
@@ -2255,9 +2249,9 @@
             }
         },
         "@codemirror/state": {
-            "version": "6.5.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.0.tgz",
-            "integrity": "sha512-MwBHVK60IiIHDcoMet78lxt6iw5gJOGSbNbOIVBHWVXIH4/Nq1+GQgLLGgI1KlnN86WDXsPudVaqYHKBIx7Eyw==",
+            "version": "6.5.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
+            "integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
             "requires": {
                 "@marijn/find-cluster-break": "^1.0.0"
             }
@@ -2274,9 +2268,9 @@
             }
         },
         "@codemirror/view": {
-            "version": "6.35.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.35.3.tgz",
-            "integrity": "sha512-ScY7L8+EGdPl4QtoBiOzE4FELp7JmNUsBvgBcCakXWM2uiv/K89VAzU3BMDscf0DsACLvTKePbd5+cFDTcei6g==",
+            "version": "6.36.3",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
+            "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
             "requires": {
                 "@codemirror/state": "^6.5.0",
                 "style-mod": "^4.1.0",
@@ -2343,9 +2337,9 @@
             "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
         },
         "@lezer/css": {
-            "version": "1.1.9",
-            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.9.tgz",
-            "integrity": "sha512-TYwgljcDv+YrV0MZFFvYFQHCfGgbPMR6nuqLabBdmZoFH3EP1gvw8t0vae326Ne3PszQkbXfVBjCnf3ZVCr0bA==",
+            "version": "1.1.10",
+            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.10.tgz",
+            "integrity": "sha512-V5/89eDapjeAkWPBpWEfQjZ1Hag3aYUUJOL8213X0dFRuXJ4BXa5NKl9USzOnaLod4AOpmVCkduir2oKwZYZtg==",
             "requires": {
                 "@lezer/common": "^1.2.0",
                 "@lezer/highlight": "^1.0.0",
@@ -2389,9 +2383,9 @@
             }
         },
         "@lezer/xml": {
-            "version": "1.0.5",
-            "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.5.tgz",
-            "integrity": "sha512-VFouqOzmUWfIg+tfmpcdV33ewtK+NSwd4ngSe1aG7HFb4BN0ExyY1b8msp+ndFrnlG4V4iC8yXacjFtrwERnaw==",
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@lezer/xml/-/xml-1.0.6.tgz",
+            "integrity": "sha512-CdDwirL0OEaStFue/66ZmFSeppuL6Dwjlk8qk153mSQwiSH/Dlri4GNymrNWnUmPl2Um7QfV1FO9KFUyX3Twww==",
             "requires": {
                 "@lezer/common": "^1.2.0",
                 "@lezer/highlight": "^1.0.0",
@@ -2404,9 +2398,9 @@
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
         },
         "@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.20",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.20.tgz",
-            "integrity": "sha512-X4eXaSyyby9fYKz5iGJIB44xqXDYa5/uEWUsSMHUvczB0a/+XtU2BzE5lGfPZPVyUCSXPwLyB0aWdLS3dfQdDg==",
+            "version": "0.0.1-beta.21",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.21.tgz",
+            "integrity": "sha512-ERKpLNa/hOmzlCjBQsbQ5XWEUdoI3hyuByhtqPCeTL3gHCM4MTh431EXm89lwF3xK4CBORfEjD84+vEJMhHz7Q==",
             "requires": {
                 "@codemirror/language": "^6.10.2",
                 "@lezer/highlight": "^1.2.1",
@@ -2414,14 +2408,14 @@
             }
         },
         "@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.28",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.28.tgz",
-            "integrity": "sha512-1u7rqJLfzpsBBQKJol0dsdlPcClZJjG4pfCGBc+fhLonD5fA8XBxGvVhm5PytegSkGBJHDDXhtQR65DGev/GuQ==",
+            "version": "0.0.1-beta.29",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.29.tgz",
+            "integrity": "sha512-BEM3hX4g2b5WLtZwM/E+ZSPams7G9v2mDxLsj6iWbXt9RPfh9IgXPAp6ZFHnNVHd416pTMt9IoEioPdYvZVakg==",
             "requires": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.20",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.21",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.2.1",
                 "cm6-theme-basic-dark": "^0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
-        "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.28",
+        "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.29",
         "bootstrap": "~5.3.3",
         "flatpickr": "^4.6.13",
         "iframe-resizer": "^4.3.11",


### PR DESCRIPTION
There is early termination code in the CodeMirror PGML parser that is not actually part of PGML. It is there to catch impartial constructs that occur while typeing.  For instance, say you have already typed ``[` `]``, and then you start to type `[$` inside that.  This code terminates the outer block so that syntax highlighting continues to work after the outer block.

Unfortunately, it was also early terminating 'balance' blocks inside outer blocks even though those could contain the terminator of the outer block.  This can cause tokens inside the block to be incorrectly terminated early.  For example, in `[@ '[@ "inner code" @]' @]**` the single quote starts a 'balance' type block, and the `@]` inside the string tries to terminate the outer `[@` block. Of course that example isn't something you should do any, but this was seen in a more complicated construct than that example.  That sort of thing is often needed for cases inside a BEGIN_PGML_SOLUTION/END_PGML_SOLUTION block.