### PR TITLE
Add missing maketext call.

### DIFF
--- a/templates/ContentGenerator/Instructor/Config/config_help.html.ep
+++ b/templates/ContentGenerator/Instructor/Config/config_help.html.ep
@@ -26,7 +26,7 @@
 						</div>
 						<div class="modal-body">
 							<h2 class="fs-4"><code><%= $configObject->help_name =%></code></h2>
-							<div><%== $configObject->{doc2} || $configObject->{doc} %></div>
+							<div><%== maketext($configObject->{doc2} || $configObject->{doc}) %></div>
 						</div>
 					</div>
 				</div>


### PR DESCRIPTION
This missing `maketext` call prevents translation of the documentation for course configuration variables.  This was brought up in https://webwork.maa.org/moodle/mod/forum/discuss.php?d=8682.