### PR TITLE
when copying a course including its sets, don't copy the lis_source_i…

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -385,6 +385,7 @@ sub addCourse {
 	if ($db0 && $options{copySets}) {
 		my @sets = $db0->getGlobalSetsWhere;
 		for my $set (@sets) {
+			$set->lis_source_did(undef);
 			eval { $db->addGlobalSet($set) };
 			warn $@ if $@;
 


### PR DESCRIPTION
…d of the sets

Before this change, if a new WW course was cloned from an old one (including its sets) then the new WW course may end up attempting to send grades to the old LMS course.