### PR TITLE
Properly quote file names in the regexp used to extract backup times.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -988,7 +988,7 @@ sub checkPWD ($c, $pwd, $renameError = 0) {
 	my $original = $pwd;
 	$pwd =~ s!(^|/)\.!$1_!g;                  # don't enter hidden directories
 	$pwd =~ s!^/!!;                           # remove leading /
-	$pwd =~ s![^-_./A-Z0-9~, ]!_!gi;          # no illegal characters
+	$pwd =~ s![^-_./A-Z0-9~,() ]!_!gi;        # no illegal characters
 	return if $renameError && $original ne $pwd;
 
 	$pwd = '.' if $pwd eq '';

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -620,7 +620,7 @@ sub getBackupTimes ($c) {
 	my $backupBasePath = $c->{backupBasePath};
 	my @files          = glob(qq("$backupBasePath*"));
 	return unless @files;
-	return reverse(map { $_ =~ s/$backupBasePath//r } @files);
+	return reverse(map { $_ =~ s/\Q$backupBasePath\E//r } @files);
 }
 
 sub backupFile ($c, $outputFilePath) {


### PR DESCRIPTION
If a backup filename contains certain special characters, then an exception is thrown when used in the regular expression to extract the time from the backup filename. To protect against this the metaquoting escape sequence (`\Q...\E`) is needed.

This fixes issue #2680.

Edit: Also allow parenthesis in file names in the file manager.  I went to delete the file I created to test the first part of this pull request, and discovered that I could not because the FileManager `checkPWD` method considers parentheses (or really anything except `-_./A-Z0-9~, `) to be an illegal character.  This probably needs to be revisited.  There are lots of other valid characters in file names that this does not allow.