### PR TITLE
Rework the warning and exception handling in the config file safe compartment.

### DIFF
--- a/lib/WeBWorK/CourseEnvironment.pm
+++ b/lib/WeBWorK/CourseEnvironment.pm
@@ -51,6 +51,7 @@ safe compartment into a hash. This hash becomes the course environment.
 
 use strict;
 use warnings;
+use feature 'state';
 
 use Carp;
 use Opcode qw(empty_opset);
@@ -100,17 +101,23 @@ sub new {
 	# https://github.com/openwebwork/webwork2/pull/2098#issuecomment-1619812699.
 	my %dummy = %+;
 
+	my @warnings;
+	my $outer_sig_warn = $SIG{__WARN__};
+	local $SIG{__WARN__} = sub { push(@warnings, $_[0]); };
+
 	my $safe = WeBWorK::WWSafe->new;
 	$safe->permit('rand');
+
 	# seed course environment with initial values
 	while (my ($var, $val) = each %$seedVars) {
-		$val = "" if not defined $val;
+		$val //= '';
 		$safe->reval("\$$var = '$val';");
 	}
 
 	# Compile the "include" function with all opcodes available.
 	my $include = q[ sub include {
 		my ($file) = @_;
+		state @dieMessages;
 		my $fullPath = "] . $seedVars->{webwork_dir} . q[/$file";
 		# This regex matches any string that begins with "../",
 		# ends with "/..", contains "/../", or is "..".
@@ -118,12 +125,15 @@ sub new {
 			die "Included file $file has potentially insecure path: contains \"..\"";
 		} else {
 			local @INC = ();
+			local $SIG{__DIE__} = sub { push(@dieMessages, $_[0]) };
 			my $result = do $fullPath;
-			if ($!) {
-				die "Failed to read include file $fullPath (has it been created from the corresponding .dist file?): $!";
+			if (@dieMessages) {
+				die pop @dieMessages;
 			} elsif ($@) {
 				die "Failed to compile include file $fullPath: $@";
-			} elsif (not $result) {
+			} elsif ($!) {
+				die "Failed to read include file $fullPath (has it been created from the corresponding .dist file?): $!";
+			} elsif (!$result) {
 				die "Include file $fullPath did not return a true value.";
 			}
 		}
@@ -147,11 +157,15 @@ sub new {
 	my $globalFileContents = readFile($globalEnvironmentFile);
 	$safe->share_from('main', [qw(%ENV)]);
 	$safe->reval($globalFileContents);
-	# warn "end the evaluation\n";
 
 	# if that evaluation failed, we can't really go on...
 	# we need a global environment!
-	$@ and croak "Could not evaluate global environment file $globalEnvironmentFile: $@";
+	if ($@) {
+		# Make sure any warnings that occurred are passed back to the global warning handler.
+		local $SIG{__WARN__} = ref($outer_sig_warn) eq 'CODE' ? $outer_sig_warn : 'DEFAULT';
+		warn $_ for @warnings;
+		croak "Could not evaluate global environment file $globalEnvironmentFile: $@";
+	}
 
 	# determine location of courseEnvironmentFile and simple configuration file
 	# pull it out of $safe's symbol table ad hoc
@@ -172,6 +186,10 @@ sub new {
 		my $courseWebConfigContents = eval { readFile($courseWebConfigFile) };    # catch exceptions
 		$@ or $safe->reval($courseWebConfigContents);
 	}
+
+	# Pass any warnings that occurred back to the global warning handler.
+	local $SIG{__WARN__} = ref($outer_sig_warn) eq 'CODE' ? $outer_sig_warn : 'DEFAULT';
+	warn $_ for @warnings;
 
 	# get the safe compartment's namespace as a hash
 	no strict 'refs';
@@ -206,19 +224,15 @@ sub new {
 	}
 	# #	We'll get the pg version here and read it into the safe symbol table
 	if (-r $PG_version_file) {
-		#print STDERR ( "\n\nread PG_version file $PG_version_file\n\n");
 		my $PG_version_file_contents = readFile($PG_version_file) // '';
 		$safe->reval($PG_version_file_contents);
-		#print STDERR ("\n contents: $PG_version_file_contents");
 
 		no strict 'refs';
 		my %symbolHash2 = %{ $safe->root . "::" };
-		#print STDERR "symbolHash".join(' ', keys %symbolHash2);
 		use strict 'refs';
 		$self->{PG_VERSION} = ${ *{ $symbolHash2{PG_VERSION} } };
 	} else {
 		$self->{PG_VERSION} = "unknown";
-		#croak "Cannot read PG version file $PG_version_file";
 		warn "Cannot read PG version file $PG_version_file";
 	}
 


### PR DESCRIPTION
This is so that evaluation of the configuration files gives better messages.

Currently if a file is included from another included file then exceptions in the inner included file are not shown, but rather the exception from the outer included file is shown.  For example, if `include('authen_LTI.conf')` is called in `localOverrides.conf` which is included from `defaults.config`, and `authen_LTI.conf` does not exist, then the current message says `Failed to read include file /opt/webwork/webwork2/conf/localOverrides.conf (has it been created from the corresponding .dist file?): No such file or directory` and now it says `Failed to read include file /opt/webwork/webwork2/conf/authen_LTI.conf (has it been created from the corresponding .dist file?): No such file or directory`. This was fixed by adding a local die signal handler to the `include` method defined in the safe compartment.  That pushes messages onto a `state` array variable.  When an exception occurs, only the last message is shown which is the one from the inner inclusion since that exception is pushed onto the array first (the exception from the outer inclusion happens second as a result of the inner exception).

In addition if warnings occur inside an included file, then this actually becomes an exception.  The reason for this is that the global warning signal handler defined in `lib/Mojolicious/WeBWorK.pm` is called inside the safe compartment used for evaluating the configuration files. This causes an exception when that handler attempts to access the controller `stash` which is not defined in the safe compartment. Note that this only occurs for a request, and not when the application first loads because that doesn't go through the global warning signal handler. Although, that isn't the exception you see because when that exception occurs Mojolicious attempts to wrap that exception with a `Mojo::Exception`. That causes another exception because that package is also not shared to the safe compartment. So you get an exception about the `new` method of the `Mojo::Exception` package not existing which is completely uninformative.  To fix this a local warning signal handler is used that pushes messages into a warning array.  Those warnings are rebroadcast to the global warning signal handler after the safe compartment evaluation of the configuration files is complete. A simple way to test this is to add a `warn` statement to `localOverrides.conf` and try to open a page in the browser.