### PR TITLE
Fix an issue with conflicting JSON modules in use in FormatRenderedProblem.pm.

### DIFF
--- a/bin/OPL-update-legacy
+++ b/bin/OPL-update-legacy
@@ -539,8 +539,6 @@ if($canopenfile) {
 }
 #### End of taxonomy/taxonomy2
 
-use JSON;
-
 #### Save the official taxonomy in json format
 my $webwork_htdocs = $ce->{webworkDirs}{htdocs};
 my $file = "$webwork_htdocs/DATA/tagging-taxonomy.json";

--- a/bin/OPLUtils.pm
+++ b/bin/OPLUtils.pm
@@ -17,7 +17,7 @@ use warnings;
 use File::Find::Rule;
 use File::Basename;
 use open qw/:std :utf8/;
-use JSON;
+use Mojo::JSON qw(encode_json);
 
 our @EXPORT = ();
 our @EXPORT_OK =
@@ -373,7 +373,7 @@ sub build_library_textbook_tree {
 sub writeJSONtoFile {
 	my ($data, $filename) = @_;
 
-	my $json = JSON->new->utf8->encode($data);
+	my $json = encode_json($data);
 	open my $fh, ">", $filename or die "Cannot open $filename";
 	print $fh $json;
 	close $fh;

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -108,7 +108,6 @@ my @modulesList = qw(
 	Iterator
 	Iterator::Util
 	JSON
-	JSON::MaybeXS
 	Locale::Maketext::Lexicon
 	Locale::Maketext::Simple
 	LWP::Protocol::https

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -107,7 +107,6 @@ my @modulesList = qw(
 	IO::Socket::SSL
 	Iterator
 	Iterator::Util
-	JSON
 	Locale::Maketext::Lexicon
 	Locale::Maketext::Simple
 	LWP::Protocol::https

--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -11,7 +11,7 @@ use File::Copy;
 use File::Path;
 use Archive::Tar;
 use Mojo::File;
-use JSON;
+use Mojo::JSON qw(decode_json);
 
 BEGIN {
 	use Mojo::File qw(curfile);
@@ -36,7 +36,7 @@ my $releaseDataFF =
 	File::Fetch->new(uri => 'https://api.github.com/repos/openwebwork/webwork-open-problem-library/releases/latest');
 my $file        = $releaseDataFF->fetch(to => $ce->{webworkDirs}{tmp}) or die $releaseDataFF->error;
 my $path        = Mojo::File->new($file);
-my $releaseData = JSON->new->utf8->decode($path->slurp);
+my $releaseData = decode_json($path->slurp);
 $path->remove;
 
 my $releaseTag = $releaseData->{tag_name};

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1363,7 +1363,7 @@ ${pg}{modules} = [
 	[qw(PGcore PGalias PGresource PGloadfiles PGanswergroup PGresponsegroup Tie::IxHash)],
 	[qw(Locale::Maketext)],
 	[qw(WeBWorK::PG::Localize)],
-	[qw(JSON)],
+	[qw(Mojo::JSON)],
 	[qw(Rserve Class::Tiny IO::Handle)],
 	[qw(DragNDrop)],
 	[qw(Types::Serialiser)],

--- a/lib/Caliper/Sensor.pm
+++ b/lib/Caliper/Sensor.pm
@@ -7,7 +7,7 @@ use WeBWorK::CourseEnvironment;
 use WeBWorK::DB;
 use WeBWorK::Debug;
 use Data::Dumper;
-use JSON;
+use Mojo::JSON  qw(encode_json);
 use Time::HiRes qw/gettimeofday/;
 use Date::Format;
 
@@ -67,7 +67,7 @@ sub sendEvents {
 			'data'        => $event_chunk,
 		};
 
-		my $json_payload = JSON->new->canonical->encode($envelope);
+		my $json_payload = encode_json($envelope);
 		# debug("Caliper event json_payload: " . $json_payload);
 
 		my $HTTPRequest = HTTP::Request->new(

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -24,7 +24,6 @@ package FormatRenderedProblem;
 use strict;
 use warnings;
 
-use JSON;
 use Digest::SHA qw(sha1_base64);
 use Mojo::Util  qw(xml_escape);
 use Mojo::JSON  qw(encode_json);
@@ -228,7 +227,7 @@ sub formatRenderedProblem {
 		$output->{pg_version} = $ce->{PG_VERSION};
 
 		# Convert to JSON and render.
-		return $ws->c->render(data => JSON->new->utf8(1)->encode($output));
+		return $ws->c->render(data => encode_json($output));
 	}
 
 	# Setup arnd render the appropriate template in the templates/RPCRenderFormats folder depending on the outputformat.

--- a/lib/WeBWorK/ContentGenerator/InstructorRPCHandler.pm
+++ b/lib/WeBWorK/ContentGenerator/InstructorRPCHandler.pm
@@ -39,8 +39,6 @@ error occurs, then the response will contain an "error" key.
 # was "instructor" only.  Usage of all commands is based on permissions, and there have always been non-instructor users
 # that have some of these permissions. So this module and the corresponding route should really be renamed.
 
-use JSON;
-
 use WebworkWebservice;
 
 sub initializeRoute ($c, $routeCaptures) {

--- a/lib/WeBWorK/Controller.pm
+++ b/lib/WeBWorK/Controller.pm
@@ -25,7 +25,6 @@ fields.
 =cut
 
 use Encode;
-use JSON::MaybeXS;
 
 use WeBWorK::Localize;
 

--- a/lib/WeBWorK/Utils/Instructor.pm
+++ b/lib/WeBWorK/Utils/Instructor.pm
@@ -26,6 +26,7 @@ use strict;
 use warnings;
 
 use File::Find;
+use Mojo::JSON qw(decode_json);
 
 use WeBWorK::DB::Utils qw(initializeUserProblem);
 use WeBWorK::Debug;
@@ -642,7 +643,7 @@ sub loadSetDefListFile {
 			$contents;
 		};
 
-		return @{ JSON->new->decode($data) };
+		return @{ decode_json($data) };
 	}
 
 	return;

--- a/lib/WebworkWebservice/SetActions.pm
+++ b/lib/WebworkWebservice/SetActions.pm
@@ -20,7 +20,6 @@ use strict;
 use warnings;
 
 use Carp;
-use JSON;
 use Data::Structure::Util qw(unbless);
 
 use WeBWorK::Utils             qw(max);


### PR DESCRIPTION
Both the `JSON` module and `Mojo::JSON::encode_json` method are loaded in `lib/FormatRenderedProblem.pm`.  This causes first request issued to the `render_rpc` endpoint after each server process starts to issue the warning `Prototype mismatch: sub FormatRenderedProblem::encode_json ($) vs none at /usr/lib/x86_64-linux-gnu/perl-base/Exporter.pm line 63.`  Once the modules are loaded in the process they aren't loaded again,  so the warning only occurs once per process.

There is no need for both modules that both do essentially the same thing.  The `Mojo::JSON::encode_json` method also UTF-8 encodes the data as was done before.

Note that the only place the `JSON` module was used was for rendering the `raw` format.

This is just something I noticed while working on #2691.