### PR TITLE
Fix an issue with feedback emails with text and html body, and an attachment.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -203,6 +203,19 @@ sub initialize ($c) {
 				return;
 			}
 
+			# Email::Stuffer incorrectly adds the attachment together with the text and html body parts at the same
+			# level.  As a result, when an email has a text body, an html body, and an attachment, both the text and
+			# html are shown in most email clients.  The text and html body should be parts of a separate part that has
+			# content type 'multipart/alternative'.  So the email has two parts, and the first part has two parts which
+			# are the text and html body.  The second part is the attachment. So before attaching the file move the text
+			# and html body into their own part.
+			$email->{parts} = [
+				Email::MIME->create(
+					attributes => { content_type => 'multipart/alternative' },
+					parts      => $email->{parts}
+				)
+			];
+
 			# Attach the file.
 			$email->attach($contents, filename => $filename);
 		}


### PR DESCRIPTION
Email::Stuffer incorrectly adds an attachment together with the text and html body parts all at the same level with content type multipart/mixed. Structurally this is as follows:

```
[
    (content type with multipart/mixed)
    text body,
    html body,
    attachment
]
```

As a result, when an email has a text body, an html body, and an attachment, both the text and html are shown in most email clients.

The text and html body should be parts of a separate part that has content type 'multipart/alternative'.  So the email has two parts, and the first part has two parts in that which are the text and html body. The second part is the attachment. The following shows how it should be structurally:

```
[
    (content type multipart/mixed)
    [
       (content type multipart/alternative)
        text body,
        html body
    ],
    attachment
]
```

To fix this, before adding an attachment the text and html body are moved into a separate part with content type multipart/alternative.

This is something that I noticed when working on issue #2690.  I use Thunderbird, and was confused when I got the old text email with the attachment.  Scrolling down I discovered that the html body was there as well.