### PR TITLE
Add a couple of `use Mojo:JSON` statements that are needed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -106,9 +106,6 @@ RUN apt-get update \
 	libhttp-async-perl \
 	libiterator-perl \
 	libiterator-util-perl \
-	libjson-maybexs-perl \
-	libjson-perl \
-	libjson-xs-perl \
 	liblocale-maketext-lexicon-perl \
 	libmariadb-dev \
 	libmath-random-secure-perl \

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -68,9 +68,6 @@ RUN apt-get update \
 	libhttp-async-perl \
 	libiterator-perl \
 	libiterator-util-perl \
-	libjson-maybexs-perl \
-	libjson-perl \
-	libjson-xs-perl \
 	liblocale-maketext-lexicon-perl \
 	libmariadb-dev \
 	libmath-random-secure-perl \

--- a/lib/WeBWorK/Controller.pm
+++ b/lib/WeBWorK/Controller.pm
@@ -25,6 +25,7 @@ fields.
 =cut
 
 use Encode;
+use Mojo::JSON qw(encode_json);
 
 use WeBWorK::Localize;
 

--- a/lib/WebworkWebservice/SetActions.pm
+++ b/lib/WebworkWebservice/SetActions.pm
@@ -20,6 +20,7 @@ use strict;
 use warnings;
 
 use Carp;
+use Mojo::JSON            qw(from_json to_json);
 use Data::Structure::Util qw(unbless);
 
 use WeBWorK::Utils             qw(max);


### PR DESCRIPTION
The `use JSON` statement from before was removed in these files because I though the module was not used.  However, these files used the methods in a different way and I missed it. So these files need the appropriate methods from `Mojo::JSON` imported.

Edit: Also remove the now unneeded JSON packages from the docker build.