### PR TITLE
LTI section identification

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -238,7 +238,7 @@ sub get_credentials {
 			[ 'oauth_signature',    'oauth_signature' ],
 			[ 'oauth_nonce',        'oauth_nonce' ],
 			[ 'oauth_timestamp',    'oauth_timestamp' ],
-			[ 'section',            'custom_section' ],
+			[ 'section',            'context_label' ],
 			[ 'recitation',         'custom_recitation' ],
 		);
 

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -193,7 +193,7 @@ sub get_credentials ($self) {
 				[ roles      => 'https://purl.imsglobal.org/spec/lti/claim/roles' ],
 				[ last_name  => 'family_name' ],
 				[ first_name => 'given_name' ],
-				[ section    => 'https://purl.imsglobal.org/spec/lti/claim/custom#section' ],
+				[ section    => 'https://purl.imsglobal.org/spec/lti/claim/lis#course_section_sourcedid' ],
 				[ recitation => 'https://purl.imsglobal.org/spec/lti/claim/custom#recitation' ],
 			);
 


### PR DESCRIPTION
Perhaps this should be rejected; it may be specific to D2L Brightspace.

But these are local changes we have so that when student WW accounts are created using LTI, their sections from the LMS will carry over into their WW account. Let me know if one or both of these are wrong for Canvas or Moodle, and I will modify or withdraw the PR.

Note: this is not useful when all students in a D2L course are from the same section. However it is common here to cross-list multiple sections into one D2L course. So these settings help us sort students in the one WW course based on their section number.