### PR TITLE
Fix classlist exporting with users that do not have passwords.

### DIFF
--- a/htdocs/js/UserList/userlist.js
+++ b/htdocs/js/UserList/userlist.js
@@ -113,7 +113,10 @@
 				e.preventDefault();
 				e.stopPropagation();
 				show_errors(['select_user_err_msg'], [export_select]);
-			} else if (export_select_target?.value === 'new' && export_filename.value === '') {
+			} else if (
+				export_select_target?.value === 'new' &&
+				(export_filename.value === '' || /\//.test(export_filename.value))
+			) {
 				e.preventDefault();
 				e.stopPropagation();
 				show_errors(['export_file_err_msg'], [export_filename, export_select_target]);

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -726,31 +726,29 @@ sub importUsersFromCSV ($c, $fileName, $replaceExisting, $fallbackPasswordSource
 }
 
 sub exportUsersToCSV ($c, $fileName, @userIDsToExport) {
-	my $ce  = $c->ce;
-	my $db  = $c->db;
-	my $dir = $ce->{courseDirs}->{templates};
+	my $ce = $c->ce;
+	my $db = $c->db;
 
-	die $c->maketext("illegal character in input: '/'") if $fileName =~ m|/|;
+	die $c->maketext(q{illegal character in input: '/'}) if $fileName =~ m|/|;
 
 	my @records;
 
-	my @Users            = $db->getUsers(@userIDsToExport);
-	my @Passwords        = $db->getPasswords(@userIDsToExport);
-	my @PermissionLevels = $db->getPermissionLevels(@userIDsToExport);
-	foreach my $i (0 .. $#userIDsToExport) {
-		my $User            = $Users[$i];
-		my $Password        = $Passwords[$i];
-		my $PermissionLevel = $PermissionLevels[$i];
-		next unless defined $User;
-		my %record = (
-			defined $PermissionLevel ? $PermissionLevel->toHash : (),
-			defined $Password        ? $Password->toHash        : (),
-			$User->toHash,
+	my @users            = $db->getUsers(@userIDsToExport);
+	my %passwords        = map { $_->user_id => $_ } $db->getPasswords(@userIDsToExport);
+	my %permissionLevels = map { $_->user_id => $_ } $db->getPermissionLevels(@userIDsToExport);
+
+	for my $user (@users) {
+		my $password        = $passwords{ $user->user_id };
+		my $permissionLevel = $permissionLevels{ $user->user_id };
+		my %record          = (
+			defined $permissionLevel ? $permissionLevel->toHash : (),
+			defined $password        ? $password->toHash        : (),
+			$user->toHash,
 		);
 		push @records, \%record;
 	}
 
-	write_classlist("$dir/$fileName", @records);
+	write_classlist("$ce->{courseDirs}{templates}/$fileName", @records);
 
 	return;
 }

--- a/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/export_form.html.ep
@@ -34,6 +34,6 @@
 		</div>
 	</div>
 	<div id="export_file_err_msg" class="alert alert-danger p-1 d-inline-flex d-none">
-		<%= maketext('Please input file name to export to.') %>
+		<%= maketext('Please input a file name to export to that does not contain forward slashes.') %>
 	</div>
 </div>


### PR DESCRIPTION
The `exportUsersToCSV` method of `WeBWorK::ContentGenerator::Instructor::UserList` assumes that all users have password and permission records in the database.  Since that is no longer the case, that code is not working right.  In fact if some users do not have password records and others do, then the resulting classlist that is exported will have many passwords in associated to the wrong users.  Some of the users that don't have passwords will have passwords, and vice versa. Note that the code had `defined` statements checking if the permission and password records exist, which mean that the code was technically incorrect to begin with.  It only worked because usually all users had password and permission records.

The general issue with this is noted in #2704 with regards to the deletion of the code that auto creates password or permission records when `getPasswords` or `getPermissionLevels` is called.  The general issue is that the `getPasswords` and `getPermissionLevels` methods call the `WeBWorK::DB::Schema::NewSQL::Std::gets` method which does not even include non-existent records.  So for example, if `getPasswords` is called with the list of user IDs `'user1', 'user2', 'user3'` and `user2` does not have a password, but the others do, then `getPasswords` will return an array with two elements which are the password records for `user1` and `user3`.  So when iterating by index on the original list the password record for `user1` will correctly go to `user1`, but the password record for `user3` will be paired with `user2`, and `user3` will not have a password record.

Also, the `exportUsersToCSV` dies if the provided filename contains a forward slash.  So now the JavaScript form validation checks for this, and prevents those filenames from being submitted to the server.  Thus preventing the `die` statement from occurring.