### PR TITLE
Speed up deleting of global user achievements.

### DIFF
--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -1467,17 +1467,8 @@ sub deleteGlobalUserAchievement {
 	# userAchievementID can be undefined if being called from this package
 	my $U = caller eq __PACKAGE__ ? "!" : "";
 	my ($self, $userID) = shift->checkArgs(\@_, "user_id$U");
-
-	my @achievements = $self->listUserAchievements($userID);
-	foreach my $achievement (@achievements) {
-		$self->deleteUserAchievement($userID, $achievement);
-	}
-
-	if ($self->{global_user_achievement}) {
-		return $self->{global_user_achievement}->delete($userID);
-	} else {
-		return 0;
-	}
+	$self->{achievement_user}->delete_where({ user_id => $userID });
+	return $self->{global_user_achievement}->delete($userID);
 }
 
 ################################################################################


### PR DESCRIPTION
Instead of listing user achievements and then deleting them one by one in a loop, just delete them with one query using a `where` statement.

This improved the deletion of 5000 users all of which had the default set of achievements assigned to them from taking a minute and a half to less than 20 seconds.