### PR TITLE
Fix the import form date shift input on the sets manager page.

### DIFF
--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -188,7 +188,9 @@
 			return (
 				new Date(dateTime.toLocaleString('en-US')).getTime() -
 				new Date(
-					dateTime.toLocaleString('en-US', { timeZone: open_rule.dataset.timezone ?? 'America/New_York' })
+					dateTime.toLocaleString('en-US', {
+						timeZone: importDateShift.dataset.timezone ?? 'America/New_York'
+					})
 				).getTime()
 			);
 		};


### PR DESCRIPTION
This was a cut and paste error in #2655. I cut the similar code from `htdocs/js/DatePicker/datepicker.js` and needed to change the input variable name.

Currently if you select a date on the import form no date is actually entered into the input, and console errors are output.  Obviously that is fixed with this pull request.