### PR TITLE
Finalize the PG CodeMirror Editor for the 2.20 release.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
             "license": "GPL-2.0+",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.5.2",
-                "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.29",
+                "@openwebwork/pg-codemirror-editor": "^0.0.1",
                 "bootstrap": "~5.3.3",
                 "flatpickr": "^4.6.13",
                 "iframe-resizer": "^4.3.11",
@@ -44,9 +44,9 @@
             }
         },
         "node_modules/@codemirror/commands": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
-            "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+            "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.0.0",
@@ -115,9 +115,9 @@
             }
         },
         "node_modules/@codemirror/language": {
-            "version": "6.10.8",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
-            "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+            "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -129,9 +129,9 @@
             }
         },
         "node_modules/@codemirror/lint": {
-            "version": "6.8.4",
-            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
-            "integrity": "sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==",
+            "version": "6.8.5",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+            "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.0.0",
@@ -172,9 +172,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.36.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
-            "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
+            "version": "6.36.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.6.tgz",
+            "integrity": "sha512-uxugGLet+Nzp0Jcit8Hn3LypM8ioMLKTsdf8FRoT3HWvZtb9GhaWMe0Cc15rz90Ljab4YFJiAulmIVB74OY0IQ==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
@@ -256,9 +256,9 @@
             "license": "MIT"
         },
         "node_modules/@lezer/css": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.10.tgz",
-            "integrity": "sha512-V5/89eDapjeAkWPBpWEfQjZ1Hag3aYUUJOL8213X0dFRuXJ4BXa5NKl9USzOnaLod4AOpmVCkduir2oKwZYZtg==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.11.tgz",
+            "integrity": "sha512-FuAnusbLBl1SEAtfN8NdShxYJiESKw9LAFysfea1T96jD3ydBn12oYjaSG1a04BQRIUd93/0D8e5CV1cUMkmQg==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.2.0",
@@ -287,9 +287,9 @@
             }
         },
         "node_modules/@lezer/javascript": {
-            "version": "1.4.21",
-            "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.21.tgz",
-            "integrity": "sha512-lL+1fcuxWYPURMM/oFZLEDm0XuLN128QPV+VuGtKpeaOGdcl9F2LYC3nh1S9LkPqx9M0mndZFdXCipNAZpzIkQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+            "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
             "license": "MIT",
             "dependencies": {
                 "@lezer/common": "^1.2.0",
@@ -324,28 +324,28 @@
             "license": "MIT"
         },
         "node_modules/@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.21",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.21.tgz",
-            "integrity": "sha512-ERKpLNa/hOmzlCjBQsbQ5XWEUdoI3hyuByhtqPCeTL3gHCM4MTh431EXm89lwF3xK4CBORfEjD84+vEJMhHz7Q==",
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1.tgz",
+            "integrity": "sha512-qeqxdz1ldMMiCtPGeTCcMmGx/OIbd19jxe2yC8G+9zAnQfm8JhRrLS6LQ8GrJ7R19iLAZ4wVuQqowEfZkC0N/w==",
             "license": "MIT",
             "dependencies": {
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }
         },
         "node_modules/@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.29",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.29.tgz",
-            "integrity": "sha512-BEM3hX4g2b5WLtZwM/E+ZSPams7G9v2mDxLsj6iWbXt9RPfh9IgXPAp6ZFHnNVHd416pTMt9IoEioPdYvZVakg==",
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1.tgz",
+            "integrity": "sha512-2YbyoeWPBuJW6FuLagbSWyZvW/jAG2Ddr2xiYgjQbxUq7VCc2M1oEDbqyuo/pRv4NeuvqlZXGz2DO8lNCuGg5Q==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.21",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1",
                 "@replit/codemirror-emacs": "^6.1.0",
-                "@replit/codemirror-vim": "^6.2.1",
+                "@replit/codemirror-vim": "^6.3.0",
                 "cm6-theme-basic-dark": "^0.2.0",
                 "cm6-theme-basic-light": "^0.2.0",
                 "cm6-theme-gruvbox-dark": "^0.2.0",
@@ -355,8 +355,8 @@
                 "cm6-theme-solarized-dark": "^0.2.0",
                 "cm6-theme-solarized-light": "^0.2.0",
                 "codemirror": "^6.0.1",
-                "codemirror-lang-mt": "^0.0.2-beta.5",
-                "codemirror-lang-perl": "^0.1.5-beta.6",
+                "codemirror-lang-mt": "^0.0.2",
+                "codemirror-lang-perl": "^0.1.5",
                 "style-mod": "^4.1.2",
                 "thememirror": "^2.0.1"
             }
@@ -385,16 +385,16 @@
             }
         },
         "node_modules/@replit/codemirror-vim": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.2.1.tgz",
-            "integrity": "sha512-qDAcGSHBYU5RrdO//qCmD8K9t6vbP327iCj/iqrkVnjbrpFhrjOt92weGXGHmTNRh16cUtkUZ7Xq7rZf+8HVow==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz",
+            "integrity": "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==",
             "license": "MIT",
             "peerDependencies": {
-                "@codemirror/commands": "^6.0.0",
-                "@codemirror/language": "^6.1.0",
-                "@codemirror/search": "^6.2.0",
-                "@codemirror/state": "^6.0.1",
-                "@codemirror/view": "^6.0.3"
+                "@codemirror/commands": "6.x.x",
+                "@codemirror/language": "6.x.x",
+                "@codemirror/search": "6.x.x",
+                "@codemirror/state": "6.x.x",
+                "@codemirror/view": "6.x.x"
             }
         },
         "node_modules/@trysound/sax": {
@@ -758,26 +758,26 @@
             }
         },
         "node_modules/codemirror-lang-mt": {
-            "version": "0.0.2-beta.5",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2-beta.5.tgz",
-            "integrity": "sha512-+ixkIP2r/gq/pteghu5Llw5SqmhQMidq4xtiD9hjTNpslZ84iInR0+m/beazvqii7j6kMDzsV/PomxC9OAqxXA==",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2.tgz",
+            "integrity": "sha512-m2q+EVgNeDxq3A8gCnoUGZvTuXvvZKlZliiqif4VAMPiu7dKJsaopvXZo8S1KH6cb2x9fJuKr5yUTnkxSLQZIQ==",
             "license": "MIT",
             "dependencies": {
-                "@codemirror/lang-css": "^6.3.0",
+                "@codemirror/lang-css": "^6.3.1",
                 "@codemirror/lang-html": "^6.4.9",
-                "@codemirror/lang-javascript": "^6.2.2",
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/lang-javascript": "^6.2.3",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }
         },
         "node_modules/codemirror-lang-perl": {
-            "version": "0.1.5-beta.6",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5-beta.6.tgz",
-            "integrity": "sha512-RpKsMRr/5IGcVbo0cj1JWga6My7jbx+Lzs9tbijEEE31a3BcyHcNN0VbmBVm1Z1UJA/C9q0TxhZu5WH/ZgYjFA==",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5.tgz",
+            "integrity": "sha512-o0QBzsO4z+ZWaN7ueYnFVYWoFlFvvfgcgNA/dQLxYUDiKGSUY0R52UL/NqTO6swUVrR+O6JI3Xh1j/ed81JIwA==",
             "license": "MIT",
             "dependencies": {
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }
@@ -2150,9 +2150,9 @@
             }
         },
         "@codemirror/commands": {
-            "version": "6.8.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.0.tgz",
-            "integrity": "sha512-q8VPEFaEP4ikSlt6ZxjB3zW72+7osfAYW9i8Zu943uqbKuz6utc1+F170hyLUCUltXORjQXRyYQNfkckzA/bPQ==",
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
+            "integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.4.0",
@@ -2216,9 +2216,9 @@
             }
         },
         "@codemirror/language": {
-            "version": "6.10.8",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.10.8.tgz",
-            "integrity": "sha512-wcP8XPPhDH2vTqf181U8MbZnW+tDyPYy0UzVOa+oHORjyT+mhhom9vBd7dApJwoDz9Nb/a8kHjJIsuA/t8vNFw==",
+            "version": "6.11.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
+            "integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.23.0",
@@ -2229,9 +2229,9 @@
             }
         },
         "@codemirror/lint": {
-            "version": "6.8.4",
-            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.4.tgz",
-            "integrity": "sha512-u4q7PnZlJUojeRe8FJa/njJcMctISGgPQ4PnWsd9268R4ZTtU+tfFYmwkBvgcrK2+QQ8tYFVALVb5fVJykKc5A==",
+            "version": "6.8.5",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
+            "integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.35.0",
@@ -2268,9 +2268,9 @@
             }
         },
         "@codemirror/view": {
-            "version": "6.36.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.3.tgz",
-            "integrity": "sha512-N2bilM47QWC8Hnx0rMdDxO2x2ImJ1FvZWXubwKgjeoOrWwEiFrtpA7SFHcuZ+o2Ze2VzbkgbzWVj4+V18LVkeg==",
+            "version": "6.36.6",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.6.tgz",
+            "integrity": "sha512-uxugGLet+Nzp0Jcit8Hn3LypM8ioMLKTsdf8FRoT3HWvZtb9GhaWMe0Cc15rz90Ljab4YFJiAulmIVB74OY0IQ==",
             "requires": {
                 "@codemirror/state": "^6.5.0",
                 "style-mod": "^4.1.0",
@@ -2337,9 +2337,9 @@
             "integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
         },
         "@lezer/css": {
-            "version": "1.1.10",
-            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.10.tgz",
-            "integrity": "sha512-V5/89eDapjeAkWPBpWEfQjZ1Hag3aYUUJOL8213X0dFRuXJ4BXa5NKl9USzOnaLod4AOpmVCkduir2oKwZYZtg==",
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.11.tgz",
+            "integrity": "sha512-FuAnusbLBl1SEAtfN8NdShxYJiESKw9LAFysfea1T96jD3ydBn12oYjaSG1a04BQRIUd93/0D8e5CV1cUMkmQg==",
             "requires": {
                 "@lezer/common": "^1.2.0",
                 "@lezer/highlight": "^1.0.0",
@@ -2365,9 +2365,9 @@
             }
         },
         "@lezer/javascript": {
-            "version": "1.4.21",
-            "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.4.21.tgz",
-            "integrity": "sha512-lL+1fcuxWYPURMM/oFZLEDm0XuLN128QPV+VuGtKpeaOGdcl9F2LYC3nh1S9LkPqx9M0mndZFdXCipNAZpzIkQ==",
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
+            "integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
             "requires": {
                 "@lezer/common": "^1.2.0",
                 "@lezer/highlight": "^1.1.3",
@@ -2398,26 +2398,26 @@
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
         },
         "@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1-beta.21",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1-beta.21.tgz",
-            "integrity": "sha512-ERKpLNa/hOmzlCjBQsbQ5XWEUdoI3hyuByhtqPCeTL3gHCM4MTh431EXm89lwF3xK4CBORfEjD84+vEJMhHz7Q==",
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1.tgz",
+            "integrity": "sha512-qeqxdz1ldMMiCtPGeTCcMmGx/OIbd19jxe2yC8G+9zAnQfm8JhRrLS6LQ8GrJ7R19iLAZ4wVuQqowEfZkC0N/w==",
             "requires": {
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }
         },
         "@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1-beta.29",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1-beta.29.tgz",
-            "integrity": "sha512-BEM3hX4g2b5WLtZwM/E+ZSPams7G9v2mDxLsj6iWbXt9RPfh9IgXPAp6ZFHnNVHd416pTMt9IoEioPdYvZVakg==",
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1.tgz",
+            "integrity": "sha512-2YbyoeWPBuJW6FuLagbSWyZvW/jAG2Ddr2xiYgjQbxUq7VCc2M1oEDbqyuo/pRv4NeuvqlZXGz2DO8lNCuGg5Q==",
             "requires": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1-beta.21",
+                "@openwebwork/codemirror-lang-pg": "^0.0.1",
                 "@replit/codemirror-emacs": "^6.1.0",
-                "@replit/codemirror-vim": "^6.2.1",
+                "@replit/codemirror-vim": "^6.3.0",
                 "cm6-theme-basic-dark": "^0.2.0",
                 "cm6-theme-basic-light": "^0.2.0",
                 "cm6-theme-gruvbox-dark": "^0.2.0",
@@ -2427,8 +2427,8 @@
                 "cm6-theme-solarized-dark": "^0.2.0",
                 "cm6-theme-solarized-light": "^0.2.0",
                 "codemirror": "^6.0.1",
-                "codemirror-lang-mt": "^0.0.2-beta.5",
-                "codemirror-lang-perl": "^0.1.5-beta.6",
+                "codemirror-lang-mt": "^0.0.2",
+                "codemirror-lang-perl": "^0.1.5",
                 "style-mod": "^4.1.2",
                 "thememirror": "^2.0.1"
             }
@@ -2446,9 +2446,9 @@
             "requires": {}
         },
         "@replit/codemirror-vim": {
-            "version": "6.2.1",
-            "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.2.1.tgz",
-            "integrity": "sha512-qDAcGSHBYU5RrdO//qCmD8K9t6vbP327iCj/iqrkVnjbrpFhrjOt92weGXGHmTNRh16cUtkUZ7Xq7rZf+8HVow==",
+            "version": "6.3.0",
+            "resolved": "https://registry.npmjs.org/@replit/codemirror-vim/-/codemirror-vim-6.3.0.tgz",
+            "integrity": "sha512-aTx931ULAMuJx6xLf7KQDOL7CxD+Sa05FktTDrtLaSy53uj01ll3Zf17JdKsriER248oS55GBzg0CfCTjEneAQ==",
             "requires": {}
         },
         "@trysound/sax": {
@@ -2655,24 +2655,24 @@
             }
         },
         "codemirror-lang-mt": {
-            "version": "0.0.2-beta.5",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2-beta.5.tgz",
-            "integrity": "sha512-+ixkIP2r/gq/pteghu5Llw5SqmhQMidq4xtiD9hjTNpslZ84iInR0+m/beazvqii7j6kMDzsV/PomxC9OAqxXA==",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2.tgz",
+            "integrity": "sha512-m2q+EVgNeDxq3A8gCnoUGZvTuXvvZKlZliiqif4VAMPiu7dKJsaopvXZo8S1KH6cb2x9fJuKr5yUTnkxSLQZIQ==",
             "requires": {
-                "@codemirror/lang-css": "^6.3.0",
+                "@codemirror/lang-css": "^6.3.1",
                 "@codemirror/lang-html": "^6.4.9",
-                "@codemirror/lang-javascript": "^6.2.2",
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/lang-javascript": "^6.2.3",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }
         },
         "codemirror-lang-perl": {
-            "version": "0.1.5-beta.6",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5-beta.6.tgz",
-            "integrity": "sha512-RpKsMRr/5IGcVbo0cj1JWga6My7jbx+Lzs9tbijEEE31a3BcyHcNN0VbmBVm1Z1UJA/C9q0TxhZu5WH/ZgYjFA==",
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5.tgz",
+            "integrity": "sha512-o0QBzsO4z+ZWaN7ueYnFVYWoFlFvvfgcgNA/dQLxYUDiKGSUY0R52UL/NqTO6swUVrR+O6JI3Xh1j/ed81JIwA==",
             "requires": {
-                "@codemirror/language": "^6.10.2",
+                "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
                 "@lezer/lr": "^1.4.2"
             }

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
             "license": "GPL-2.0+",
             "dependencies": {
                 "@fortawesome/fontawesome-free": "^6.5.2",
-                "@openwebwork/pg-codemirror-editor": "^0.0.1",
+                "@openwebwork/pg-codemirror-editor": "^0.0.4",
                 "bootstrap": "~5.3.3",
                 "flatpickr": "^4.6.13",
                 "iframe-resizer": "^4.3.11",
@@ -172,9 +172,9 @@
             }
         },
         "node_modules/@codemirror/view": {
-            "version": "6.36.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.6.tgz",
-            "integrity": "sha512-uxugGLet+Nzp0Jcit8Hn3LypM8ioMLKTsdf8FRoT3HWvZtb9GhaWMe0Cc15rz90Ljab4YFJiAulmIVB74OY0IQ==",
+            "version": "6.36.7",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.7.tgz",
+            "integrity": "sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
@@ -324,9 +324,9 @@
             "license": "MIT"
         },
         "node_modules/@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1.tgz",
-            "integrity": "sha512-qeqxdz1ldMMiCtPGeTCcMmGx/OIbd19jxe2yC8G+9zAnQfm8JhRrLS6LQ8GrJ7R19iLAZ4wVuQqowEfZkC0N/w==",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.2.tgz",
+            "integrity": "sha512-xnipB2bydjDbcRVO9XpFNkhI9muoA6FzPqx6gRxQk10cXj8nzOn694gl7ATpn/xn5J5Y+7YpFAFTDqs0atgI6g==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/language": "^6.11.0",
@@ -335,15 +335,15 @@
             }
         },
         "node_modules/@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1.tgz",
-            "integrity": "sha512-2YbyoeWPBuJW6FuLagbSWyZvW/jAG2Ddr2xiYgjQbxUq7VCc2M1oEDbqyuo/pRv4NeuvqlZXGz2DO8lNCuGg5Q==",
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.4.tgz",
+            "integrity": "sha512-aJ3/AmKc1Ck/6zKctETP29QnuKn4PHIWhEZNdCzi49zAI+Ls2wH0JQdPadoj3z4savAxhabsdYOu8WWV7vwx5g==",
             "license": "MIT",
             "dependencies": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1",
+                "@openwebwork/codemirror-lang-pg": "^0.0.2",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.3.0",
                 "cm6-theme-basic-dark": "^0.2.0",
@@ -2268,9 +2268,9 @@
             }
         },
         "@codemirror/view": {
-            "version": "6.36.6",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.6.tgz",
-            "integrity": "sha512-uxugGLet+Nzp0Jcit8Hn3LypM8ioMLKTsdf8FRoT3HWvZtb9GhaWMe0Cc15rz90Ljab4YFJiAulmIVB74OY0IQ==",
+            "version": "6.36.7",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.7.tgz",
+            "integrity": "sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==",
             "requires": {
                 "@codemirror/state": "^6.5.0",
                 "style-mod": "^4.1.0",
@@ -2398,9 +2398,9 @@
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
         },
         "@openwebwork/codemirror-lang-pg": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.1.tgz",
-            "integrity": "sha512-qeqxdz1ldMMiCtPGeTCcMmGx/OIbd19jxe2yC8G+9zAnQfm8JhRrLS6LQ8GrJ7R19iLAZ4wVuQqowEfZkC0N/w==",
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.2.tgz",
+            "integrity": "sha512-xnipB2bydjDbcRVO9XpFNkhI9muoA6FzPqx6gRxQk10cXj8nzOn694gl7ATpn/xn5J5Y+7YpFAFTDqs0atgI6g==",
             "requires": {
                 "@codemirror/language": "^6.11.0",
                 "@lezer/highlight": "^1.2.1",
@@ -2408,14 +2408,14 @@
             }
         },
         "@openwebwork/pg-codemirror-editor": {
-            "version": "0.0.1",
-            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.1.tgz",
-            "integrity": "sha512-2YbyoeWPBuJW6FuLagbSWyZvW/jAG2Ddr2xiYgjQbxUq7VCc2M1oEDbqyuo/pRv4NeuvqlZXGz2DO8lNCuGg5Q==",
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.4.tgz",
+            "integrity": "sha512-aJ3/AmKc1Ck/6zKctETP29QnuKn4PHIWhEZNdCzi49zAI+Ls2wH0JQdPadoj3z4savAxhabsdYOu8WWV7vwx5g==",
             "requires": {
                 "@codemirror/lang-html": "^6.4.9",
                 "@codemirror/lang-xml": "^6.1.0",
                 "@codemirror/theme-one-dark": "^6.1.2",
-                "@openwebwork/codemirror-lang-pg": "^0.0.1",
+                "@openwebwork/codemirror-lang-pg": "^0.0.2",
                 "@replit/codemirror-emacs": "^6.1.0",
                 "@replit/codemirror-vim": "^6.3.0",
                 "cm6-theme-basic-dark": "^0.2.0",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
-        "@openwebwork/pg-codemirror-editor": "^0.0.1",
+        "@openwebwork/pg-codemirror-editor": "^0.0.4",
         "bootstrap": "~5.3.3",
         "flatpickr": "^4.6.13",
         "iframe-resizer": "^4.3.11",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
     },
     "dependencies": {
         "@fortawesome/fontawesome-free": "^6.5.2",
-        "@openwebwork/pg-codemirror-editor": "^0.0.1-beta.29",
+        "@openwebwork/pg-codemirror-editor": "^0.0.1",
         "bootstrap": "~5.3.3",
         "flatpickr": "^4.6.13",
         "iframe-resizer": "^4.3.11",


### PR DESCRIPTION
A non beta version 0.0.1 of the `@openwebwork/pg-codemirror-editor` has now been published.  So make that the version for the 2.20 release.  If there are any other changes the version can still be bumped if needed, but I doubt that there will be at this point.

The `@openwebwork/codemirror-lang-pg` package that the `@openwebwork/pg-codemirror-editor` depends on has a non beta version published (version 0.0.1).

The `codemirror-lang-perl` and `codemirror-lang-mt` packages are now also published in non beta status. Those are under my name still at this point since they are not specific to the openwebwork project.