### PR TITLE
Remove the current version in "Information for Downloading" from the `Readme.md` file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,6 @@ New users interested in getting started with their own WeBWorK server, or instru
 
 ## Information for Downloading
 
-* The current version is WeBWorK-2.18 and its companion PG-2.18
-
 * Installation manuals can be found at https://webwork.maa.org/wiki/Category:Installation_Manuals
 
 ## Information For Developers


### PR DESCRIPTION
This was missed in #2722 and was also missed for the 2.19 release obviously.  So by deleting it from the file it won't be missed again!