### PR TITLE
Fix file uploads.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -18,7 +18,7 @@ use Archive::Zip::SimpleZip qw($SimpleZipError);
 
 use WeBWorK::Utils                   qw(sortByName min);
 use WeBWorK::Utils::CourseManagement qw(archiveCourse);
-use WeBWorK::Utils::Files            qw(readFile);
+use WeBWorK::Utils::Files            qw(readFile path_is_subdir);
 use WeBWorK::Upload;
 
 use constant HOME => 'templates';
@@ -515,8 +515,8 @@ sub unpack_archive ($c, $archive) {
 
 		@members = $zip->members;
 		for (@members) {
-			my $out_file = $dir->child($_->fileName)->realpath;
-			if ($out_file !~ /^$dir/) {
+			my $out_file = $dir->child($_->fileName);
+			if (!path_is_subdir($out_file, $dir)) {
 				push(@outside_files, $_->fileName);
 				next;
 			}
@@ -550,8 +550,8 @@ sub unpack_archive ($c, $archive) {
 
 		@members = $tar->list_files;
 		for (@members) {
-			my $out_file = $dir->child($_)->realpath;
-			if ($out_file !~ /^$dir/) {
+			my $out_file = $dir->child($_);
+			if (!path_is_subdir($out_file->to_string, $dir->to_string)) {
 				push(@outside_files, $_);
 				next;
 			}

--- a/lib/WeBWorK/Upload.pm
+++ b/lib/WeBWorK/Upload.pm
@@ -61,10 +61,8 @@ sub store {
 
 	croak "no upload specified" unless $upload;
 
-	local $ENV{MOJO_TMPDIR} = $dir;
-	my $asset = $upload->asset->to_file;
-	$asset->cleanup(0);
-	my $tmpFile = path($asset->path)->basename;
+	my $tmpFile = path($upload->asset->to_file->path)->basename;
+	$upload->move_to("$dir/$tmpFile");
 
 	# Generate a one-time secret.
 	my $secret = sprintf('%X' x 4, map { int rand 2**32 } 1 .. 4);

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -871,7 +871,7 @@ sub archiveCourse {
 	my $parent_dir = $ce->{webworkDirs}{courses};
 	my $files      = path($course_dir)->list_tree({ dir => 1, hidden => 1 })->map('to_abs');
 	my $tar        = Archive::Tar->new;
-	$tar->add_files(@$files);
+	$tar->add_files($course_dir, @$files);
 	for ($tar->get_files) {
 		$tar->rename($_->full_path, $_->full_path =~ s!^$parent_dir/!!r);
 	}


### PR DESCRIPTION
The `MOJO_TMPDIR` attempt was not working.  The problem is that the `Mojo::Upload` object is already created before the `WeBWorK::Upload::store` method is called, and so the temporary file location is already determined and the temporrary file saved there.  So when the upload is later retrieved it is not where it is expected to be.

This does not happen with rather small files because a Mojo::Upload::Memory object is used instead of a Mojo::Upload::File object, and in that case the file is not saved to a temporary file to begin with.

Note: I just noticed that uploading tar files and automatically extracting them is broken and was broken in 2.19 as well.  That is another issue that needs to be fixed.