### PR TITLE
Reset the cookie session before Mojolicious saves it.

### DIFF
--- a/lib/WeBWorK/Authen.pm
+++ b/lib/WeBWorK/Authen.pm
@@ -844,6 +844,10 @@ sub store_session {
 		}
 	}
 
+	# The session parameters need to be set again, because another request may have occured during this
+	# request in which case the session parameters for the app will now be set for that request.
+	$self->{c}->setSessionParams;
+
 	return;
 }
 


### PR DESCRIPTION
Currently the session parameters are set at the beginning of each request.  However, if another request occurs for the same process before the first request completes, then the session for the first request gets saved with the parameters of the second request.  This is because there is only one Mojoicious session setup for the entire app and the session parameters are global for the process.

To fix this the session parameters need to be set again at the end of the request just before the session is saved.

This is only an issue if there are multiple clients per worker process. Of course that is not the case at this point, but hopefully will be some day, so I am going to go ahead an put this in.  This is not critical that it goes into this release, and it can be delayed until after the release.