### PR TITLE
Use tex-svg-full.js instead of tex-svg.js for MathJax.

### DIFF
--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -91,7 +91,7 @@ sub formatRenderedProblem {
 		[ 'node_modules/jquery-ui-dist/jquery-ui.min.js',                      0, {} ],
 		[ 'node_modules/iframe-resizer/js/iframeResizer.contentWindow.min.js', 0, {} ],
 		[ 'js/MathJaxConfig/mathjax-config.js',                     0, { defer => undef } ],
-		[ 'node_modules/mathjax/es5/tex-svg.js',                    0, { defer => undef, id => 'MathJax-script' } ],
+		[ 'node_modules/mathjax/es5/tex-svg-full.js',               0, { defer => undef, id => 'MathJax-script' } ],
 		[ 'node_modules/bootstrap/dist/js/bootstrap.bundle.min.js', 0, { defer => undef } ],
 		[ 'js/Problem/problem.js',                                  0, { defer => undef } ],
 		[ 'js/System/system.js',                                    0, { defer => undef } ],

--- a/templates/layouts/system.html.ep
+++ b/templates/layouts/system.html.ep
@@ -25,7 +25,7 @@
 % # JS Loads
 <%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'js/MathJaxConfig/mathjax-config.js' }),
 	defer => undef =%>
-<%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'node_modules/mathjax/es5/tex-svg.js' }),
+<%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'node_modules/mathjax/es5/tex-svg-full.js' }),
 	id => 'MathJax-script', defer => undef =%>
 <%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'node_modules/jquery/dist/jquery.min.js' }) %>
 <%= javascript $c->url({


### PR DESCRIPTION
Some MathObjects create TeX that uses `\boldsymbol`, which needs to be loaded to use in MathJax.

Side note, why is `noerrors` being loaded here? I actually find the errors MathJax gives when a complicated formula is malformed quite useful in debugging. Is it to limit memory/processing power of the clients?