### PR TITLE
Rework check_modules.pl.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -1,53 +1,39 @@
 #!/usr/bin/env perl
-#
 
 =head1 NAME
 
-check_modules.pl - check to ensure that all applications and perl modules are installed.
+check_modules.pl - Check to ensure that applications and perl modules needed by
+webwork2 are installed.
 
 =head1 SYNOPSIS
 
 check_modules.pl [options]
 
  Options:
-   -m|--modules          Lists the perl modules needed to be installed.
-   -p|--programs       	 Lists the programs/applications that are needed.
-   -A|--all         		 checks both programs and modules (Default if -m or -p is not selected)
+   -m|--modules          Check that the perl modules needed by webwork2 can be loaded.
+   -p|--programs         Check that the programs needed by webwork2 exist.
+
+Both programs and modules are checked if no options are given.
 
 =head1 DESCRIPTION
 
-Lists all needed applications for webwork as well as a perl modules.
+Checks that modules needed by webwork2 can be loaded and are at the sufficient
+version, and that applications needed by webwork2 exist.
 
 =cut
 
 use strict;
 use warnings;
 use version;
+use feature 'say';
+
 use Getopt::Long qw(:config bundling);
 use Pod::Usage;
-
-my @applicationsList = qw(
-	convert
-	curl
-	dvisvgm
-	mkdir
-	mv
-	mysql
-	node
-	tar
-	git
-	gzip
-	latex
-	pandoc
-	xelatex
-	dvipng
-);
 
 my @modulesList = qw(
 	Archive::Tar
 	Archive::Zip
 	Archive::Zip::SimpleZip
-	Array::Utils
 	Benchmark
 	Carp
 	Class::Accessor
@@ -60,12 +46,10 @@ my @modulesList = qw(
 	Date::Format
 	Date::Parse
 	DateTime
-	DBD::mysql
 	DBI
 	Digest::MD5
 	Digest::SHA
 	Email::Address::XS
-	Email::Sender::Simple
 	Email::Sender::Transport::SMTP
 	Email::Stuffer
 	Errno
@@ -85,11 +69,8 @@ my @modulesList = qw(
 	Getopt::Long
 	Getopt::Std
 	HTML::Entities
-	HTML::Tagset
-	HTML::Template
 	HTTP::Async
 	IO::File
-	IO::Socket::SSL
 	Iterator
 	Iterator::Util
 	Locale::Maketext::Lexicon
@@ -104,29 +85,21 @@ my @modulesList = qw(
 	Mojolicious::Plugin::NotYAMLConfig
 	Mojolicious::Plugin::RenderFile
 	Net::IP
-	Net::LDAPS
 	Net::OAuth
-	Net::SMTP
-	Net::SSLeay
 	Opcode
-	PadWalker
 	Pandoc
-	Path::Class
 	Perl::Tidy
 	PHP::Serialization
 	Pod::Simple::Search
 	Pod::Simple::XHTML
 	Pod::Usage
 	Pod::WSDL
-	Safe
 	Scalar::Util
 	SOAP::Lite
 	Socket
 	SQL::Abstract
-	Statistics::R::IO
 	String::ShellQuote
 	SVG
-	Template
 	Text::CSV
 	Text::Wrap
 	Tie::IxHash
@@ -147,90 +120,146 @@ my %moduleVersion = (
 	'IO::Socket::SSL'      => 2.007,
 	'LWP::Protocol::https' => 6.06,
 	'Mojolicious'          => 9.34,
-	'Net::SSLeay'          => 1.46,
 	'SQL::Abstract'        => 2.000000
 );
 
-my ($test_programs, $test_modules, $show_help);
-my $test_all = 1;
+my @programList = qw(
+	convert
+	curl
+	mkdir
+	mv
+	mysql
+	mysqldump
+	node
+	npm
+	tar
+	git
+	gzip
+	latex
+	latex2pdf
+	pandoc
+	dvipng
+);
+
+my ($test_modules, $test_programs, $show_help);
 
 GetOptions(
 	'm|modules'  => \$test_modules,
 	'p|programs' => \$test_programs,
-	'A|all'      => \$test_all,
 	'h|help'     => \$show_help,
 );
 pod2usage(2) if $show_help;
 
+$test_modules = $test_programs = 1 unless $test_programs || $test_modules;
+
 my @PATH = split(/:/, $ENV{PATH});
 
-if ($test_all or $test_programs) {
-	check_apps(@applicationsList);
-}
-
-if ($test_all or $test_modules) {
-	check_modules(@modulesList);
-}
-
-sub check_apps {
-	my @applicationsList = @_;
-	print "\nChecking your \$PATH for executables required by WeBWorK...\n";
-	print "\$PATH=";
-	print join("\n", map("      $_", @PATH)), "\n\n";
-
-	foreach my $app (@applicationsList) {
-		my $found = which($app);
-		if ($found) {
-			print "   $app found at $found\n";
-		} else {
-			print "** $app not found in \$PATH\n";
-		}
-	}
-
-	## Check that the node version is sufficient.
-	my $node_version_str = qx/node -v/;
-	my ($node_version) = $node_version_str =~ m/v(\d+)\./;
-
-	print "\n\n**The version of node should be at least 16.  You have version $node_version"
-		if ($node_version < 16);
-}
+check_modules() if $test_modules;
+say ''          if $test_modules && $test_programs;
+check_apps()    if $test_programs;
 
 sub which {
-	my $app = shift;
-	foreach my $path (@PATH) {
-		return "$path/$app" if -e "$path/$app";
+	my $program = shift;
+	for my $path (@PATH) {
+		return "$path/$program" if -e "$path/$program";
 	}
+	return;
 }
 
 sub check_modules {
-	my @modulesList = @_;
+	say "Checking for modules required by WeBWorK...";
 
-	print "\nChecking your \@INC for modules required by WeBWorK...\n";
-	my @inc = @INC;
-	print "\@INC=";
-	print join("\n", map("     $_", @inc)), "\n\n";
+	my $moduleNotFound = 0;
 
-	no strict 'refs';
+	my $checkModule = sub {
+		my $module = shift;
 
-	foreach my $module (@modulesList) {
+		no strict 'refs';
 		eval "use $module";
 		if ($@) {
-			my $file = $module;
-			$file =~ s|::|/|g;
-			$file .= ".pm";
+			$moduleNotFound = 1;
+			my $file = ($module =~ s|::|/|gr) . '.pm';
 			if ($@ =~ /Can't locate $file in \@INC/) {
-				print "** $module not found in \@INC\n";
+				say "** $module not found in \@INC";
 			} else {
-				print "** $module found, but failed to load: $@";
+				say "** $module found, but failed to load: $@";
 			}
 		} elsif (defined($moduleVersion{$module})
 			&& version->parse(${ $module . '::VERSION' }) < version->parse($moduleVersion{$module}))
 		{
-			print "** $module found, but not version $moduleVersion{$module} or better\n";
+			$moduleNotFound = 1;
+			say "** $module found, but not version $moduleVersion{$module} or better";
 		} else {
-			print "   $module found and loaded\n";
+			say "   $module found and loaded";
+		}
+		use strict 'refs';
+	};
+
+	for my $module (@modulesList) {
+		$checkModule->($module);
+	}
+
+	if ($moduleNotFound) {
+		say '';
+		say 'Some requred modules were not found, could not be loaded, or were not at the sufficient version.';
+		say 'Exiting as this is required to check the database driver and programs.';
+		exit 0;
+	}
+
+	say '';
+	say 'Checking for the database driver required by WeBWorK...';
+	my $ce     = loadCourseEnvironment();
+	my $driver = $ce->{database_driver} =~ /^mysql$/i ? 'DBD::mysql' : 'DBD::MariaDB';
+	say "Configured to use $driver in site.conf";
+	$checkModule->($driver);
+
+	return;
+}
+
+sub check_apps {
+	my $ce = loadCourseEnvironment();
+
+	say 'Checking external programs required by WeBWorK...';
+
+	push(@programList, $ce->{pg}{specialPGEnvironmentVars}{latexImageSVGMethod});
+
+	for my $program (@programList) {
+		if ($ce->{externalPrograms}{$program}) {
+			# Remove command line arguments (for latex and latex2pdf).
+			my $executable = $ce->{externalPrograms}{$program} =~ s/ .*$//gr;
+			if (-e $executable) {
+				say "   $executable found for $program";
+			} else {
+				say "** $executable not found for $program";
+			}
+		} else {
+			my $found = which($program);
+			if ($found) {
+				say "   $found found for $program";
+			} else {
+				say "** $program not found in \$PATH";
+			}
 		}
 	}
+
+	# Check that the node version is sufficient.
+	my $node_version_str = qx/node -v/;
+	my ($node_version) = $node_version_str =~ m/v(\d+)\./;
+
+	say "\n**The version of node should be at least 18.  You have version $node_version."
+		if $node_version < 18;
+
+	return;
+}
+
+sub loadCourseEnvironment {
+	eval 'require Mojo::File';
+	die "Unable to load Mojo::File: $@" if $@;
+	my $webworkRoot = Mojo::File->curfile->dirname->dirname;
+	push @INC, "$webworkRoot/lib";
+	eval 'require WeBWorK::CourseEnvironment';
+	die "Unable to load WeBWorK::CourseEnvironment: $@" if $@;
+	return WeBWorK::CourseEnvironment->new({ webwork_dir => $webworkRoot });
 }
 
 1;


### PR DESCRIPTION
The script now uses the settings in the course environment for external programs and to check the database driver (DBD::mysql or DBD::MariaDB). In order for that to work, first the script checks that all of the needed modules are found, load, and are at the sufficient version. That is except for the database driver module.  If any are not found, then the script exits with a message stating that it is unable to continue without the required modules.

If all modules are good, then the script checks the database driver module next. For this it "runtime" loads the course environment and its dependencies (as well as a runtime detection of the webwork2 root and lib directories).

This is to address issue #2740.

In addition the following modules are removed that are no longer needed:

* Array::Utils
* Email::Sender::Simple - still used but is a dependency of Email::Stuffer and doesn't need to be checked separately
* HTML::Tagset
* HTML::Template
* IO::Socket::SSL
* Net::LDAPS
* Net::SMPT
* Net::SSLeay
* PadWalker
* Path::Class
* Safe - we use our local version (WWSafe.pm) and still check Opcode which it uses
* Statistics::R::IO
* Template

`npm` is added to the list of required applications.

Most of these things were noted in issue #1917.