### PR TITLE
Add back the "real" upload check.

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -108,6 +108,9 @@ async sub dispatch ($c) {
 	my @uploads = @{ $c->req->uploads };
 
 	for my $u (@uploads) {
+		# Make sure it's a "real" upload.
+		next unless $u->filename;
+
 		# Store the upload.
 		my $upload = WeBWorK::Upload->store($u, $ce->{webworkDirs}{uploadCache});
 


### PR DESCRIPTION
This was removed when the uploads were reworked, but I see now that it should not have been.  Without this a warning about the empty string not being a valid upload occurs if there is not an upload.