### PR TITLE
give hints about password fallback

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -235,6 +235,24 @@ $mail{feedbackRecipients}    = [
 #$permissionLevels{record_answers_when_acting_as_student} = "professor";
 
 ################################################################################
+# Initial password fallback
+################################################################################
+
+# This sets the default fallback source to use for a user's password when a user
+# account is created in a course. That is the source that will be shown by
+# default in a select menu in the user interface, and the source that will be
+# used by the importClassList.pl and addcourse scripts.  It can be one of
+# 'user_id', 'first_name', 'last_name', or 'student_id', or can be set to '' (or
+# anything not listed before).  If a user is created and no password is
+# explicitly provided, then this source will used for the password (assuming
+# that source value is also set).  If this is not one of the allowed sources,
+# and if a password is not explicitly provided, then the user will be created
+# without a password and will not be able to sign in with username and password.
+# Note that this is only used at the time that a user is initially created in a
+# course, and not when editing passwords at a later time.
+#$fallback_password_source = 'student_id';
+
+################################################################################
 # Default settings for the problem editor pages
 ################################################################################
 
@@ -513,6 +531,7 @@ $mail{feedbackRecipients}    = [
 
 #include("conf/authen_shibboleth.conf");
 
+################################################################################
 # Saml2 Authentication
 ################################################################################
 # Uncomment the following line to enable authentication via a Saml2 identity

--- a/htdocs/js/AddUsers/add-users.js
+++ b/htdocs/js/AddUsers/add-users.js
@@ -1,0 +1,16 @@
+(() => {
+	const passwordSelect = document.getElementById('fallback_password_source');
+
+	const setPlaceholders = () => {
+		for (const input of document.querySelectorAll('.new_password')) {
+			let placeholder = 'placeholder';
+			for (const part of passwordSelect.value.split('_')) {
+				placeholder += part.charAt(0).toUpperCase() + part.slice(1);
+			}
+			input.setAttribute('placeholder', passwordSelect.dataset[placeholder]);
+		}
+	};
+
+	passwordSelect.addEventListener('change', setPlaceholders);
+	setPlaceholders();
+})();

--- a/templates/ContentGenerator/Instructor/AddUsers.html.ep
+++ b/templates/ContentGenerator/Instructor/AddUsers.html.ep
@@ -1,4 +1,5 @@
 % use WeBWorK::Utils::Sets qw(format_set_name_display);
+% use WeBWorK::Utils qw(getAssetURL);
 %
 % unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
 	<div class="alert alert-danger p-1 mb-0">
@@ -12,6 +13,9 @@
 	% last;
 % }
 %
+% content_for js => begin
+    <%= javascript getAssetURL($ce, 'js/AddUsers/add-users.js'), defer => undef =%>
+% end
 <p><%= defined $c->{studentEntryReport} ? $c->{studentEntryReport}->join('') : '' %></p>
 <p><%= maketext('Enter information below for students you wish to add.') =%></p>
 %
@@ -56,12 +60,19 @@
 				<% end =%>
 		<% end =%>
 		<%= select_field fallback_password_source => [
-				[ 'None'       => '',           $default eq ''           ? (selected => undef) : () ],
-				[ 'Login Name' => 'user_id',    $default eq 'user_id'    ? (selected => undef) : () ],
-				[ 'First Name' => 'first_name', $default eq 'first_name' ? (selected => undef) : () ],
-				[ 'Last Name'  => 'last_name',  $default eq 'last_name'  ? (selected => undef) : () ],
-				[ 'Student ID' => 'student_id', $default eq 'student_id' ? (selected => undef) : () ]
+				[ maketext('None')       => '',           $default eq ''           ? (selected => undef) : () ],
+				[ maketext('Login Name') => 'user_id',    $default eq 'user_id'    ? (selected => undef) : () ],
+				[ maketext('First Name') => 'first_name', $default eq 'first_name' ? (selected => undef) : () ],
+				[ maketext('Last Name')  => 'last_name',  $default eq 'last_name'  ? (selected => undef) : () ],
+				[ maketext('Student ID') => 'student_id', $default eq 'student_id' ? (selected => undef) : () ]
 			],
+			data => {
+				placeholder            => maketext('No password'),
+				placeholder_user_id    => maketext('Use login name'),
+				placeholder_first_name => maketext('Use first name'),
+				placeholder_last_name  => maketext('Use last name'),
+				placeholder_student_id => maketext('Use student ID')
+			},
 			id => 'fallback_password_source', class => 'form-select w-auto flex-grow-0' =%>
 	</div>
 
@@ -141,7 +152,7 @@
 						<td>
 							% param("password_$_", undef);
 							<%= text_field "password_$_" => '', size => '16', 'aria-labelledby' => 'password_header',
-							class => 'form-control form-control-sm w-auto' =%>
+							class => 'form-control form-control-sm w-auto new_password' =%>
 						</td>
 					</tr>
 				% }


### PR DESCRIPTION
This makes it so when you go to add users, the password fields have placeholder text that indicates what the fallback will be.