### PR TITLE
Show Deprecated macros warning in PG editor and library Browser

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -512,6 +512,17 @@
 						container.innerHTML = data.pg_flags.comment;
 						iframe.after(container);
 					}
+					if (data.deprecated_macros?.length) {
+						const container = document.createElement('div');
+						container.classList.add('alert', 'alert-danger', 'mx-2');
+						container.innerHTML =
+							'Warning!! This problem uses the following deprecated macros:' +
+							'<ul class="mb-0">' +
+							data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
+							'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+							'If this is a custom problem, please update the problem to use modern macros.';
+						iframe.after(container);
+					}
 
 					iframe.addEventListener(
 						'load',

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -514,13 +514,13 @@
 					}
 					if (data.deprecated_macros?.length) {
 						const container = document.createElement('div');
-						container.classList.add('alert', 'alert-danger', 'mx-2');
+						container.classList.add('alert', 'alert-danger', 'mx-2', 'p-2');
 						container.innerHTML =
-							'<p>Warning!! This problem uses the following deprecated macros:</p>' +
-							'<ul class="mb-0">' +
+							'Warning!! This problem uses the following deprecated macros:' +
+							'<ul class="my-1">' +
 							data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-							'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
-							'If this is a custom problem, please update the problem to use modern macros.</p>';
+							'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+							'If this is a custom problem, please update the problem to use modern macros.';
 						iframe.after(container);
 					}
 

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -516,11 +516,11 @@
 						const container = document.createElement('div');
 						container.classList.add('alert', 'alert-danger', 'mx-2');
 						container.innerHTML =
-							'Warning!! This problem uses the following deprecated macros:' +
+							'<p>Warning!! This problem uses the following deprecated macros:</p>' +
 							'<ul class="mb-0">' +
 							data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-							'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
-							'If this is a custom problem, please update the problem to use modern macros.';
+							'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
+							'If this is a custom problem, please update the problem to use modern macros.</p>';
 						iframe.after(container);
 					}
 

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -77,6 +77,17 @@
 							container.innerHTML = data.pg_flags.comment;
 							iframe.after(container);
 						}
+						if (data.deprecated_macros?.length) {
+							const container = document.createElement('div');
+							container.classList.add('alert', 'alert-danger');
+							container.innerHTML =
+								'Warning!! This problem uses the following deprecated macros:' +
+								'<ul class="mb-0">' +
+								data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
+								'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+								'If this is a custom problem, please update the problem to use modern macros.';
+							iframe.after(container);
+						}
 						iFrameResize(
 							{
 								checkOrigin: false,

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -79,13 +79,13 @@
 						}
 						if (data.deprecated_macros?.length) {
 							const container = document.createElement('div');
-							container.classList.add('alert', 'alert-danger');
+							container.classList.add('alert', 'alert-danger', 'p-2');
 							container.innerHTML =
-								'<p>Warning!! This problem uses the following deprecated macros:</p>' +
-								'<ul class="mb-0">' +
+								'Warning!! This problem uses the following deprecated macros:' +
+								'<ul class="my-1">' +
 								data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-								'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
-								'If this is a custom problem, please update the problem to use modern macros.</p>';
+								'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
+								'If this is a custom problem, please update the problem to use modern macros.';
 							iframe.after(container);
 						}
 						iFrameResize(

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -81,11 +81,11 @@
 							const container = document.createElement('div');
 							container.classList.add('alert', 'alert-danger');
 							container.innerHTML =
-								'Warning!! This problem uses the following deprecated macros:' +
+								'<p>Warning!! This problem uses the following deprecated macros:</p>' +
 								'<ul class="mb-0">' +
 								data.deprecated_macros.reduce((acc, item) => `${acc}<li>${item}</li>`, '') +
-								'</ul>If this is an OPL problem, please report this issue to the OPL. ' +
-								'If this is a custom problem, please update the problem to use modern macros.';
+								'</ul><p>If this is an OPL problem, please report this issue to the OPL. ' +
+								'If this is a custom problem, please update the problem to use modern macros.</p>';
 							iframe.after(container);
 						}
 						iFrameResize(

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -286,7 +286,12 @@ sub formatRenderedProblem {
 
 	return $ws->c->render(%template_params) if $formatName eq 'json' || !$ws->{inputs_ref}{send_pg_flags};
 	return $ws->c->render(
-		json => { html => $ws->c->render_to_string(%template_params)->to_string, pg_flags => $rh_result->{flags} });
+		json => {
+			html              => $ws->c->render_to_string(%template_params)->to_string,
+			pg_flags          => $rh_result->{flags},
+			deprecated_macros => $rh_result->{deprecated_macros}
+		}
+	);
 }
 
 sub saveGradeToLTI {

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -268,11 +268,18 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 			flags            => $pg->{flags},
 		};
 
+		# get a list of the deprecated macros
+		my @deprecated_macros;
+		for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
+			my @dirs = split('/', $_);
+			push(@deprecated_macros, $dirs[$#dirs]) if $dirs[ $#dirs - 1 ] eq 'deprecated';
+		}
+
 		if (ref($pg->{pgcore}) eq 'PGcore') {
 			$ret->{internal_debug_messages} = $pg->{pgcore}->get_internal_debug_messages;
 			$ret->{warning_messages}        = $pg->{pgcore}->get_warning_messages();
 			$ret->{debug_messages}          = $pg->{pgcore}->get_debug_messages();
-			$ret->{deprecated_macros}       = $pg->{pgcore}{PG_loadMacros}{deprecated_macros};
+			$ret->{deprecated_macros}       = \@deprecated_macros;
 			$ret->{PG_ANSWERS_HASH}         = {
 				map {
 					$_ => {

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -272,6 +272,7 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 			$ret->{internal_debug_messages} = $pg->{pgcore}->get_internal_debug_messages;
 			$ret->{warning_messages}        = $pg->{pgcore}->get_warning_messages();
 			$ret->{debug_messages}          = $pg->{pgcore}->get_debug_messages();
+			$ret->{deprecated_macros}       = $pg->{pgcore}{PG_loadMacros}{deprecated_macros};
 			$ret->{PG_ANSWERS_HASH}         = {
 				map {
 					$_ => {

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -272,7 +272,7 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 		my @deprecated_macros;
 		for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
 			my @dirs = split('/', $_);
-			push(@deprecated_macros, $dirs[$#dirs]) if $dirs[ $#dirs - 1 ] eq 'deprecated';
+			push(@deprecated_macros, $dirs[-1]) if $dirs[-2] eq 'deprecated';
 		}
 
 		if (ref($pg->{pgcore}) eq 'PGcore') {

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -268,19 +268,12 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 			flags            => $pg->{flags},
 		};
 
-		# get a list of the deprecated macros
-		my @deprecated_macros;
-		for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
-			my @dirs = split('/', $_);
-			push(@deprecated_macros, $dirs[-1]) if $dirs[-2] eq 'deprecated';
-		}
-
 		if (ref($pg->{pgcore}) eq 'PGcore') {
 			$ret->{internal_debug_messages} = $pg->{pgcore}->get_internal_debug_messages;
 			$ret->{warning_messages}        = $pg->{pgcore}->get_warning_messages();
 			$ret->{debug_messages}          = $pg->{pgcore}->get_debug_messages();
-			$ret->{deprecated_macros}       = \@deprecated_macros;
-			$ret->{PG_ANSWERS_HASH}         = {
+
+			$ret->{PG_ANSWERS_HASH} = {
 				map {
 					$_ => {
 						response_obj => unbless($pg->{pgcore}{PG_ANSWERS_HASH}{$_}->response_obj),
@@ -294,6 +287,14 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 					keys %{ $pg->{pgcore}{PG_alias}{resource_list} }
 			};
 			$ret->{PERSISTENCE_HASH} = $pg->{pgcore}{PERSISTENCE_HASH};
+
+			# Get a list of the deprecated macros used in the problem.
+			my @deprecated_macros;
+			for (keys %{ $pg->{pgcore}{PG_loadMacros}{macroFileList} }) {
+				my @dirs = split('/', $_);
+				push(@deprecated_macros, $dirs[-1]) if $dirs[-2] eq 'deprecated';
+			}
+			$ret->{deprecated_macros} = \@deprecated_macros;
 		}
 
 		# Save the problem source. This is used by Caliper::Entity. Why?

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -279,8 +279,9 @@ async sub renderProblem {
 		psvn                    => $psvn,
 		problem_seed            => $problemSeed,
 		resource_list           => $pg->{resource_list},
-		warning_messages        => ref $pg->{warning_messages} eq 'ARRAY' ? $pg->{warning_messages} : [],
-		debug_messages          => ref $pg->{debug_messages} eq 'ARRAY'   ? $pg->{debug_messages}   : [],
+		warning_messages        => ref $pg->{warning_messages} eq 'ARRAY'  ? $pg->{warning_messages}  : [],
+		debug_messages          => ref $pg->{debug_messages} eq 'ARRAY'    ? $pg->{debug_messages}    : [],
+		deprecated_macros       => ref $pg->{deprecated_macros} eq 'ARRAY' ? $pg->{deprecated_macros} : [],
 		internal_debug_messages => ref $pg->{internal_debug_messages} eq 'ARRAY'
 		? $pg->{internal_debug_messages}
 		: [],


### PR DESCRIPTION
This uses code from @somiaj to take the list of deprecated macros in the PG object and display only for instructors in the PGeditor and library browser.  

Note: this needs openwebwork/pg#1256.