### PR TITLE
Update the pg codemirror editor dependency to pull in quote like fat comma fix.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^6.5.2",
-				"@openwebwork/pg-codemirror-editor": "^0.0.4",
+				"@openwebwork/pg-codemirror-editor": "^0.0.5",
 				"bootstrap": "~5.3.3",
 				"flatpickr": "^4.6.13",
 				"iframe-resizer": "^4.3.11",
@@ -86,9 +86,9 @@
 			}
 		},
 		"node_modules/@codemirror/lang-javascript": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
-			"integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -115,9 +115,9 @@
 			}
 		},
 		"node_modules/@codemirror/language": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
-			"integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
+			"integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -140,9 +140,9 @@
 			}
 		},
 		"node_modules/@codemirror/search": {
-			"version": "6.5.10",
-			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
-			"integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
+			"version": "6.5.11",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -160,9 +160,9 @@
 			}
 		},
 		"node_modules/@codemirror/theme-one-dark": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
-			"integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+			"integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -172,12 +172,13 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.36.7",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.7.tgz",
-			"integrity": "sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==",
+			"version": "6.37.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.2.tgz",
+			"integrity": "sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
@@ -256,14 +257,14 @@
 			"license": "MIT"
 		},
 		"node_modules/@lezer/css": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.11.tgz",
-			"integrity": "sha512-FuAnusbLBl1SEAtfN8NdShxYJiESKw9LAFysfea1T96jD3ydBn12oYjaSG1a04BQRIUd93/0D8e5CV1cUMkmQg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.2.1.tgz",
+			"integrity": "sha512-2F5tOqzKEKbCUNraIXc0f6HKeyKlmMWJnBB0i4XW6dJgssrZO/YlZ2pY5xgyqDleqqhiNJ3dQhbrV2aClZQMvg==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0"
+				"@lezer/lr": "^1.3.0"
 			}
 		},
 		"node_modules/@lezer/highlight": {
@@ -324,9 +325,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.2.tgz",
-			"integrity": "sha512-xnipB2bydjDbcRVO9XpFNkhI9muoA6FzPqx6gRxQk10cXj8nzOn694gl7ATpn/xn5J5Y+7YpFAFTDqs0atgI6g==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.3.tgz",
+			"integrity": "sha512-ZKtb2r0Ck6tVz44wwMKY7w/82P470whIzM5C8pi2GiBlnFWmkQcadmOaCBz31FELY1SrKE3AO2TmMrwUt2EKPA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.11.0",
@@ -335,15 +336,15 @@
 			}
 		},
 		"node_modules/@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.4.tgz",
-			"integrity": "sha512-aJ3/AmKc1Ck/6zKctETP29QnuKn4PHIWhEZNdCzi49zAI+Ls2wH0JQdPadoj3z4savAxhabsdYOu8WWV7vwx5g==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.5.tgz",
+			"integrity": "sha512-ue4aciJzF7PPdQwWvYQkSf7h3pqOSM21fXyQ1vXRNndiQ7TCNX6FBI5JalMWDzi7CttGR+Mj+PgffmADwmKIMg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-html": "^6.4.9",
 				"@codemirror/lang-xml": "^6.1.0",
 				"@codemirror/theme-one-dark": "^6.1.2",
-				"@openwebwork/codemirror-lang-pg": "^0.0.2",
+				"@openwebwork/codemirror-lang-pg": "^0.0.3",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -355,8 +356,8 @@
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
 				"codemirror": "^6.0.1",
-				"codemirror-lang-mt": "^0.0.2",
-				"codemirror-lang-perl": "^0.1.5",
+				"codemirror-lang-mt": "^0.0.3",
+				"codemirror-lang-perl": "^0.1.6",
 				"style-mod": "^4.1.2",
 				"thememirror": "^2.0.1"
 			}
@@ -743,9 +744,9 @@
 			}
 		},
 		"node_modules/codemirror": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
-			"integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+			"integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -758,9 +759,9 @@
 			}
 		},
 		"node_modules/codemirror-lang-mt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2.tgz",
-			"integrity": "sha512-m2q+EVgNeDxq3A8gCnoUGZvTuXvvZKlZliiqif4VAMPiu7dKJsaopvXZo8S1KH6cb2x9fJuKr5yUTnkxSLQZIQ==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.3.tgz",
+			"integrity": "sha512-OC2qG6GQI96BTgKzD4XVJd8fLOTyeB0pb7gy41BHjqot2gES6Bi/3esIgTygYUxw/SspMNSZnQZdWHPmD7/YYA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-css": "^6.3.1",
@@ -772,9 +773,9 @@
 			}
 		},
 		"node_modules/codemirror-lang-perl": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5.tgz",
-			"integrity": "sha512-o0QBzsO4z+ZWaN7ueYnFVYWoFlFvvfgcgNA/dQLxYUDiKGSUY0R52UL/NqTO6swUVrR+O6JI3Xh1j/ed81JIwA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.6.tgz",
+			"integrity": "sha512-cYBmCQa7/itIRNx1AHfn9OQkInJQpL0sqCoikJXhQZwYNOHFSMd0L16pofEOU/1/f+s7CPA+XucUrNr/f1qigQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.11.0",
@@ -2189,9 +2190,9 @@
 			}
 		},
 		"@codemirror/lang-javascript": {
-			"version": "6.2.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.3.tgz",
-			"integrity": "sha512-8PR3vIWg7pSu7ur8A07pGiYHgy3hHj+mRYRCSG8q+mPIrl0F02rgpGv+DsQTHRTc30rydOsf5PZ7yjKFg2Ackw==",
+			"version": "6.2.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
+			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.6.0",
@@ -2216,9 +2217,9 @@
 			}
 		},
 		"@codemirror/language": {
-			"version": "6.11.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.0.tgz",
-			"integrity": "sha512-A7+f++LodNNc1wGgoRDTt78cOwWm9KVezApgjOMp1W4hM0898nsqBXwF+sbePE7ZRcjN7Sa1Z5m2oN27XkmEjQ==",
+			"version": "6.11.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
+			"integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -2239,9 +2240,9 @@
 			}
 		},
 		"@codemirror/search": {
-			"version": "6.5.10",
-			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.10.tgz",
-			"integrity": "sha512-RMdPdmsrUf53pb2VwflKGHEe1XVM07hI7vV2ntgw1dmqhimpatSJKva4VA9h4TLUDOD4EIF02201oZurpnEFsg==",
+			"version": "6.5.11",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
+			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
@@ -2257,9 +2258,9 @@
 			}
 		},
 		"@codemirror/theme-one-dark": {
-			"version": "6.1.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.2.tgz",
-			"integrity": "sha512-F+sH0X16j/qFLMAfbciKTxVOwkdAS336b7AXTKOZhy8BR3eH/RelsnLgLFINrpST63mmN2OuwUt0W2ndUgYwUA==",
+			"version": "6.1.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+			"integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2268,11 +2269,12 @@
 			}
 		},
 		"@codemirror/view": {
-			"version": "6.36.7",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.36.7.tgz",
-			"integrity": "sha512-kCWGW/chWGPgZqfZ36Um9Iz0X2IVpmCjg1P/qY6B6a2ecXtWRRAigmpJ6YgUQ5lTWXMyyVdfmpzhLZmsZQMbtg==",
+			"version": "6.37.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.2.tgz",
+			"integrity": "sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==",
 			"requires": {
 				"@codemirror/state": "^6.5.0",
+				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
@@ -2337,13 +2339,13 @@
 			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
 		},
 		"@lezer/css": {
-			"version": "1.1.11",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.1.11.tgz",
-			"integrity": "sha512-FuAnusbLBl1SEAtfN8NdShxYJiESKw9LAFysfea1T96jD3ydBn12oYjaSG1a04BQRIUd93/0D8e5CV1cUMkmQg==",
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.2.1.tgz",
+			"integrity": "sha512-2F5tOqzKEKbCUNraIXc0f6HKeyKlmMWJnBB0i4XW6dJgssrZO/YlZ2pY5xgyqDleqqhiNJ3dQhbrV2aClZQMvg==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
-				"@lezer/lr": "^1.0.0"
+				"@lezer/lr": "^1.3.0"
 			}
 		},
 		"@lezer/highlight": {
@@ -2398,9 +2400,9 @@
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
 		},
 		"@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.2.tgz",
-			"integrity": "sha512-xnipB2bydjDbcRVO9XpFNkhI9muoA6FzPqx6gRxQk10cXj8nzOn694gl7ATpn/xn5J5Y+7YpFAFTDqs0atgI6g==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.3.tgz",
+			"integrity": "sha512-ZKtb2r0Ck6tVz44wwMKY7w/82P470whIzM5C8pi2GiBlnFWmkQcadmOaCBz31FELY1SrKE3AO2TmMrwUt2EKPA==",
 			"requires": {
 				"@codemirror/language": "^6.11.0",
 				"@lezer/highlight": "^1.2.1",
@@ -2408,14 +2410,14 @@
 			}
 		},
 		"@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.4.tgz",
-			"integrity": "sha512-aJ3/AmKc1Ck/6zKctETP29QnuKn4PHIWhEZNdCzi49zAI+Ls2wH0JQdPadoj3z4savAxhabsdYOu8WWV7vwx5g==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.5.tgz",
+			"integrity": "sha512-ue4aciJzF7PPdQwWvYQkSf7h3pqOSM21fXyQ1vXRNndiQ7TCNX6FBI5JalMWDzi7CttGR+Mj+PgffmADwmKIMg==",
 			"requires": {
 				"@codemirror/lang-html": "^6.4.9",
 				"@codemirror/lang-xml": "^6.1.0",
 				"@codemirror/theme-one-dark": "^6.1.2",
-				"@openwebwork/codemirror-lang-pg": "^0.0.2",
+				"@openwebwork/codemirror-lang-pg": "^0.0.3",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -2427,8 +2429,8 @@
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
 				"codemirror": "^6.0.1",
-				"codemirror-lang-mt": "^0.0.2",
-				"codemirror-lang-perl": "^0.1.5",
+				"codemirror-lang-mt": "^0.0.3",
+				"codemirror-lang-perl": "^0.1.6",
 				"style-mod": "^4.1.2",
 				"thememirror": "^2.0.1"
 			}
@@ -2641,9 +2643,9 @@
 			"requires": {}
 		},
 		"codemirror": {
-			"version": "6.0.1",
-			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.1.tgz",
-			"integrity": "sha512-J8j+nZ+CdWmIeFIGXEFbFPtpiYacFMDR8GlHK3IyHQJMCaVRfGx9NT+Hxivv1ckLWPvNdZqndbr/7lVhrf/Svg==",
+			"version": "6.0.2",
+			"resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+			"integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/commands": "^6.0.0",
@@ -2655,9 +2657,9 @@
 			}
 		},
 		"codemirror-lang-mt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.2.tgz",
-			"integrity": "sha512-m2q+EVgNeDxq3A8gCnoUGZvTuXvvZKlZliiqif4VAMPiu7dKJsaopvXZo8S1KH6cb2x9fJuKr5yUTnkxSLQZIQ==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.3.tgz",
+			"integrity": "sha512-OC2qG6GQI96BTgKzD4XVJd8fLOTyeB0pb7gy41BHjqot2gES6Bi/3esIgTygYUxw/SspMNSZnQZdWHPmD7/YYA==",
 			"requires": {
 				"@codemirror/lang-css": "^6.3.1",
 				"@codemirror/lang-html": "^6.4.9",
@@ -2668,9 +2670,9 @@
 			}
 		},
 		"codemirror-lang-perl": {
-			"version": "0.1.5",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.5.tgz",
-			"integrity": "sha512-o0QBzsO4z+ZWaN7ueYnFVYWoFlFvvfgcgNA/dQLxYUDiKGSUY0R52UL/NqTO6swUVrR+O6JI3Xh1j/ed81JIwA==",
+			"version": "0.1.6",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.6.tgz",
+			"integrity": "sha512-cYBmCQa7/itIRNx1AHfn9OQkInJQpL0sqCoikJXhQZwYNOHFSMd0L16pofEOU/1/f+s7CPA+XucUrNr/f1qigQ==",
 			"requires": {
 				"@codemirror/language": "^6.11.0",
 				"@lezer/highlight": "^1.2.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^6.5.2",
-		"@openwebwork/pg-codemirror-editor": "^0.0.4",
+		"@openwebwork/pg-codemirror-editor": "^0.0.5",
 		"bootstrap": "~5.3.3",
 		"flatpickr": "^4.6.13",
 		"iframe-resizer": "^4.3.11",


### PR DESCRIPTION
This fixes issue #2739.

Prior to this pull request something like `my $a = { y => 1, b => 2, c => 3 };` would have syntax highlighting issues because it was being recognized as the transliteration `y=>1,b=>2,c=` with the quote like delimiters being the equality symbol.

This is not exclusive to the `y` transliteration operator.  The same could happen with any of the quote like operators (`q`, `qq`, `tr`, etc.).  For example, `my $a = { q => 1, b => 3 };` had the same problem. It would be recognized as the single quoted string `q=>1,b=` with the equality symbol again being the quote like start and end delimiter.

Of course with this pull request the `=>` is properly recognized as a fat comma.