### PR TITLE
Move LTI login JavaScript out of html template

### DIFF
--- a/htdocs/js/LTILogin/ltilogin.js
+++ b/htdocs/js/LTILogin/ltilogin.js
@@ -1,0 +1,1 @@
+document.getElementById('ltiRepost')?.submit();

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -36,7 +36,6 @@
 % end
 %
 % content_for js => begin
-	% # Page specfific javascript
 	<%= javascript getAssetURL($ce, 'js/GatewayQuiz/gateway.js'), defer => undef =%>
 	%
 	% # Output javascript for jquery-ui for problems to use.

--- a/templates/ContentGenerator/LTI/self_posting_form.html.ep
+++ b/templates/ContentGenerator/LTI/self_posting_form.html.ep
@@ -1,9 +1,8 @@
+<%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'js/LTILogin/ltilogin.js' }),
+        defer => undef =%>
 <%= form_for $form_target, method => 'POST', enctype => 'application/x-www-form-urlencoded',
 	name => 'ltiRepost', id => 'ltiRepost', begin =%>
 	% for (keys %$form_params) {
 		<%= hidden_field $_ => $form_params->{$_} =%>
 	% }
-<% end =%>
-<%= javascript begin =%>
-	document.ltiRepost.submit();
 <% end =%>


### PR DESCRIPTION
I am trying to move JavaScript out of the the HTML files, in order to allow the core WW2 functionality to work with a Content-Security-Policy which does not require `script-src` to include `unsafe-inline` and without a need to add specific hash values to get mission-critical JavaScript functionality to work.

I am aware that several advanced features of PG will currently not work with such a CSP.

This PR allows the LTI 1.3 login process to work without needing either `unsafe-inline` or the relevant hash value in the CSP.

~~One small typo I noticed in an unrelated file was corrected.~~

A unneeeded comment with a type in an unrelated file was deleted.

These same changes were tested on my production WW 2.19 server