### PR TITLE
Fix a potential XSS vulnerability in the past answers table (the Answer Log).

### DIFF
--- a/templates/ContentGenerator/Instructor/ShowAnswers/past-answers-table.html.ep
+++ b/templates/ContentGenerator/Instructor/ShowAnswers/past-answers-table.html.ep
@@ -53,7 +53,11 @@
 									% if ($answer eq '') {
 										<small><i><%= maketext('empty') %></i></small>
 									% } else {
-										<%== $answer =%>
+										% my @parts = split("&#9070;", $answer);
+										% for (0 .. $#parts - 1) {
+											<%= $parts[$_] =%>&#9070;\
+										% }
+										<%= $parts[-1] =%>
 									% }
 								</td>
 							% }


### PR DESCRIPTION
If MathQuill is enabled and a student types `"<script>alert(1);</script>` and submits the answer, then that script is executed if an instructor views the answer on the past answers page.  If MathQuill is not enabled, and a student simply enters `<script>alert(1);</script>` the same thing happens.

This is due to a change in #1899 to make the special character `&#1970;` used to separate array answers (usually coming from checkbox answers) display correctly.

To fix this better handling of answers with that character is needed. So this splits the student answers on that character, and now DOES html escape all other parts of the student answer again, but directly inserts the `&#9070` characters without escaping. The effect is that answers will still be displayed the same as they were before other than scripts in the answer. Those will now actually appear as text. Note that is the same as it would have been before #1899.