### PR TITLE
record/update user lis_source_did even when grade passback not in use

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -326,11 +326,9 @@ sub authenticate ($self) {
 		$self->{initial_login} = 1;
 	}
 
-	# If we are using grade passback then make sure the data we need to submit the grade is kept up to date.
-	my $LTIGradeMode = $ce->{LTIGradeMode} // '';
-	if ($LTIGradeMode eq 'course' || $LTIGradeMode eq 'homework') {
-		WeBWorK::Authen::LTIAdvantage::SubmitGrade->new($c)->update_passback_data($self->{user_id});
-	}
+	# In case we will use grade passback at some point,
+	# make sure the data we need to submit the grade is kept up to date.
+	WeBWorK::Authen::LTIAdvantage::SubmitGrade->new($c)->update_passback_data($self->{user_id});
 
 	return 1;
 }

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -70,6 +70,8 @@ sub update_passback_data ($self, $userID) {
 		$self->warning('Missing LMS user id (sub) in JWT.');
 	}
 
+	return unless $ce->{LTIGradeMode};
+
 	# The lti_lms_lineitem is the url to post grades to.  It was the 'lineitem' key of the
 	# 'https://purl.imsglobal.org/spec/lti-ags/claim/endpoint' object in the JWT received from the LMS.
 	if ($ce->{LTIGradeMode} eq 'course') {


### PR DESCRIPTION
Just because a course has LTIGradeMode set to false, we should still record a user's lis_source_did in case LTIGradeMode gets toggled later. This has happened both at PCC and with Runestone instructors, and they don't understand why some students are not having grades passed back even when the instructor initiates an LTI Grade Update. If they understood what was going on, they would know they can wait until those students visit WeBWorK again from the LMS and things will be fine. But they usually don't understand that level of detail about this process.