### PR TITLE
Fix the session expired message in the problem editor.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -177,6 +177,8 @@
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
 			.then((data) => {
+				if (data.error) throw new Error(data.error);
+				if (!data.result_data) throw new Error('An invalid response was received.');
 				if (data.result_data.status) {
 					if (data.result_data.errors) {
 						renderArea.innerHTML =
@@ -219,6 +221,8 @@
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
 			.then((data) => {
+				if (data.error) throw new Error(data.error);
+				if (!data.result_data) throw new Error('An invalid response was received.');
 				if (request_object.pgCode === data.result_data.pgmlCode) {
 					showMessage('There were no changes to the code.', true);
 				} else {


### PR DESCRIPTION
Currently if the session has expired and one of the options in the "Format Code" tabe is used in the PG problem editor, then the message reads `Error: can't access property "status", t.result_data is undefined` which is not very informative. This makes it so that the error message in the response which is `Error: Authentication failed. Log in again to continue.`

An easy way to test this is to open a problem in the problem editor, delete the cookie for the session in the developer tools, and then switch to the "Format Code" tabe and click the "Format Code" button.