### PR TITLE
Add "PG Critic" to the PG problem editor.

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -88,6 +88,7 @@ my @modulesList = qw(
 	Net::OAuth
 	Opcode
 	Pandoc
+	Perl::Critic
 	Perl::Tidy
 	PHP::Serialization
 	Pod::Simple::Search

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -235,6 +235,30 @@
 			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));
 	};
 
+	// Send a request to the server to run the PG critic in the CodeMirror editor.
+	const runPGCritic = () => {
+		const request_object = { courseID: document.getElementsByName('courseID')[0]?.value };
+
+		const user = document.getElementsByName('user')[0];
+		if (user) request_object.user = user.value;
+		const sessionKey = document.getElementsByName('key')[0];
+		if (sessionKey) request_object.key = sessionKey.value;
+
+		request_object.rpc_command = 'runPGCritic';
+		request_object.pgCode =
+			webworkConfig?.pgCodeMirror?.source ?? document.getElementById('problemContents')?.value ?? '';
+
+		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
+			.then((response) => response.json())
+			.then((data) => {
+				renderArea.innerHTML = data.result_data.html;
+			})
+			.catch((err) => {
+				console.log(err);
+				showMessage(`Error: ${err?.message ?? err}`);
+			});
+	};
+
 	document.getElementById('take_action')?.addEventListener('click', async (e) => {
 		if (document.getElementById('current_action')?.value === 'format_code') {
 			e.preventDefault();
@@ -244,6 +268,8 @@
 				document.querySelector('input[name="action.format_code"]:checked').value == 'convertCodeToPGML'
 			) {
 				convertCodeToPGML();
+			} else if (document.querySelector('input[name="action.format_code"]:checked').value == 'runPGCritic') {
+				runPGCritic();
 			}
 			return;
 		}

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -161,6 +161,15 @@
 			?.addEventListener('change', () => (deleteBackupCheck.checked = true));
 	}
 
+	const renderArea = document.getElementById('pgedit-render-area');
+
+	const scrollToRenderArea = () => {
+		// Scroll to the top of the render window if the current scroll position is below that.
+		const renderAreaRect = renderArea.getBoundingClientRect();
+		const topBarHeight = document.querySelector('.webwork-logo')?.getBoundingClientRect().height ?? 0;
+		if (renderAreaRect.top < topBarHeight) window.scrollBy(0, renderAreaRect.top - topBarHeight);
+	};
+
 	// Send a request to the server to perltidy the current PG code in the CodeMirror editor.
 	const tidyPGCode = () => {
 		const request_object = { courseID: document.getElementsByName('courseID')[0]?.value };
@@ -251,24 +260,26 @@
 		fetch(webserviceURL, { method: 'post', mode: 'same-origin', body: new URLSearchParams(request_object) })
 			.then((response) => response.json())
 			.then((data) => {
+				if (data.error) throw new Error(data.error);
+				if (!data.result_data) throw new Error('An invalid response was received.');
 				renderArea.innerHTML = data.result_data.html;
+				scrollToRenderArea();
 			})
-			.catch((err) => {
-				console.log(err);
-				showMessage(`Error: ${err?.message ?? err}`);
-			});
+			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));
 	};
 
 	document.getElementById('take_action')?.addEventListener('click', async (e) => {
-		if (document.getElementById('current_action')?.value === 'format_code') {
+		if (document.getElementById('current_action')?.value === 'code_maintenance') {
 			e.preventDefault();
-			if (document.querySelector('input[name="action.format_code"]:checked').value == 'tidyPGCode') {
+			if (document.querySelector('input[name="action.code_maintenance"]:checked').value === 'tidyPGCode') {
 				tidyPGCode();
 			} else if (
-				document.querySelector('input[name="action.format_code"]:checked').value == 'convertCodeToPGML'
+				document.querySelector('input[name="action.code_maintenance"]:checked').value === 'convertCodeToPGML'
 			) {
 				convertCodeToPGML();
-			} else if (document.querySelector('input[name="action.format_code"]:checked').value == 'runPGCritic') {
+			} else if (
+				document.querySelector('input[name="action.code_maintenance"]:checked').value === 'runPGCritic'
+			) {
 				runPGCritic();
 			}
 			return;
@@ -332,7 +343,6 @@
 	});
 
 	const renderURL = `${webworkConfig?.webwork_url ?? '/webwork2'}/render_rpc`;
-	const renderArea = document.getElementById('pgedit-render-area');
 	const fileType = document.getElementsByName('file_type')[0]?.value;
 
 	// This is either the div containing the CodeMirror editor or the problemContents textarea in the case that
@@ -417,11 +427,7 @@
 		}
 
 		adjustIFrameHeight();
-
-		// Scroll to the top of the render window if the current scroll position is below that.
-		const renderAreaRect = renderArea.getBoundingClientRect();
-		const topBarHeight = document.querySelector('.webwork-logo')?.getBoundingClientRect().height ?? 0;
-		if (renderAreaRect.top < topBarHeight) window.scrollBy(0, renderAreaRect.top - topBarHeight);
+		scrollToRenderArea();
 	});
 
 	const render = () =>

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -90,7 +90,7 @@ the submit button pressed (the action).
     Requested actions and aliases
         View/Reload                action = view
         Generate Hardcopy:         action = hardcopy
-        Format Code:               action = format_code
+        Code Maintenance:          action = code_maintenance
         Save:                      action = save
         Save as:                   action = save_as
         Append:                    action = add_problem
@@ -118,15 +118,15 @@ use SampleProblemParser        qw(getSampleProblemCode generateMetadata);
 use constant DEFAULT_SEED => 123456;
 
 # Editor tabs
-use constant ACTION_FORMS => [qw(view hardcopy format_code save save_as add_problem revert)];
+use constant ACTION_FORMS => [qw(view hardcopy code_maintenance save save_as add_problem revert)];
 use constant ACTION_FORM_TITLES => {
-	view        => x('View/Reload'),
-	hardcopy    => x('Generate Hardcopy'),
-	format_code => x('Format Code'),
-	save        => x('Save'),
-	save_as     => x('Save As'),
-	add_problem => x('Append'),
-	revert      => x('Revert'),
+	view             => x('View/Reload'),
+	hardcopy         => x('Generate Hardcopy'),
+	code_maintenance => x('Code Maintenance'),
+	save             => x('Save'),
+	save_as          => x('Save As'),
+	add_problem      => x('Append'),
+	revert           => x('Revert'),
 };
 
 my $BLANKPROBLEM = 'newProblem.pg';
@@ -847,9 +847,9 @@ sub view_handler ($c) {
 	return;
 }
 
-# The format_code action is handled by javascript.  This is provided just in case
+# The code_maintenance action is handled by javascript.  This is provided just in case
 # something goes wrong and the handler is called.
-sub format_code_handler { }
+sub code_maintenance_handler { }
 
 sub hardcopy_handler ($c) {
 	# Redirect to problem editor page.

--- a/lib/WebworkWebservice.pm
+++ b/lib/WebworkWebservice.pm
@@ -255,6 +255,7 @@ sub command_permission {
 		putPastAnswer     => 'problem_grader',
 		tidyPGCode        => 'access_instructor_tools',
 		convertCodeToPGML => 'access_instructor_tools',
+		runPGCritic       => 'access_instructor_tools',
 
 		# WebworkWebservice::RenderProblem
 		renderProblem => 'webservice_render_problem',

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -172,8 +172,8 @@ sub runPGCritic {
 	return {
 		ra_out => {
 			html => $self->c->render_to_string(
-				template => 'ContentGenerator/Instructor/PGProblemEditor/pg_critic',
-				results  => [ critiquePGCode($params->{pgCode}) ]
+				template   => 'ContentGenerator/Instructor/PGProblemEditor/pg_critic',
+				violations => [ critiquePGCode($params->{pgCode}) ]
 			)
 		},
 		text => 'The script pg-critic has been run successfully.'

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -6,8 +6,9 @@ use warnings;
 
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::PG::Tidy          qw(pgtidy);
-use WeBWorK::PG::ConvertToPGML qw(convertToPGML);
+use WeBWorK::PG::Tidy            qw(pgtidy);
+use WeBWorK::PG::ConvertToPGML   qw(convertToPGML);
+use WeBWorK::PG::PGProblemCritic qw(analyzePGcode);
 
 sub getUserProblem {
 	my ($invocant, $self, $params) = @_;
@@ -163,6 +164,23 @@ sub convertCodeToPGML {
 		text   => 'Converted to PGML'
 	};
 
+}
+
+sub runPGCritic {
+	my ($invocant, $self, $params) = @_;
+	my $pg_critic_results = analyzePGcode($params->{pgCode});
+
+	my $html_output = $self->c->render_to_string(
+		template => 'ContentGenerator/Instructor/PGProblemEditor/pg_critic',
+		results  => $pg_critic_results
+	);
+
+	return {
+		ra_out => {
+			html => $html_output
+		},
+		text => 'The script pg-critic has been run successfully.'
+	};
 }
 
 1;

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -6,9 +6,9 @@ use warnings;
 
 use Data::Structure::Util qw(unbless);
 
-use WeBWorK::PG::Tidy            qw(pgtidy);
-use WeBWorK::PG::ConvertToPGML   qw(convertToPGML);
-use WeBWorK::PG::PGProblemCritic qw(analyzePGcode);
+use WeBWorK::PG::Tidy          qw(pgtidy);
+use WeBWorK::PG::ConvertToPGML qw(convertToPGML);
+use WeBWorK::PG::Critic        qw(critiquePGCode);
 
 sub getUserProblem {
 	my ($invocant, $self, $params) = @_;
@@ -168,16 +168,13 @@ sub convertCodeToPGML {
 
 sub runPGCritic {
 	my ($invocant, $self, $params) = @_;
-	my $pg_critic_results = analyzePGcode($params->{pgCode});
-
-	my $html_output = $self->c->render_to_string(
-		template => 'ContentGenerator/Instructor/PGProblemEditor/pg_critic',
-		results  => $pg_critic_results
-	);
 
 	return {
 		ra_out => {
-			html => $html_output
+			html => $self->c->render_to_string(
+				template => 'ContentGenerator/Instructor/PGProblemEditor/pg_critic',
+				results  => [ critiquePGCode($params->{pgCode}) ]
+			)
 		},
 		text => 'The script pg-critic has been run successfully.'
 	};

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/code_maintenance_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/code_maintenance_form.html.ep
@@ -1,9 +1,9 @@
 % last unless $c->{is_pg};
 <div>
 	<div class="form-check">
-		<%= radio_button 'action.format_code' => 'tidyPGCode',
-			id => 'action_format_code_perltidy', class => 'form-check-input', checked => undef  =%>
-		<%= label_for 'action_format_code_perltidy', class => 'form-check-label', begin =%>
+		<%= radio_button 'action.code_maintenance' => 'tidyPGCode',
+			id => 'action_code_maintenance_perltidy', class => 'form-check-input', checked => undef  =%>
+		<%= label_for 'action_code_maintenance_perltidy', class => 'form-check-label', begin =%>
 			<%== maketext('Reformat the code using perltidy.') =%>
 		<% end =%>
 		<a class="help-popup" data-bs-content="<%== maketext('Perltidy is a reformatting '
@@ -15,9 +15,9 @@
 		</a>
 	</div>
 	<div class="form-check">
-		<%= radio_button 'action.format_code' => 'convertCodeToPGML',
-			id => 'action_format_code_convert_PGML', class => 'form-check-input'=%>
-		<%= label_for 'action_format_code_convert_PGML', class => 'form-check-label', begin =%>
+		<%= radio_button 'action.code_maintenance' => 'convertCodeToPGML',
+			id => 'action_code_maintenance_convert_PGML', class => 'form-check-input'=%>
+		<%= label_for 'action_code_maintenance_convert_PGML', class => 'form-check-label', begin =%>
 			<%== maketext('Convert the code to PGML') =%>
 		<% end =%>
 		<a class="help-popup" data-bs-content="<%== maketext('This option converts the text blocks '
@@ -25,21 +25,21 @@
 			. 'This can be used as a first pass of the conversion, however the author will still need '
 			. 'to ensure the problem functions.  One area of attention should be the answer blanks, '
 			. 'which may not be converted correctly.') =%>"
-		data-bs-placement="top" data-bs-toggle="popover" role="button">
+			data-bs-placement="top" data-bs-toggle="popover" role="button">
 			<i aria-hidden="true" class="fas fa-question-circle"></i>
 			<span class="visually-hidden"><%= maketext('PGML Conversion Help') %></span>
 		</a>
 	</div>
 	<div class="form-check">
-		<%= radio_button 'action.format_code' => 'runPGCritic',
-			id => 'action_format_code_run_pgcritic', class => 'form-check-input'=%>
-		<%= label_for 'action_format_code_run_pgcritic', class => 'form-check-label', begin =%>
+		<%= radio_button 'action.code_maintenance' => 'runPGCritic',
+			id => 'action_code_maintenance_run_pgcritic', class => 'form-check-input'=%>
+		<%= label_for 'action_code_maintenance_run_pgcritic', class => 'form-check-label', begin =%>
 			<%== maketext('Run the PG Critic Analyzer') =%>
 		<% end =%>
 		<a class="help-popup" data-bs-content="<%== maketext('This option runs the PG Critic '
-			. 'code analyzer, which gives suggestions on using more modern PG constructs and  '
-			. 'ensure that you include important features. ') =%>"
-		data-bs-placement="top" data-bs-toggle="popover" role="button">
+			. 'code analyzer which gives suggestions on using modern PG constructs and  '
+			. 'ensures that you include important features.') =%>"
+			data-bs-placement="top" data-bs-toggle="popover" role="button">
 			<i aria-hidden="true" class="fas fa-question-circle"></i>
 			<span class="visually-hidden"><%= maketext('PG Critic Help') %></span>
 		</a>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/code_maintenance_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/code_maintenance_form.html.ep
@@ -34,11 +34,11 @@
 		<%= radio_button 'action.code_maintenance' => 'runPGCritic',
 			id => 'action_code_maintenance_run_pgcritic', class => 'form-check-input'=%>
 		<%= label_for 'action_code_maintenance_run_pgcritic', class => 'form-check-label', begin =%>
-			<%== maketext('Run the PG Critic Analyzer') =%>
+			<%== maketext('Analyze code with PG Critic') =%>
 		<% end =%>
-		<a class="help-popup" data-bs-content="<%== maketext('This option runs the PG Critic '
-			. 'code analyzer which gives suggestions on using modern PG constructs and  '
-			. 'ensures that you include important features.') =%>"
+		<a class="help-popup" data-bs-content="<%== maketext('This option analyzes the code with PG Critic '
+			. 'which gives suggestions on using modern PG constructs and ensures that the code conforms '
+			. 'to current best-practices.') =%>"
 			data-bs-placement="top" data-bs-toggle="popover" role="button">
 			<i aria-hidden="true" class="fas fa-question-circle"></i>
 			<span class="visually-hidden"><%= maketext('PG Critic Help') %></span>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/format_code_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/format_code_form.html.ep
@@ -30,4 +30,18 @@
 			<span class="visually-hidden"><%= maketext('PGML Conversion Help') %></span>
 		</a>
 	</div>
+	<div class="form-check">
+		<%= radio_button 'action.format_code' => 'runPGCritic',
+			id => 'action_format_code_run_pgcritic', class => 'form-check-input'=%>
+		<%= label_for 'action_format_code_run_pgcritic', class => 'form-check-label', begin =%>
+			<%== maketext('Run the PG Critic Analyzer') =%>
+		<% end =%>
+		<a class="help-popup" data-bs-content="<%== maketext('This option runs the PG Critic '
+			. 'code analyzer, which gives suggestions on using more modern PG constructs and  '
+			. 'ensure that you include important features. ') =%>"
+		data-bs-placement="top" data-bs-toggle="popover" role="button">
+			<i aria-hidden="true" class="fas fa-question-circle"></i>
+			<span class="visually-hidden"><%= maketext('PG Critic Help') %></span>
+		</a>
+	</div>
 </div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
@@ -1,0 +1,147 @@
+<div class="m-3" style="overflow: scroll">
+<h2>PG Critic Results</h2>
+
+<h3>Metadata</h3>
+
+<p>The following lists required metadata. If any is missing, the given tag must be filled in.
+	However, make sure that the categories are correct, especially if the problem has been
+	copied.</p>
+
+% sub showIcon { my $show = shift;
+%  return $show ? q!<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-square text-success" viewBox="0 0 16 16">
+%  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+%  <path d="M10.97 4.97a.75.75 0 0 1 1.071 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425z"/>
+% </svg>! : q!<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-square text-danger" viewBox="0 0 16 16">
+%  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
+%  <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
+% </svg>!;
+%}
+
+<table class="table table-bordered">
+<tbody>
+<tr><th>DBsubject</th><td> <%== showIcon($results->{metadata}{DBsection}) %> </td></tr>
+<tr><th>DBchapter</th><td> <%== showIcon($results->{metadata}{DBchapter}) %> </td></tr>
+<tr><th>DBsection</th><td> <%== showIcon($results->{metadata}{DBsection})  %> </td></tr>
+<tr><th>Keywords</th><td> <%== showIcon($results->{metadata}{KEYWORDS})  %> </td></tr>
+</table>
+
+% my $pos = $results->{positive};
+% if ($pos->{PGML} || $pos->{solution} || $pos->{hint}) {
+<h3>Good aspects of this problems are the following</h3>
+% }
+<table class="table table-bordered">
+<tbody>
+% if ($pos->{PGML}) {
+	<tr><th>PGML</th><td>This problem uses PGML, the current preferred way to write problem (text), solution and hint
+		blocks.</td></tr>
+% }
+% if ($pos->{solution}) {
+	<tr><th>Solutions</th><td>This problem has a solution block.  Every problem should have solutions that the
+		student can view after the answer data. </td></tr>
+% }
+% if ($pos->{hint}) {
+	<tr><th>Hints</th><td>This problem has a hint.  This can be helpful for students after attempting the problem
+		a few times (this can be set by the instructor).
+% }
+% if ($pos->{randomness}) {
+	<tr><th>Randomness</th><td>This problem uses randomness.  This is desired to give to a class of students, each
+		of whom may have a different problem. </td>
+% }
+% # list of the positive contexts:
+% my @good_contexts =  grep { $pos->{contexts}{$_} } keys %{$pos->{parsers}};
+% if (@good_contexts) {
+	<tr><th>Modern Contexts</th><td>This problem uses the following modern contexts:
+		<%= join(', ', @good_contexts) %> </td>
+% }
+% my @good_parsers = grep { $pos->{parsers}->{$_} } keys %{$pos->{parsers}};
+% if (@good_parsers) {
+	<tr><th>Modern Parsers</th><td>This problem uses features of the following modern parsers:
+		<%= join(', ', @good_parsers) %> </td>
+% }
+% my @good_macros = grep { $pos->{macros}->{$_} } keys %{$pos->{macros}};
+% if (@good_macros) {
+	<tr><th>Modern Macros</th><td>This problem uses functionality from the following modern macros:
+		<%= join(', ', @good_macros) %> </td>
+% }
+</tbody>
+</table>
+
+
+% if( scalar(@{$results->{deprecated_macros}}) > 0) {
+	<h3>Deprecated Macros</h3>
+	<p>This problem has the following deprecated macros: <%= join(', ',@{$results->{deprecated_macros}} ) %> </p>
+
+	<p>These should be removed from the problem in that these macros will be deleted from PG in a future
+		version.  The functions from these macros may be listed below to help aid in transitioning away from
+		these macros. </p>
+% }
+
+%  my $has_bad_features = 0;
+%  $has_bad_features += $results->{negative}{$_} for (keys %{$results->{negative}});
+
+% if ($has_bad_features || !$pos->{solution}) {
+	<h3>You can improve on the following:</h3>
+	<p> There are features in this problem that contain old or deprecated features.  The following
+		list gives feedback of how the problem can be improved. </p>
+%}
+
+<ul>
+% if ($results->{negative}{BEGIN_TEXT}) {
+	<li>This problem contains older formatting blocks like BEGIN_TEXT.  Consider use PGML.
+		In the <em>Format Code</em> section of the PG Editor, the "Convert to PGML" should be used
+		as a start to get the problem switched.</li>
+%}
+% if ($results->{negative}{beginproblem}) {
+	<li>This problem contains the line <tt>TEXT(beginproblem())</tt>.  This is no longer necessary and should be removed. </li>
+%}
+% if ($results->{negative}{context_texstrings}) {
+	<li>This problem contains  the line <tt>Context()->texStrings;</tt>.  This is no longer necessary and should be removed.  </li>
+%}
+% if ($results->{negative}{oldtable}) {
+	<li>This problem contains the deprecated <tt>begintable</tt> command.  This is not assessible and often cannot be
+		converted to hardcopy.  This table should be written using <tt>nicetables</tt> or a PGML table.   </li>
+%}
+% if ($results->{negative}{showPartialCorrect}) {
+	<li>This problem contains the line <tt>$showPartialCorrectAnswers = 1</tt>. This is enabled by default and needed only
+		if set to 0.</li>
+% }
+% if (!$pos->{solution}) {
+	<li>This problem does not have a solution.  Consider adding one.</li>
+% }
+% if (!$pos->{randomness}) {
+	<li>This problem does not have randomness.  Consider adding variables that take on random values.</li>
+% }
+% if ($results->{negative}{fun_cmp} || $results->{negative}{str_cmp} || $results->{negative}{num_cmp}) {
+	<li>This problem contains the functioins <tt>num_cmp</tt>, <tt>str_cmp</tt> or <tt>fun_cmp</tt>.
+		These are old ways of checking answers.  These should be converted to MathObjects.
+% }
+% if ($results->{negative}{multiple_loadmacros}) {
+	<li>This problem contains two <tt>loadMacros</tt> function call. Combine the function
+		calls and make sure that all macros are needed for your problem. </li>
+% }
+% if ($results->{negative}{macros}{PGchoicemacros}) {
+	<li>This problem contains old versions of multiple choice.  The sample problems
+		<a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoiceCheckbox.html">
+		Multiple Choice with Checkbox</a>, <a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoicePopup.html">
+		Multiple Choice with Popup</a> and <a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoiceRadio.html">
+		Multiple Choice with Radio Buttons</a> should be examined as well the macros:
+		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserPopUp.html">parserPopUp.pl</a>,
+		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserCheckboxList.html">parserCheckboxList.pl</a> and
+		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserRadioButtons.html">parserRadioButtons.pl</a>.
+
+	 </li>
+% }
+% if ($results->{negative}{macros}{PGgraphmacros}) {
+	<li>This problem uses <tt>PGgraphmacros</tt> a old plotting library. Consider using
+		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/graph/plots.html"><tt>Plots.pl</tt></a>
+		or <a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/graph/PGtikz.html"><tt>PGtikz.pl</tt></a></li>
+%}
+% if ($results->{negative}{lines_below_enddocument}) {
+	<li>There is content (code or other text), below the  <tt>ENDDOCUMENT()</tt> line.  Although this
+		is ignored, there shouldn't be content in this area.</li>
+% }
+
+</ul>
+
+
+</div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
@@ -1,31 +1,12 @@
 % Perl::Critic::Violation::set_format('%m at line %l, column %c.');
 %
 <div class="m-3 overflow-auto">
-	<h2><%= maketext('PG Critic Results') %></h2>
-	% my @goodResults = grep { ref($_->explanation) eq 'HASH' && ($_->explanation->{score} // 0) > 0 } @$results;
-	% if (@goodResults) {
-		<h3 class="mt-2"><%= maketext('The following are good aspects of this problem:') %></h3>
+	<h2><%= maketext('PG Critic Violations') %></h2>
+	% my @pgCriticViolations = grep { $_->policy =~ /^Perl::Critic::Policy::PG::/ } @$violations;
+	% if (@pgCriticViolations) {
+		<h3 class="mt-2"><%= maketext('The following PG issues should be fixed:') %></h3>
 		<ul class="list-group">
-			% for (@goodResults) {
-				<li class="list-group-item">
-					<div><%= $_->to_string %></div>
-					<div>
-						<%= $_->explanation->{explanation} %>
-						See <%= link_to(
-							($_->policy =~ s/^Perl::Critic::Policy:://r)
-								=> pod_viewer => { filePath => 'lib/' . ($_->policy =~ s/::/\//gr) . '.pm' },
-							target => '_blank'
-						) %>.
-					</div>
-				</li>
-			% }
-		</ul>
-	%}
-	% my @badResults = grep { ref($_->explanation) eq 'HASH' && ($_->explanation->{score} // 0) < 0 } @$results;
-	% if (@badResults) {
-		<h3 class="mt-2"><%= maketext('The following are things that can be improved:') %></h3>
-		<ul class="list-group">
-			% for (@badResults) {
+			% for (@pgCriticViolations) {
 				<li class="list-group-item">
 					<div><%= $_->to_string %></div>
 					<div>
@@ -55,11 +36,11 @@
 			% }
 		</ul>
 	%}
-	% my @badPerlResults = grep { !ref($_->explanation) } @$results;
-	% if (@badPerlResults) {
-		<h3 class="mt-2"><%= maketext('The following are general Perl issues that can be improved:') %></h3>
+	% my @perlCriticViolations = grep { $_->policy !~ /^Perl::Critic::Policy::PG::/ } @$violations;
+	% if (@perlCriticViolations) {
+		<h3 class="mt-2"><%= maketext('The following general Perl issues should be fixed:') %></h3>
 		<ul class="list-group">
-			% for (@badPerlResults) {
+			% for (@perlCriticViolations) {
 				<li class="list-group-item">
 					<div><%= $_->to_string %></div>
 					<div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
@@ -1,147 +1,75 @@
-<div class="m-3" style="overflow: scroll">
-<h2>PG Critic Results</h2>
-
-<h3>Metadata</h3>
-
-<p>The following lists required metadata. If any is missing, the given tag must be filled in.
-	However, make sure that the categories are correct, especially if the problem has been
-	copied.</p>
-
-% sub showIcon { my $show = shift;
-%  return $show ? q!<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-check-square text-success" viewBox="0 0 16 16">
-%  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
-%  <path d="M10.97 4.97a.75.75 0 0 1 1.071 1.05l-3.992 4.99a.75.75 0 0 1-1.08.02L4.324 8.384a.75.75 0 1 1 1.06-1.06l2.094 2.093 3.473-4.425z"/>
-% </svg>! : q!<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-x-square text-danger" viewBox="0 0 16 16">
-%  <path d="M14 1a1 1 0 0 1 1 1v12a1 1 0 0 1-1 1H2a1 1 0 0 1-1-1V2a1 1 0 0 1 1-1zM2 0a2 2 0 0 0-2 2v12a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V2a2 2 0 0 0-2-2z"/>
-%  <path d="M4.646 4.646a.5.5 0 0 1 .708 0L8 7.293l2.646-2.647a.5.5 0 0 1 .708.708L8.707 8l2.647 2.646a.5.5 0 0 1-.708.708L8 8.707l-2.646 2.647a.5.5 0 0 1-.708-.708L7.293 8 4.646 5.354a.5.5 0 0 1 0-.708"/>
-% </svg>!;
-%}
-
-<table class="table table-bordered">
-<tbody>
-<tr><th>DBsubject</th><td> <%== showIcon($results->{metadata}{DBsection}) %> </td></tr>
-<tr><th>DBchapter</th><td> <%== showIcon($results->{metadata}{DBchapter}) %> </td></tr>
-<tr><th>DBsection</th><td> <%== showIcon($results->{metadata}{DBsection})  %> </td></tr>
-<tr><th>Keywords</th><td> <%== showIcon($results->{metadata}{KEYWORDS})  %> </td></tr>
-</table>
-
-% my $pos = $results->{positive};
-% if ($pos->{PGML} || $pos->{solution} || $pos->{hint}) {
-<h3>Good aspects of this problems are the following</h3>
-% }
-<table class="table table-bordered">
-<tbody>
-% if ($pos->{PGML}) {
-	<tr><th>PGML</th><td>This problem uses PGML, the current preferred way to write problem (text), solution and hint
-		blocks.</td></tr>
-% }
-% if ($pos->{solution}) {
-	<tr><th>Solutions</th><td>This problem has a solution block.  Every problem should have solutions that the
-		student can view after the answer data. </td></tr>
-% }
-% if ($pos->{hint}) {
-	<tr><th>Hints</th><td>This problem has a hint.  This can be helpful for students after attempting the problem
-		a few times (this can be set by the instructor).
-% }
-% if ($pos->{randomness}) {
-	<tr><th>Randomness</th><td>This problem uses randomness.  This is desired to give to a class of students, each
-		of whom may have a different problem. </td>
-% }
-% # list of the positive contexts:
-% my @good_contexts =  grep { $pos->{contexts}{$_} } keys %{$pos->{parsers}};
-% if (@good_contexts) {
-	<tr><th>Modern Contexts</th><td>This problem uses the following modern contexts:
-		<%= join(', ', @good_contexts) %> </td>
-% }
-% my @good_parsers = grep { $pos->{parsers}->{$_} } keys %{$pos->{parsers}};
-% if (@good_parsers) {
-	<tr><th>Modern Parsers</th><td>This problem uses features of the following modern parsers:
-		<%= join(', ', @good_parsers) %> </td>
-% }
-% my @good_macros = grep { $pos->{macros}->{$_} } keys %{$pos->{macros}};
-% if (@good_macros) {
-	<tr><th>Modern Macros</th><td>This problem uses functionality from the following modern macros:
-		<%= join(', ', @good_macros) %> </td>
-% }
-</tbody>
-</table>
-
-
-% if( scalar(@{$results->{deprecated_macros}}) > 0) {
-	<h3>Deprecated Macros</h3>
-	<p>This problem has the following deprecated macros: <%= join(', ',@{$results->{deprecated_macros}} ) %> </p>
-
-	<p>These should be removed from the problem in that these macros will be deleted from PG in a future
-		version.  The functions from these macros may be listed below to help aid in transitioning away from
-		these macros. </p>
-% }
-
-%  my $has_bad_features = 0;
-%  $has_bad_features += $results->{negative}{$_} for (keys %{$results->{negative}});
-
-% if ($has_bad_features || !$pos->{solution}) {
-	<h3>You can improve on the following:</h3>
-	<p> There are features in this problem that contain old or deprecated features.  The following
-		list gives feedback of how the problem can be improved. </p>
-%}
-
-<ul>
-% if ($results->{negative}{BEGIN_TEXT}) {
-	<li>This problem contains older formatting blocks like BEGIN_TEXT.  Consider use PGML.
-		In the <em>Format Code</em> section of the PG Editor, the "Convert to PGML" should be used
-		as a start to get the problem switched.</li>
-%}
-% if ($results->{negative}{beginproblem}) {
-	<li>This problem contains the line <tt>TEXT(beginproblem())</tt>.  This is no longer necessary and should be removed. </li>
-%}
-% if ($results->{negative}{context_texstrings}) {
-	<li>This problem contains  the line <tt>Context()->texStrings;</tt>.  This is no longer necessary and should be removed.  </li>
-%}
-% if ($results->{negative}{oldtable}) {
-	<li>This problem contains the deprecated <tt>begintable</tt> command.  This is not assessible and often cannot be
-		converted to hardcopy.  This table should be written using <tt>nicetables</tt> or a PGML table.   </li>
-%}
-% if ($results->{negative}{showPartialCorrect}) {
-	<li>This problem contains the line <tt>$showPartialCorrectAnswers = 1</tt>. This is enabled by default and needed only
-		if set to 0.</li>
-% }
-% if (!$pos->{solution}) {
-	<li>This problem does not have a solution.  Consider adding one.</li>
-% }
-% if (!$pos->{randomness}) {
-	<li>This problem does not have randomness.  Consider adding variables that take on random values.</li>
-% }
-% if ($results->{negative}{fun_cmp} || $results->{negative}{str_cmp} || $results->{negative}{num_cmp}) {
-	<li>This problem contains the functioins <tt>num_cmp</tt>, <tt>str_cmp</tt> or <tt>fun_cmp</tt>.
-		These are old ways of checking answers.  These should be converted to MathObjects.
-% }
-% if ($results->{negative}{multiple_loadmacros}) {
-	<li>This problem contains two <tt>loadMacros</tt> function call. Combine the function
-		calls and make sure that all macros are needed for your problem. </li>
-% }
-% if ($results->{negative}{macros}{PGchoicemacros}) {
-	<li>This problem contains old versions of multiple choice.  The sample problems
-		<a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoiceCheckbox.html">
-		Multiple Choice with Checkbox</a>, <a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoicePopup.html">
-		Multiple Choice with Popup</a> and <a target="_blank" href="https://openwebwork.github.io/pg-docs/sample-problems/Misc/MultipleChoiceRadio.html">
-		Multiple Choice with Radio Buttons</a> should be examined as well the macros:
-		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserPopUp.html">parserPopUp.pl</a>,
-		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserCheckboxList.html">parserCheckboxList.pl</a> and
-		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/parsers/parserRadioButtons.html">parserRadioButtons.pl</a>.
-
-	 </li>
-% }
-% if ($results->{negative}{macros}{PGgraphmacros}) {
-	<li>This problem uses <tt>PGgraphmacros</tt> a old plotting library. Consider using
-		<a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/graph/plots.html"><tt>Plots.pl</tt></a>
-		or <a target="_blank" href="https://openwebwork.github.io/pg-docs/pod/pg/macros/graph/PGtikz.html"><tt>PGtikz.pl</tt></a></li>
-%}
-% if ($results->{negative}{lines_below_enddocument}) {
-	<li>There is content (code or other text), below the  <tt>ENDDOCUMENT()</tt> line.  Although this
-		is ignored, there shouldn't be content in this area.</li>
-% }
-
-</ul>
-
-
+% Perl::Critic::Violation::set_format('%m at line %l, column %c.');
+%
+<div class="m-3 overflow-auto">
+	<h2><%= maketext('PG Critic Results') %></h2>
+	% my @goodResults = grep { ref($_->explanation) eq 'HASH' && ($_->explanation->{score} // 0) > 0 } @$results;
+	% if (@goodResults) {
+		<h3 class="mt-2"><%= maketext('The following are good aspects of this problem:') %></h3>
+		<ul class="list-group">
+			% for (@goodResults) {
+				<li class="list-group-item">
+					<div><%= $_->to_string %></div>
+					<div>
+						<%= $_->explanation->{explanation} %>
+						See <%= link_to(
+							($_->policy =~ s/^Perl::Critic::Policy:://r)
+								=> pod_viewer => { filePath => 'lib/' . ($_->policy =~ s/::/\//gr) . '.pm' },
+							target => '_blank'
+						) %>.
+					</div>
+				</li>
+			% }
+		</ul>
+	%}
+	% my @badResults = grep { ref($_->explanation) eq 'HASH' && ($_->explanation->{score} // 0) < 0 } @$results;
+	% if (@badResults) {
+		<h3 class="mt-2"><%= maketext('The following are things that can be improved:') %></h3>
+		<ul class="list-group">
+			% for (@badResults) {
+				<li class="list-group-item">
+					<div><%= $_->to_string %></div>
+					<div>
+						<%= $_->explanation->{explanation} %>
+						<%== maketext(
+							'See [_1].',
+							link_to(
+								($_->policy =~ s/^Perl::Critic::Policy:://r)
+									=> pod_viewer => { filePath => 'lib/' . ($_->policy =~ s/::/\//gr) . '.pm' },
+								target => '_blank'
+							)
+						) =%>
+					</div>
+					% if (ref($_->explanation->{sampleProblems}) eq 'ARRAY' && @{ $_->explanation->{sampleProblems} }) {
+						<div>
+							<%== maketext('Related sample [plural,_1,problem]:',
+								scalar(@{ $_->explanation->{sampleProblems} })) %>
+							<%= c(map {
+								link_to(
+									$_->[0] => sample_problem_viewer => { filePath => $_->[1] },
+									target => '_blank'
+								)
+							} @{ $_->explanation->{sampleProblems} })->join(', ') =%>
+						</div>
+					% }
+				</li>
+			% }
+		</ul>
+	%}
+	% my @badPerlResults = grep { !ref($_->explanation) } @$results;
+	% if (@badPerlResults) {
+		<h3 class="mt-2"><%= maketext('The following are general Perl issues that can be improved:') %></h3>
+		<ul class="list-group">
+			% for (@badPerlResults) {
+				<li class="list-group-item">
+					<div><%= $_->to_string %></div>
+					<div>
+						See <%= link_to(
+							($_->policy =~ s/^Perl::Critic::Policy:://r) => 'https://metacpan.org/pod/' . $_->policy,
+							target => '_blank'
+						) %>.
+					</div>
+				</li>
+			% }
+		</ul>
+	%}
 </div>

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -169,9 +169,9 @@
 		. 'Second the code can be converted to PGML. This changes the code in text blocks to use PGML features. '
 		. 'Generally the conversion of much of the formatting and LaTeX is performed correctly. However, answer '
 		. 'blanks need attention. In any case, make sure to inspect the formatted code, and edit further or revert '
-		. 'if needed. Third, the code can be analyzed by the "PG Critic Analyzer." This checks that the code uses '
-		. 'modern features of PG, that it does not use old or deprecated features of PG, and offers advice on how '
-		. 'to fix issues that are found.') =%>
+		. 'if needed. Third, the code can be analyzed by the "PG Critic." This checks that the code does not use '
+		. 'old or deprecated features of PG and conforms to current best-practices in problem authoring, and offers '
+		. 'suggestions on how to fix issues that are found.') =%>
 	</dd>
 
 	<dt><%= maketext('Save') %></dt>

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -156,19 +156,22 @@
 			. 'generating the PDF file using LaTeX.') =%>
 		</p>
 		<p>
-		<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be saved to '
-			. 'the templates/hardcopyThemes folder.') =%>
+		<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be saved '
+			. 'to the templates/hardcopyThemes folder.') =%>
 		</p>
 	</dd>
 
-	<dt><%= maketext('Format Code') %></dt>
+	<dt><%= maketext('Code Maintenance') %></dt>
 	<dd>
-		<%= maketext('Reformat the code using perltidy or a conversion to PGML. Using perltidy will change the code '
-			. 'in the editor window, and save changes to the temporary file. In some cases (if the code contains '
-			. 'backslashes or double tildes) this can result in odd spacing in the code. The convert to PGML '
-			. 'feature changes the code in text blocks in the code to use PGML features. Generally the conversion of '
-			. 'many of the formatting and LaTeX is performed correctly, however answer blanks need attention. In '
-			. 'either case, make sure to inspect the formatted code, and edit further or revert if needed.') =%>
+		<%= maketext('Three code maintenance tools can be utilized. First, the code can be reformatted using perltidy. '
+		. 'Using perltidy will change the code in the editor window, and save changes to the temporary file. In some '
+		. 'cases (if the code contains backslashes or double tildes) this can result in odd spacing in the code. '
+		. 'Second the code can be converted to PGML. This changes the code in text blocks to use PGML features. '
+		. 'Generally the conversion of much of the formatting and LaTeX is performed correctly. However, answer '
+		. 'blanks need attention. In any case, make sure to inspect the formatted code, and edit further or revert '
+		. 'if needed. Third, the code can be analyzed by the "PG Critic Analyzer." This checks that the code uses '
+		. 'modern features of PG, that it does not use old or deprecated features of PG, and offers advice on how '
+		. 'to fix issues that are found.') =%>
 	</dd>
 
 	<dt><%= maketext('Save') %></dt>


### PR DESCRIPTION
This adds the PG critic results from `WeBWorK::PG::Critic` to the PG problem editor.  Note that the "Format Code" tab in the editor is now the "Code Maintenance" tab.  This is because this new option is not a code formatter.  All of the options fit into the category of code, so this is a better name.

This is dependent on https://github.com/openwebwork/pg/pull/1278 (so make sure to check that PG branch out to test this), and is intended to replace https://github.com/openwebwork/webwork2/pull/2748.