### PR TITLE
Add an LTI 1.3 debug log in the case that the JWT fails to decode on a launch request. (hotfix version)

### DIFF
--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -116,6 +116,19 @@ $LTI{v1p3}{AuthReqURL}      = '';
 # don't pile up in the database.
 $LTI{v1p3}{StateKeyLifetime} = 60;    # in seconds
 
+# When a LTI 1.3 launch request occurs the JWT in the request is decoded and the exp and iat in
+# the token are validated.  The expectation is that the iat and exp values are before (less
+# than) the current time on the webwork2 server plus the JWTLeeway, and if they are greater than
+# the current time plus the JWTLeeway then the JWT fails to validate.  So the JWTLeeway is the
+# maximum allowed time in seconds that the exp and iat values in the token are allowed to be
+# after the current time.  If the JWTs in these launch requests are failing to validate, then
+# increase this value to allow for a larger difference between the exp and iat values in the JWT
+# and the current time. This is usually caused by the clock on the LMS server being ahead of the
+# clock on the webwork2 server.  Generally, a small leeway may be needed, but if the clock on
+# the LMS server is too far ahead of the clock on the webwork2 server, then steps should be
+# taken to synchronize the clocks.
+$LTI{v1p3}{JWTLeeway} = 0;    # in seconds
+
 ################################################################################################
 # LTI 1.3 LMS Roles Mapped to WeBWorK Roles
 ################################################################################################

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -367,6 +367,7 @@ sub extract_jwt_claims ($c) {
 		verify_aud => $ce->{LTI}{v1p3}{ClientID},
 		verify_iat => 1,
 		verify_exp => 1,
+		leeway     => $ce->{LTI}{v1p3}{JWTLeeway} // 0,
 		# This just checks that this claim is present.
 		verify_sub => sub ($value) { return $value =~ /\S/ }
 	);

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -161,6 +161,8 @@ sub launch ($c) {
 					$c->stash->{lti_jwt_claims}{'https://purl.imsglobal.org/spec/lti/claim/context'}{id}
 				]
 			];
+		} elsif ($c->stash->{LTIAuthenError}) {
+			debug($c->stash->{LTIAuthenError});
 		}
 		return $c->render(
 			'ContentGenerator/LTI/content_item_selection_error',


### PR DESCRIPTION
In this case the LTIAuthenError stash value is set, but that error is never shown anywhere because the course ID was not determined and the authen verify method is never called.  So this information goes to the abyss and the debug log abrubtly terminates (see https://forums.openwebwork.org/mod/forum/discuss.php?d=8749 for what this debug log looks like).  So this pull request always debug logs it in this case.  There is not enough information to even determine if LTI debugging is enabled for the course (which the request failed to determine), so it has to be the more general debug logging facility. This may help in resolving the issues that are occuring with the cases such as those in the above mentioned forum post and https://forums.openwebwork.org/mod/forum/discuss.php?d=8738#p22228.

Edit:

This also now adds a JWTLeeway for LTI 1.3 JWT validation. This is the maximum number of seconds that the exp and iat values in the JWT sent with a launch request are allowed to be in the future relative to the current time on the webwork2 server.  The Crypt::JWT module by default uses a value of 0 for this, meaning that the iat and exp values in the token must be before the current time on the webwork2 server.
    
This may be why many are experiencing issues with JWT tokens failing to validate, and is due to the clock on the LMS server being ahead of the clock on the webwork2 server. Generally such issues can be resolved by synchronizing clocks, but in some cases a small leeway may be needed.