### PR TITLE
Fix a `realpath` failure when resolving course symlinks.

### DIFF
--- a/lib/WeBWorK/Utils/CourseDirectoryIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseDirectoryIntegrityCheck.pm
@@ -74,7 +74,7 @@ sub checkCourseLinks {
 		# All links should actually be links, and should have the correct target.  Note that the link target may also be
 		# a link, and so the realpath of the configured link target and realpath of the course link path must be
 		# compared to check that the link target is correct.
-		my $good = -l $path && path($path)->realpath eq path($target)->realpath;
+		my $good = -l $path && (eval { path($path)->realpath } // '') eq path($target)->realpath;
 
 		$links_ok = 0 if !$good;
 		push @results, [ $link, $target, $path, $good ];
@@ -213,7 +213,7 @@ sub updateCourseLinks {
 		my $targetIsCorrect = 0;
 
 		if (-l $path) {
-			$targetIsCorrect = path($path)->realpath eq path($target)->realpath;
+			$targetIsCorrect = (eval { path($path)->realpath } // '') eq path($target)->realpath;
 			next if $targetIsCorrect;
 		}
 


### PR DESCRIPTION
If one of the course links that are now maintained by webwork points to a location inside a non existent directory, then the `realpath` calls in `lib/WeBWorK/Utils/CourseDirectoryIntegrityCheck.pm` throw exceptions. This occurs both when checking for course upgrades and when upgrading courses.  So those calls are wrapped in evals to prevent the exceptions.

I have identified this as the cause of the issue discussed in https://forums.openwebwork.org/mod/forum/discuss.php?d=8757#p22321.

To test this delete the Contrib link in a course's templates directory, and create a bad link with something like

```bash
sudo ln -s /bad/location /opt/webwork/courses/courseId/templates/Contrib
```

Then go to the "Upgrade Courses" page in the admin course.  It will give an error with the current develop or main branches.  With this pull request it will show that the link structure of the course needs repair. Furthermore, repairing the link will work.