### PR TITLE
Make LTI 1.3 launch redirection honor query parameters in the target_link_uri.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -2,6 +2,7 @@ package WeBWorK::ContentGenerator::LTIAdvantage;
 use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
 
 use Mojo::UserAgent;
+use Mojo::URL;
 use Mojo::JSON           qw(decode_json);
 use Crypt::JWT           qw(decode_jwt encode_jwt);
 use Math::Random::Secure qw(irand);
@@ -175,9 +176,11 @@ sub launch ($c) {
 
 	return $c->redirect_to($c->systemLink(
 		$c->url_for($c->stash->{LTILaunchRedirect}),
-		$c->stash->{isContentSelection}
-		? (
-			params => {
+		params => {
+			%{ Mojo::URL->new($c->stash->{LTILaunchRedirect})->query->to_hash },
+			$c->stash->{isContentSelection}
+			? (
+
 				courseID        => $c->stash->{courseID},
 				initial_request => 1,
 				accept_multiple =>
@@ -191,9 +194,9 @@ sub launch ($c) {
 				? (data => $c->stash->{lti_jwt_claims}
 						{'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'}{data})
 				: ()
-			}
-			)
-		: ()
+				)
+			: ()
+		}
 	));
 }
 


### PR DESCRIPTION
This is useful if you want to make unpublished instructor links in the LMS that go to specific pages in webwork with query params to make certain display options active immediately.  For example, if you use a link such as `https://webwork.server.edu/webwork2/instructor/progress/set/setID?returning=1&show_date=1&show_testtime=1&show_problems=1` then the test dates, times, and problems will be shown when the page opens.

Currently URL parameters are dropped.  This was not intentional when I implemented this, it is merely a side effect of calling `systemlink` and `url_for` on the `target_link_uri` that is given.

This just gets the query parameters that are passed in the given `target_link_uri` and then passes them to `systemLink` so that it adds them back to the generated URL that gets redirected to.