### PR TITLE
Fix the filter on the student progress page not honoring unchecked check boxes.

### DIFF
--- a/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
@@ -16,6 +16,7 @@
 		% show_section    => $showColumns->{section},
 		% show_recitation => $showColumns->{recit},
 		% show_login      => $showColumns->{login},
+		% returning       => 1
 		% )
 	% : ()
 % );


### PR DESCRIPTION
To fix this `returning => 1` needs to be added to the parameters.

This fixes issue #2800.