### PR TITLE
Fix issues when the sql_mode includes the only_full_group_by setting.

### DIFF
--- a/lib/WeBWorK/Utils/ListingDB.pm
+++ b/lib/WeBWorK/Utils/ListingDB.pm
@@ -286,7 +286,7 @@ sub getDBListings ($c, $amcounter = 0) {
 	if ($amcounter) {
 		$selectwhat = "COUNT(DISTINCT $selectwhat)";
 	} else {
-		$selectwhat .= 'as filepath, pgf.morelt_id, pgf.pgfile_id, pgf.static, pgf.MO';
+		$selectwhat .= 'as filepath, MAX(pgf.morelt_id), MAX(pgf.pgfile_id), MAX(pgf.static), MAX(pgf.MO)';
 		$group_by = 'GROUP BY filepath';
 	}
 


### PR DESCRIPTION
If `only_full_group_by` is included in the `sql_mode` mysql settings, then attempting to view problems in the library browser results in an exception with a message like `DBD::MariaDB::db selectall_arrayref failed: 'webwork.pgf.morelt_id' isn't in GROUP BY at /opt/webwork/webwork2/lib/WeBWorK/DB/Database.pm line 137.`

This just adds a `MAX` call to the columns of the `OPL_pgfile` table that are selected in the `GROUP BY` call, and eliminates the exception. The resulting data that is returned in the query is the same as before since these columns will all hold the same data for the grouped `filepath` results.  This is really just working around poor design in the OPL table structure.

This has been noted a few times in the forums recently.  See, for instance, the latest posts in https://forums.openwebwork.org/mod/forum/discuss.php?d=8757#p22352.

To test this set

```
sql_mode = "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"
```

in the `/etc/mysql/conf.d/mysql.cnf` file and execute `sudo systemctl restart msyql`. With the shown value for `sql_mode` and the develop or main branches you will get the exception when you try to view problems in the library browser, but will not with this pull request.

Note that the value for `sql_mode` above seems to be the default for MariaDB if `ONLY_FULL_GROUP_BY` is removed. At least that is the case on my system.  You can execute `select @@sql_mode` in mysql to see what the settings are for your system.  The default for MySQL does include `ONLY_FULL_GROUP_BY` (at least if I am reading things right).