### PR TITLE
Fix an error that makes the `NoReducedCred` achievement item unusable.

### DIFF
--- a/lib/WeBWorK/AchievementItems/NoReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/NoReducedCred.pm
@@ -19,8 +19,8 @@ sub new ($class) {
 }
 
 sub can_use ($self, $set, $records) {
-	return 0
-		unless $set->assignment_type eq 'default'
+	return
+		$set->assignment_type eq 'default'
 		&& $set->enable_reduced_scoring
 		&& $set->reduced_scoring_date
 		&& $set->reduced_scoring_date < $set->due_date


### PR DESCRIPTION
The `can_use` method of the `NoReducedCred.pm` achiievent item returns 0 unless the condition for which it can be used is true, and then there is no follow up return value for the case that the condition is true.  As a result the method always returns a false value.  Thus the achievement item can never be used.

Since the result of the `can_use` method is used in a purely boolean fashion it should just return the condition result.