### PR TITLE
Cap the delay on the interval that the server time delta is updated in tests. (hotfix of #2809)

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.js
+++ b/htdocs/js/GatewayQuiz/gateway.js
@@ -154,7 +154,7 @@
 		gracePeriod = parseInt(timerDiv.dataset.gracePeriod);
 
 		updateTimeDelta();
-		setInterval(updateTimeDelta, (parseInt(timerDiv.dataset.sessionTimeout) - 60) * 1000);
+		setInterval(updateTimeDelta, Math.min((parseInt(timerDiv.dataset.sessionTimeout) - 60) * 1000, 2147483646));
 
 		const remainingTime = serverDueTime - browserTime + timeDelta;
 


### PR DESCRIPTION
This fixes issue #2808.

See that issue and my comment at https://github.com/openwebwork/webwork2/issues/2808#issuecomment-3271486752 for an explanation of this fix.

In case we want a hotfix in this case.