### PR TITLE
Fix checkSet to honour the ignoreMissingSourcedID setting

### DIFF
--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -490,7 +490,7 @@ sub checkSet {
 				. 'Try logging in to the Learning Management System and visiting the set from there.',
 			$LMS
 		))
-			unless $set->lis_source_did;
+			unless $set->lis_source_did || ($ce->{LTIVersion} eq 'v1p3' && $ce->{LTI}{v1p3}{ignoreMissingSourcedID});
 	}
 
 	return 0;


### PR DESCRIPTION
Currently if `$LTI{v1p3}{ignoreMissingSourcedID}` is set to 1, students are able to click on a set on the Problem Sets page if the `lis_source_did` is not set, but when they click on the set they get an error because `checkSet` does not check for that setting.  This fixes that.
