### PR TITLE
Fix sort by comment descending in Accounts Manager (hotfix of #2817)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -592,7 +592,7 @@ sub byDescStudentID    { local ($b, $a) = ($a, $b); return byStudentID() }
 sub byDescStatus       { local ($b, $a) = ($a, $b); return byStatus() }
 sub byDescSection      { local ($b, $a) = ($a, $b); return bySection() }
 sub byDescRecitation   { local ($b, $a) = ($a, $b); return byRecitation() }
-sub byDescComment      { local ($b, $a) = ($a, $b); return byC mment() }
+sub byDescComment      { local ($b, $a) = ($a, $b); return byComment() }
 sub byDescPermission   { local ($b, $a) = ($a, $b); return byPermission() }
 
 # Utilities


### PR DESCRIPTION
Sorting by comment descending in the Accounts Manager crashes the page as it attempts to run `byC mment()`. Fixing this to `byComment()` lets the page work as expected.