### PR TITLE
When a course is renamed update the LTI course map for the course.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -707,9 +707,10 @@ sub do_rename_course ($c) {
 
 	eval {
 		renameCourse(
-			courseID    => $rename_oldCourseID,
-			ce          => WeBWorK::CourseEnvironment->new({ courseName => $rename_oldCourseID }),
-			newCourseID => $rename_newCourseID,
+			courseID           => $rename_oldCourseID,
+			ce                 => WeBWorK::CourseEnvironment->new({ courseName => $rename_oldCourseID }),
+			newCourseID        => $rename_newCourseID,
+			updateLTICourseMap => 1,
 			%optional_arguments
 		);
 	};

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -498,9 +498,9 @@ sub addCourse {
 %options may also contain:
 
  skipDBRename => $skipDBRename,
- courseTitle => $courseTitle
- courseInstitution => $courseInstitution
-
+ courseTitle => $courseTitle,
+ courseInstitution => $courseInstitution,
+ updateLTICourseMap => $updateLTICourseMap
 
 Rename the course named $courseID to $newCourseID.
 
@@ -509,15 +509,15 @@ environment.
 
 The name of the course's directory is changed to $newCourseID.
 
-If the course's database layout is C<sql_single> or C<sql_moodle>, new tables
-are created in the current database, course data is copied from the old tables
-to the new tables, and the old tables are deleted.
-
-If the course's database layout is something else, no database changes are made.
+New tables are created in the current database, course data is copied from the
+old tables to the new tables, and the old tables are deleted.
 
 If $skipDBRename is true, no database changes are made. This is useful if a
 course is being unarchived and no database was found, or for renaming the
 modelCourse.
+
+If $updateLTICourseMap is true, then the LTI course map is updated to associate
+the LMS context id to the new course name.
 
 Any errors encountered while renaming the course are returned.
 
@@ -635,6 +635,16 @@ sub renameCourse {
 			}
 		};
 		warn "Problems from resetting course title and institution = $@" if $@;
+
+		# Remap the LTI course mapping for the renamed course to the new course if that is requested.
+		if ($options{updateLTICourseMap}) {
+			my @ltiCourseMaps = $newDB->getLTICourseMapsWhere({ course_id => $oldCE->{courseName} });
+			$newDB->deleteLTICourseMapWhere({ course_id => $oldCE->{courseName} });
+			for (@ltiCourseMaps) {
+				$newDB->setLTICourseMap($newCE->{courseName}, $_->lms_context_id);
+				last;
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
This deletes the course map entry for the course's previous name, and then creates a new entry for the course's new name.

Since the `renameCourse` method is also used when unarchiving a course to a different name, care needs to be taken to ensure that this is only done for a course rename, and not for that situation. Thus there is a new `updateLTICourseMap` option for the method.  This is only true when the method is called to rename a course directly.

This addresses issue #2824.