### PR TITLE
Fix the math in the test page navigation.

### DIFF
--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -459,7 +459,9 @@
 			% end
 			% for my $i (1 .. $numPages) {
 				% content_for 'gw-navigation-pages' => begin
-					<td colspan="<%= $i == $numPages ? (@$problem_numbers % $numProbPerPage) : $numProbPerPage %>"
+					<td colspan="<%= $i == $numPages && (@$problem_numbers % $numProbPerPage)
+						? (@$problem_numbers % $numProbPerPage)
+						: $numProbPerPage %>"
 						class="<%= $i == $pageNumber ? 'page active' : 'page' %>">
 						% if ($i == $pageNumber) {
 							<%= $i =%>


### PR DESCRIPTION
I had the math wrong in #2818.  It is correct if the number of problems does not evenly divide the number of problems per page, but if it does then the modulus returns 0.  In that case it should also use the number of problems per page.