### PR TITLE
Add the hidden authentication fields to the LTI update form.

### DIFF
--- a/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
+++ b/templates/ContentGenerator/Instructor/LTIUpdate.html.ep
@@ -47,6 +47,7 @@
 %
 <h2><%= maketext('Start LTI Grade Update') %></h2>
 <%= form_for current_route, method => 'POST', id => 'updateLTIForm', name => 'updateLTIForm', begin =%>
+	<%= $c->hidden_authen_fields =%>
 	<div class="row mb-3">
 		<%= label_for updateUserID => maketext('Update user:'), class => 'col-auto col-form-label fw-bold' =%>
 		<div class="col-auto">


### PR DESCRIPTION
The content generator `hidden_authen_fields` method should be called in all page forms, but was not added ot the form in the LTI update page. As a result if you are acting as a student, go to that page, and click "Update Grades", then the acting ceases. Even worse, if `session_management_via` is set to "key", and you click "Update Grades", then you are sent to the login page, and have to login again in order for the form to submit.  I missed this when this page was created. @somiaj observed the issue when acting as another user on the page.