### PR TITLE
Make MathJax show errors for bad TeX. (alternate approach)

### DIFF
--- a/htdocs/js/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/MathJaxConfig/mathjax-config.js
@@ -1,7 +1,6 @@
 if (!window.MathJax) {
 	window.MathJax = {
-		tex: { packages: { '[+]': ['noerrors'] } },
-		loader: { load: ['input/asciimath', '[tex]/noerrors'] },
+		loader: { load: ['input/asciimath'] },
 		startup: {
 			ready() {
 				const AM = MathJax.InputJax.AsciiMath.AM;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -32,6 +32,7 @@ use MIME::Base64;
 use Scalar::Util qw(weaken);
 use HTML::Entities;
 use Encode;
+use Mojo::JSON qw(encode_json);
 
 use WeBWorK::File::Scoring qw(parse_scoring_file);
 use WeBWorK::Localize;
@@ -682,20 +683,15 @@ sub page_title ($c) {
 	return route_title($c, $c->current_route, 1);
 }
 
-=item webwork_url
+=item webwork_js_config
 
-Defined in this package.
-
-Outputs the $webwork_url defined in site.conf, unless $webwork_url is equal to
-"/", in which case this outputs the empty string.
-
-This is used to set a value in a global webworkConfig javascript variable,
-that can be accessed in javascript files.
+Outputs the webwork2 JavaScript configuration.  This configuration can be
+accessed by JavaScript files to obtain various webwork2 settings.
 
 =cut
 
-sub webwork_url ($c) {
-	return $c->location;
+sub webwork_js_config ($c) {
+	return encode_json({ webwork_url => $c->location });
 }
 
 =item warnings()

--- a/templates/ContentGenerator/SampleProblemViewer.html.ep
+++ b/templates/ContentGenerator/SampleProblemViewer.html.ep
@@ -14,7 +14,7 @@
 	<%= javascript $c->url({
 		type => 'webwork', name => 'htdocs', file => 'node_modules/minisearch/dist/umd/index.js'
 	}), defer => undef =%>
-	<script>const webworkConfig = { webwork_url: '<%= $c->webwork_url %>' };</script>
+	<script>const webworkConfig = <%== $c->webwork_js_config %>;</script>
 	<%= javascript $c->url({
 		type => 'webwork', name => 'htdocs', file => 'js/SampleProblemViewer/documentation-search.js'
 	}), defer => undef =%>

--- a/templates/layouts/system.html.ep
+++ b/templates/layouts/system.html.ep
@@ -20,7 +20,7 @@
 % }
 %
 % # Webwork configuration for javascript
-<script>const webworkConfig = { webwork_url: '<%= $c->webwork_url %>' };</script>
+<script>const webworkConfig = <%== $c->webwork_js_config %>;</script>
 %
 % # JS Loads
 <%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'js/MathJaxConfig/mathjax-config.js' }),


### PR DESCRIPTION
There have been requests to either remove this extension or at least make it so that those editing problems do not have it loaded, as it makes it easier to determine what is wrong with TeX in a problem.

This pull request just removes the `noerrors` MathJax extension. So TeX errors are shown for all users.

I am not sure why this package was added. It seems that I added it when I upgraded from MathJax version 2 to version 3, but I don't remember why.  Perhaps it was just in the configuration that @dpvc recommended, or maybe I added it for some reason.  Perhaps it was just about maintaining compatibility with version 2 of MathJax.  For version 2 (as I understand it), the `noerrors` extension was included by default, but with MathJax version 3 it must be explicitly loaded.

The change from the `webwork_url` to the `webwork_js_config` method in the `WeBWorK::ContentGenerator` module is not needed for this, but should be made anyway.  There is also a `webwork_url` method in the `Mojolicious::WeBWorK` module that is already available for all controller modules (since it is a Mojolicious helper method), and having this other one overrides that one and it is confusing to have both that return almost the same value.  The only difference is that `WeBWorK::ContentGenerator` method called the `location` helper which returns the empty string if the root URL is '/', and the `webwork_url` helper returns '/' in that case. I don't know what I was thinking creating the `WeBWorK::ContentGenerator` method which was really just an alies for the `location` helper method anyway.