### PR TITLE
Remove the `Plots::GD` PG module dependency.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1286,7 +1286,7 @@ ${pg}{modules} = [
 	[qw(Matrix)],
 	[qw(Multiple)],
 	[qw(PGrandom)],
-	[qw(Plots::Plot Plots::Axes Plots::Data Plots::Tikz Plots::JSXGraph Plots::GD)],
+	[qw(Plots::Plot Plots::Axes Plots::Data Plots::Tikz Plots::JSXGraph)],
 	[qw(Regression)],
 	[qw(Select)],
 	[qw(Units)],


### PR DESCRIPTION
The `Plots::GD` module is removed in https://github.com/openwebwork/pg/pull/1336.  So remove it from the `${pg}{modules}` array.