### PR TITLE
Add a standalone variant to check_latex.

### DIFF
--- a/bin/check_latex
+++ b/bin/check_latex
@@ -13,8 +13,8 @@ use feature 'say';
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use YAML::XS qw(LoadFile);
-	use Env qw(WEBWORK_ROOT PG_ROOT);
+	use YAML::XS   qw(LoadFile);
+	use Env        qw(WEBWORK_ROOT PG_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname->to_string;
 
@@ -51,7 +51,9 @@ my $latex_cmd =
 	. shell_quote($ce->{webworkDirs}{assetsTex}) . ':'
 	. shell_quote($ce->{pg}{directories}{assetsTex}) . ': '
 	. $ce->{externalPrograms}{latex2pdf}
-	. ' -interaction nonstopmode check_latex_exam.tex >> check_latex.nfo 2>&1';
+	. ' -interaction nonstopmode check_latex_exam.tex >> check_latex.nfo 2>&1 &&'
+	. "TEXINPUTS=$ENV{WEBWORK_ROOT}/bin: $ce->{externalPrograms}{latex2pdf}"
+	. ' -interaction nonstopmode check_latex_standalone.tex > check_latex.nfo 2>&1';
 
 if ((system $latex_cmd) >> 8) {
 	if (open(my $fh, '<', "$temp_dir/check_latex.nfo")) {

--- a/bin/check_latex_article.tex
+++ b/bin/check_latex_article.tex
@@ -8,7 +8,7 @@
 \usepackage{multicol}
 \usepackage{tcolorbox}
 
-\usepackage[active,textmath,displaymath]{preview}  % needed for dvipng
+\usepackage[textmath,displaymath]{preview}  % needed for dvipng
 
 \setlength{\columnsep}{.25in}
 \setlength{\columnseprule}{.4pt}

--- a/bin/check_latex_exam.tex
+++ b/bin/check_latex_exam.tex
@@ -9,7 +9,7 @@
   \usepackage{bidi}
 \fi
 
-\usepackage[active,textmath,displaymath]{preview}  % needed for dvipng
+\usepackage[textmath,displaymath]{preview}  % needed for dvipng
 
 \setlength{\columnsep}{.25in}
 \setlength{\columnseprule}{.4pt}

--- a/bin/check_latex_standalone.tex
+++ b/bin/check_latex_standalone.tex
@@ -1,0 +1,22 @@
+\documentclass{standalone}
+
+\usepackage[svgnames]{xcolor}
+\usepackage{tikz}
+\usepackage{pgfplots}
+\usetikzlibrary{arrows.meta,plotmarks,calc,spath3}
+\usepgfplotslibrary{fillbetween}
+\pgfplotsset{compat = 1.18}
+
+\begin{document}
+
+\begin{tikzpicture}
+	\begin{axis}
+		\addplot[name path=pathA, domain=-3:3, draw=none, mark=triangle*] {(x^2)};
+		\draw[{Stealth}-{Stealth}, spath/use=pathA];
+		\draw ($(-1, 0) + (10pt, 10pt)$) -- ($(1, 3) - (10pt, 10pt)$);
+		\addplot[name path=pathB, domain=-3:3] {(-x^2 + 3)};
+		\addplot[green, fill opacity=0.3] fill between[of=pathA and pathB];
+	\end{axis}
+\end{tikzpicture}
+
+\end{document}


### PR DESCRIPTION
The packages and TikZ libraries that are used by pg are all tested (including the TikZ spath3 library that is going to be used once https://github.com/openwebwork/pg/pull/1336 is merged).

Note that the "active" option was removed from the preview package in the check_latex_article.tex and check_latex_exam.tex files because that suppresses output.  It is enough to test that the preview package loads, and this makes the more important things that are being tested more like they are for actual hardcopy generation and not for equation generation. We really need to remove images mode.