### PR TITLE
Make MathJax show errors for bad TeX but only in the problem editor. (another alternate for #2837 and #2838)

### DIFF
--- a/htdocs/js/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/MathJaxConfig/mathjax-config.js
@@ -1,6 +1,6 @@
 if (!window.MathJax) {
 	window.MathJax = {
-		tex: { packages: { '[+]': ['noerrors'] } },
+		tex: { packages: { '[+]': webworkConfig?.showMathJaxErrors ? [] : ['noerrors'] } },
 		loader: { load: ['input/asciimath', '[tex]/noerrors'] },
 		startup: {
 			ready() {

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -382,6 +382,7 @@
 				requestData.set('send_pg_flags', 1);
 				requestData.set(button.name, button.value);
 				requestData.set('set_id', document.getElementsByName('hidden_set_id')[0]?.value ?? 'Unknown Set');
+				requestData.set('showMathJaxErrors', 1);
 
 				await renderProblem(requestData);
 
@@ -473,7 +474,8 @@
 					displayMode: document.getElementById('action_view_displayMode_id')?.value ?? 'MathJax',
 					language: document.querySelector('input[name="hidden_language"]')?.value ?? 'en',
 					send_pg_flags: 1,
-					view_problem_debugging_info: 1
+					view_problem_debugging_info: 1,
+					showMathJaxErrors: 1
 				})
 			).then(() => resolve());
 		});

--- a/lib/FormatRenderedProblem.pm
+++ b/lib/FormatRenderedProblem.pm
@@ -267,6 +267,7 @@ sub formatRenderedProblem {
 		showCorrectAnswersOnlyButton => $ws->{inputs_ref}{showCorrectAnswersOnlyButton} // 0,
 		showFooter                   => $ws->{inputs_ref}{showFooter}                   // '',
 		problem_data                 => encode_json($rh_result->{PERSISTENCE_HASH}),
+		showMathJaxErrors            => $ws->{inputs_ref}{showMathJaxErrors} // 0,
 		pretty_print                 => \&pretty_print
 	);
 

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -32,6 +32,7 @@ use MIME::Base64;
 use Scalar::Util qw(weaken);
 use HTML::Entities;
 use Encode;
+use Mojo::JSON qw(encode_json);
 
 use WeBWorK::File::Scoring qw(parse_scoring_file);
 use WeBWorK::Localize;
@@ -682,20 +683,15 @@ sub page_title ($c) {
 	return route_title($c, $c->current_route, 1);
 }
 
-=item webwork_url
+=item webwork_js_config
 
-Defined in this package.
-
-Outputs the $webwork_url defined in site.conf, unless $webwork_url is equal to
-"/", in which case this outputs the empty string.
-
-This is used to set a value in a global webworkConfig javascript variable,
-that can be accessed in javascript files.
+Outputs the webwork2 JavaScript configuration.  This configuration can be
+accessed by JavaScript files to obtain various webwork2 settings.
 
 =cut
 
-sub webwork_url ($c) {
-	return $c->location;
+sub webwork_js_config ($c) {
+	return encode_json({ webwork_url => $c->location });
 }
 
 =item warnings()

--- a/templates/ContentGenerator/SampleProblemViewer.html.ep
+++ b/templates/ContentGenerator/SampleProblemViewer.html.ep
@@ -14,7 +14,7 @@
 	<%= javascript $c->url({
 		type => 'webwork', name => 'htdocs', file => 'node_modules/minisearch/dist/umd/index.js'
 	}), defer => undef =%>
-	<script>const webworkConfig = { webwork_url: '<%= $c->webwork_url %>' };</script>
+	<script>const webworkConfig = <%== $c->webwork_js_config %>;</script>
 	<%= javascript $c->url({
 		type => 'webwork', name => 'htdocs', file => 'js/SampleProblemViewer/documentation-search.js'
 	}), defer => undef =%>

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -19,6 +19,7 @@
 	% for (@$extra_css_files) {
 		%= stylesheet $_->{file}
 	% }
+	<script>const webworkConfig = <%= $showMathJaxErrors ? '{ showMathJaxErrors: true }' : 'null' %>;</script>
 	% for (@$third_party_js) {
 		%= javascript $_->[0], %{ $_->[1] // {} }
 	% }

--- a/templates/layouts/system.html.ep
+++ b/templates/layouts/system.html.ep
@@ -20,7 +20,7 @@
 % }
 %
 % # Webwork configuration for javascript
-<script>const webworkConfig = { webwork_url: '<%= $c->webwork_url %>' };</script>
+<script>const webworkConfig = <%== $c->webwork_js_config %>;</script>
 %
 % # JS Loads
 <%= javascript $c->url({ type => 'webwork', name => 'htdocs', file => 'js/MathJaxConfig/mathjax-config.js' }),


### PR DESCRIPTION
There have been requests to either remove this extension or at least make it so that those editing problems do not have it loaded, as it makes it easier to determine what is wrong with TeX in a problem.

This pull request makes it so that these errors are only shown in the PG problem editor. Actually they are shown any time the renderRPC endpoint is used and the `showMathJaxErrors` parameter is set to a true value, but the only time that webwork2 now does this is in the problem editor.

Of #2837, #2838, and this pull request, I think this is the way to go.

This still includes thhe change from the `webwork_url` to the `webwork_js_config` method in the `WeBWorK::ContentGenerator` module. There is also a `webwork_url` method in the `Mojolicious::WeBWorK` module that is already available for all controller modules (since it is a Mojolicious helper method), and having this other one overrides that one and it is confusing to have both that return almost the same value. The only difference is that `WeBWorK::ContentGenerator` method called the `location` helper which returns the empty string if the root URL is '/', and the `webwork_url` helper returns '/' in that case. I don't know what I was thinking creating the `WeBWorK::ContentGenerator` method which was really just an alies for the `location` helper method anyway.