### PR TITLE
Add permissions to render problems with WebworkWebservice.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -780,6 +780,13 @@ $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 	modify_tags                    => "admin",
 	edit_restricted_files          => "admin",
 
+	# Permission to render problems using the WebworkWebservice.
+	# Users with only webservice_render_problem can render problems with a provided filename.
+	# Users with both permissions can also render problems with providing the problem source.
+	# Note the Problem Editor requires having both permissions.
+	webservice_render_problem      => "login_proctor",
+	webservice_render_source       => "login_proctor",
+
 	##### Behavior of the interactive problem processor #####
 	show_correct_answers_before_answer_date         => "ta",
 	show_solutions_before_answer_date               => "ta",

--- a/lib/WebworkWebservice.pm
+++ b/lib/WebworkWebservice.pm
@@ -257,7 +257,7 @@ sub command_permission {
 		convertCodeToPGML => 'access_instructor_tools',
 
 		# WebworkWebservice::RenderProblem
-		renderProblem => 'proctor_quiz_login',
+		renderProblem => 'webservice_render_problem',
 
 		# WebworkWebservice::SetActions
 		listGlobalSets        => 'access_instructor_tools',

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -26,6 +26,14 @@ async sub renderProblem {
 	# is enabled.  That is an expensive method to always call here.
 	debug(pretty_print_rh($rh)) if $WeBWorK::Debug::Enabled;
 
+	# If the problem source is provided, check user is allow to render problem source.
+	if (!$ws->authz->hasPermissions($rh->{user}, 'webservice_render_source')
+		&& ($rh->{problemSource} || $rh->{rawProblemSource} || $rh->{uriEncodedProblemSource}))
+	{
+		$ws->error_string(__PACKAGE__ . ": User $rh->{user} does not have permission to render problem source.");
+		return {};
+	}
+
 	my $problemSeed = $rh->{problemSeed} // '1234';
 
 	my $beginTime = Benchmark->new;


### PR DESCRIPTION
First, this adds the permission `webservice_render_problem` used to determine if a user can render a problem with the WebworkWebservice, instead of using the `proctor_quiz_login` permission for this.

Second, this adds an additional permission `webservice_render_source` used to determine if a user can render problems using the problem provided with the request. The use case for this is to allow users which can render problems only using a problem filename, but not by providing the problem's source.

These permissions are both set to `login_proctor` to match current behavior and are provided to allow server admins to change which users can render problems. These permissions are not added to the course configuration page as they are permissions that should not be modified by most users, only server admins via `localOverrides.conf` or `course.conf`.

One way to test this is to set `webservice_render_source` to `nobody`, and see that pages like the library browser still work since rendering is done via filenames, but the problem editor no longer works.