### PR TITLE
Add an option to add headers to only SSL request responses.

### DIFF
--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -72,6 +72,16 @@ JSON_ERROR_LOG: 0
 #  /pg_files:
 #    Access-Control-Allow-Origin: '*'
 
+# The extra_ssl_headers option is much like the extra_headers option above,
+# except that these headers are only added to responses to secure SSL requests.
+# The example below adds the Strict-Transport-Security header to responses to
+# all SSL requests. Note that like the extra_headers option above, headers can
+# be added to only specific paths as well (but only if the request is secure).
+
+#extra_ssl_headers:
+#  '.*':
+#    Strict-Transport-Security: 'max-age=31536000; includeSubDomains; preload'
+
 # The user and group to run the server as.  These are only used when the
 # webwork2 app is in production mode and run as the root user.  This means that
 # these settings are not used when proxying via another web server like apache2

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -100,13 +100,24 @@ sub startup ($app) {
 	);
 
 	# Add a hook to add extra headers if set in the config file.
-	if (ref $config->{extra_headers} eq 'HASH') {
+	if (ref $config->{extra_headers} eq 'HASH' || ref $config->{extra_ssl_headers} eq 'HASH') {
+		my $extraHeaders    = ref $config->{extra_headers} eq 'HASH'     ? $config->{extra_headers}     : {};
+		my $extraSSLHeaders = ref $config->{extra_ssl_headers} eq 'HASH' ? $config->{extra_ssl_headers} : {};
 		$app->hook(
 			before_dispatch => sub ($c) {
-				for my $path (keys %{ $config->{extra_headers} }) {
+				for my $path (keys %$extraHeaders) {
 					if ($c->req->url->path =~ /^$path/) {
-						for (keys %{ $config->{extra_headers}{$path} }) {
-							$c->res->headers->header($_ => $config->{extra_headers}{$path}{$_});
+						for (keys %{ $extraHeaders->{$path} }) {
+							$c->res->headers->header($_ => $extraHeaders->{$path}{$_});
+						}
+					}
+				}
+				if ($c->req->is_secure) {
+					for my $path (keys %$extraSSLHeaders) {
+						if ($c->req->url->path =~ /^$path/) {
+							for (keys %{ $extraSSLHeaders->{$path} }) {
+								$c->res->headers->header($_ => $extraSSLHeaders->{$path}{$_});
+							}
 						}
 					}
 				}


### PR DESCRIPTION
The option is `extra_ssl_headers` in the `conf/webwork2.mojolicious.yml` file.  It works just like the `extra_headers` option, except that the headers are only added to responses to secure requests.

This is to address a need to add the `Strict-Transport-Security` header to SSL request responses that was brought up in the forums.  See https://forums.openwebwork.org/mod/forum/discuss.php?d=8782#p22468. That header should not be added to non SSL requests.