### PR TITLE
Update the @openwebwork/pg-codemirror-editor dependency.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^7.0.0",
-				"@openwebwork/pg-codemirror-editor": "^0.0.5",
+				"@openwebwork/pg-codemirror-editor": "^0.0.6",
 				"bootstrap": "~5.3.7",
 				"flatpickr": "^4.6.13",
 				"iframe-resizer": "^4.4.2",
@@ -33,9 +33,9 @@
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
-			"version": "6.18.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
-			"integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -45,9 +45,9 @@
 			}
 		},
 		"node_modules/@codemirror/commands": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
-			"integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
+			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -70,9 +70,9 @@
 			}
 		},
 		"node_modules/@codemirror/lang-html": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
-			"integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
+			"version": "6.4.11",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+			"integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -83,7 +83,7 @@
 				"@codemirror/view": "^6.17.0",
 				"@lezer/common": "^1.0.0",
 				"@lezer/css": "^1.1.0",
-				"@lezer/html": "^1.3.0"
+				"@lezer/html": "^1.3.12"
 			}
 		},
 		"node_modules/@codemirror/lang-javascript": {
@@ -116,9 +116,9 @@
 			}
 		},
 		"node_modules/@codemirror/language": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
-			"integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -130,9 +130,9 @@
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.8.5",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
-			"integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+			"version": "6.9.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
+			"integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -173,9 +173,9 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.37.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.2.tgz",
-			"integrity": "sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==",
+			"version": "6.38.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
+			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
@@ -244,15 +244,15 @@
 			}
 		},
 		"node_modules/@lezer/common": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
-			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA==",
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
+			"integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==",
 			"license": "MIT"
 		},
 		"node_modules/@lezer/css": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.2.1.tgz",
-			"integrity": "sha512-2F5tOqzKEKbCUNraIXc0f6HKeyKlmMWJnBB0i4XW6dJgssrZO/YlZ2pY5xgyqDleqqhiNJ3dQhbrV2aClZQMvg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+			"integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -261,18 +261,18 @@
 			}
 		},
 		"node_modules/@lezer/highlight": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
 			"license": "MIT",
 			"dependencies": {
-				"@lezer/common": "^1.0.0"
+				"@lezer/common": "^1.3.0"
 			}
 		},
 		"node_modules/@lezer/html": {
-			"version": "1.3.10",
-			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
-			"integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
+			"integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -281,9 +281,9 @@
 			}
 		},
 		"node_modules/@lezer/javascript": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
-			"integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+			"integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -292,9 +292,9 @@
 			}
 		},
 		"node_modules/@lezer/lr": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
-			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.4.tgz",
+			"integrity": "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
@@ -324,26 +324,26 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.3.tgz",
-			"integrity": "sha512-ZKtb2r0Ck6tVz44wwMKY7w/82P470whIzM5C8pi2GiBlnFWmkQcadmOaCBz31FELY1SrKE3AO2TmMrwUt2EKPA==",
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.4.tgz",
+			"integrity": "sha512-lNA9PVTRDNWfmL87ux3zbFQfih+6tXKJdz+yA1CPbHWaNuNY+OK9dur+Ul5H6Hi6flGWlcE674/eMmkelLRAng==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"node_modules/@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.5.tgz",
-			"integrity": "sha512-ue4aciJzF7PPdQwWvYQkSf7h3pqOSM21fXyQ1vXRNndiQ7TCNX6FBI5JalMWDzi7CttGR+Mj+PgffmADwmKIMg==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.6.tgz",
+			"integrity": "sha512-M9pq1FuIgq3LPd1wre1O9tH5goYsOpcXlbiTpJ15e2aP7b3cHeEUgE1Dk/w8x0ZQjH45TWlh5aTSXeLDsMQGwA==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/lang-html": "^6.4.9",
+				"@codemirror/lang-html": "^6.4.11",
 				"@codemirror/lang-xml": "^6.1.0",
-				"@codemirror/theme-one-dark": "^6.1.2",
-				"@openwebwork/codemirror-lang-pg": "^0.0.3",
+				"@codemirror/theme-one-dark": "^6.1.3",
+				"@openwebwork/codemirror-lang-pg": "^0.0.4",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -354,10 +354,10 @@
 				"cm6-theme-nord": "^0.2.0",
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
-				"codemirror": "^6.0.1",
-				"codemirror-lang-mt": "^0.0.3",
-				"codemirror-lang-perl": "^0.1.6",
-				"style-mod": "^4.1.2",
+				"codemirror": "^6.0.2",
+				"codemirror-lang-mt": "^0.0.4",
+				"codemirror-lang-perl": "^0.1.7",
+				"style-mod": "^4.1.3",
 				"thememirror": "^2.0.1"
 			}
 		},
@@ -1042,28 +1042,28 @@
 			}
 		},
 		"node_modules/codemirror-lang-mt": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.3.tgz",
-			"integrity": "sha512-OC2qG6GQI96BTgKzD4XVJd8fLOTyeB0pb7gy41BHjqot2gES6Bi/3esIgTygYUxw/SspMNSZnQZdWHPmD7/YYA==",
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.4.tgz",
+			"integrity": "sha512-8jKq4H0JG/mZQwz8TaV1KP1PBL14UKj9icpIB2ZwQ05e+MlvvJbt4Q6DoSXHghbP++4frzDkgRgIDZjMJ3I0+Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-css": "^6.3.1",
-				"@codemirror/lang-html": "^6.4.9",
-				"@codemirror/lang-javascript": "^6.2.3",
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/lang-html": "^6.4.11",
+				"@codemirror/lang-javascript": "^6.2.4",
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"node_modules/codemirror-lang-perl": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.6.tgz",
-			"integrity": "sha512-cYBmCQa7/itIRNx1AHfn9OQkInJQpL0sqCoikJXhQZwYNOHFSMd0L16pofEOU/1/f+s7CPA+XucUrNr/f1qigQ==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.7.tgz",
+			"integrity": "sha512-GxGVpHIUVzVnsJDd7zpkm5S+t+mgFI+XAY4jOmocaUMRuCsPzLLbYX9VJ6LkFY00bJDwrtKSS503lSsocX46xQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"node_modules/colord": {
@@ -2320,9 +2320,9 @@
 			}
 		},
 		"node_modules/style-mod": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
 			"license": "MIT"
 		},
 		"node_modules/stylehacks": {
@@ -2522,9 +2522,9 @@
 	},
 	"dependencies": {
 		"@codemirror/autocomplete": {
-			"version": "6.18.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.18.6.tgz",
-			"integrity": "sha512-PHHBXFomUs5DF+9tCOM/UoW6XQ4R44lLNNhRaW9PKPTU0D7lIjRg3ElxaJnTwsl/oHiR93WSXDBrekhoUGCPtg==",
+			"version": "6.20.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
+			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2533,9 +2533,9 @@
 			}
 		},
 		"@codemirror/commands": {
-			"version": "6.8.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.8.1.tgz",
-			"integrity": "sha512-KlGVYufHMQzxbdQONiLyGQDUW0itrLZwq3CcY7xpv9ZLRHqzkBSoteocBHtMCoY7/Ci4xhzSrToIeLg7FxHuaw==",
+			"version": "6.10.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
+			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.4.0",
@@ -2556,9 +2556,9 @@
 			}
 		},
 		"@codemirror/lang-html": {
-			"version": "6.4.9",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.9.tgz",
-			"integrity": "sha512-aQv37pIMSlueybId/2PVSP6NPnmurFDVmZwzc7jszd2KAF8qd4VBbvNYPXWQq90WIARjsdVkPbw29pszmHws3Q==",
+			"version": "6.4.11",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-html/-/lang-html-6.4.11.tgz",
+			"integrity": "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/lang-css": "^6.0.0",
@@ -2568,7 +2568,7 @@
 				"@codemirror/view": "^6.17.0",
 				"@lezer/common": "^1.0.0",
 				"@lezer/css": "^1.1.0",
-				"@lezer/html": "^1.3.0"
+				"@lezer/html": "^1.3.12"
 			}
 		},
 		"@codemirror/lang-javascript": {
@@ -2599,9 +2599,9 @@
 			}
 		},
 		"@codemirror/language": {
-			"version": "6.11.1",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.1.tgz",
-			"integrity": "sha512-5kS1U7emOGV84vxC+ruBty5sUgcD0te6dyupyRVG2zaSjhTDM73LhVKUtVwiqSe6QwmEoA4SCiU8AKPFyumAWQ==",
+			"version": "6.11.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
+			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -2612,9 +2612,9 @@
 			}
 		},
 		"@codemirror/lint": {
-			"version": "6.8.5",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.8.5.tgz",
-			"integrity": "sha512-s3n3KisH7dx3vsoeGMxsbRAgKe4O1vbrnKBClm99PU0fWxmxsx5rR2PfqQgIt+2MMJBHbiJ5rfIdLYfB9NNvsA==",
+			"version": "6.9.2",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
+			"integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.35.0",
@@ -2651,9 +2651,9 @@
 			}
 		},
 		"@codemirror/view": {
-			"version": "6.37.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.37.2.tgz",
-			"integrity": "sha512-XD3LdgQpxQs5jhOOZ2HRVT+Rj59O4Suc7g2ULvZ+Yi8eCkickrkZ5JFuoDhs2ST1mNI5zSsNYgR3NGa4OUrbnw==",
+			"version": "6.38.8",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
+			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
 			"requires": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -2709,14 +2709,14 @@
 			}
 		},
 		"@lezer/common": {
-			"version": "1.2.3",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.2.3.tgz",
-			"integrity": "sha512-w7ojc8ejBqr2REPsWxJjrMFsA/ysDCFICn8zEOR9mrqzOu2amhITYuLD8ag6XZf0CFXDrhKqw7+tW8cX66NaDA=="
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
+			"integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="
 		},
 		"@lezer/css": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.2.1.tgz",
-			"integrity": "sha512-2F5tOqzKEKbCUNraIXc0f6HKeyKlmMWJnBB0i4XW6dJgssrZO/YlZ2pY5xgyqDleqqhiNJ3dQhbrV2aClZQMvg==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
+			"integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
@@ -2724,17 +2724,17 @@
 			}
 		},
 		"@lezer/highlight": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.1.tgz",
-			"integrity": "sha512-Z5duk4RN/3zuVO7Jq0pGLJ3qynpxUVsh7IbUbGj88+uV2ApSAn6kWg2au3iJb+0Zi7kKtqffIESgNcRXWZWmSA==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
 			"requires": {
-				"@lezer/common": "^1.0.0"
+				"@lezer/common": "^1.3.0"
 			}
 		},
 		"@lezer/html": {
-			"version": "1.3.10",
-			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.10.tgz",
-			"integrity": "sha512-dqpT8nISx/p9Do3AchvYGV3qYc4/rKr3IBZxlHmpIKam56P47RSHkSF5f13Vu9hebS1jM0HmtJIwLbWz1VIY6w==",
+			"version": "1.3.12",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
+			"integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
@@ -2742,9 +2742,9 @@
 			}
 		},
 		"@lezer/javascript": {
-			"version": "1.5.1",
-			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.1.tgz",
-			"integrity": "sha512-ATOImjeVJuvgm3JQ/bpo2Tmv55HSScE2MTPnKRMRIPx2cLhHGyX2VnqpHhtIV1tVzIjZDbcWQm+NCTF40ggZVw==",
+			"version": "1.5.4",
+			"resolved": "https://registry.npmjs.org/@lezer/javascript/-/javascript-1.5.4.tgz",
+			"integrity": "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.1.3",
@@ -2752,9 +2752,9 @@
 			}
 		},
 		"@lezer/lr": {
-			"version": "1.4.2",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.2.tgz",
-			"integrity": "sha512-pu0K1jCIdnQ12aWNaAVU5bzi7Bd1w54J3ECgANPmYLtQKP0HBj2cE/5coBD66MT10xbtIuUr7tg0Shbsvk0mDA==",
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.4.tgz",
+			"integrity": "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A==",
 			"requires": {
 				"@lezer/common": "^1.0.0"
 			}
@@ -2780,24 +2780,24 @@
 			"integrity": "sha512-kpsJgIF4FpWiwIkFgOPmWwy5GXfL25spmJJNg27HQxPddmEL8Blx0jn2BuU/nlwjM/9SnYpEfDrWiAMgLPlB8Q=="
 		},
 		"@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.3.tgz",
-			"integrity": "sha512-ZKtb2r0Ck6tVz44wwMKY7w/82P470whIzM5C8pi2GiBlnFWmkQcadmOaCBz31FELY1SrKE3AO2TmMrwUt2EKPA==",
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.4.tgz",
+			"integrity": "sha512-lNA9PVTRDNWfmL87ux3zbFQfih+6tXKJdz+yA1CPbHWaNuNY+OK9dur+Ul5H6Hi6flGWlcE674/eMmkelLRAng==",
 			"requires": {
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.5",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.5.tgz",
-			"integrity": "sha512-ue4aciJzF7PPdQwWvYQkSf7h3pqOSM21fXyQ1vXRNndiQ7TCNX6FBI5JalMWDzi7CttGR+Mj+PgffmADwmKIMg==",
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.6.tgz",
+			"integrity": "sha512-M9pq1FuIgq3LPd1wre1O9tH5goYsOpcXlbiTpJ15e2aP7b3cHeEUgE1Dk/w8x0ZQjH45TWlh5aTSXeLDsMQGwA==",
 			"requires": {
-				"@codemirror/lang-html": "^6.4.9",
+				"@codemirror/lang-html": "^6.4.11",
 				"@codemirror/lang-xml": "^6.1.0",
-				"@codemirror/theme-one-dark": "^6.1.2",
-				"@openwebwork/codemirror-lang-pg": "^0.0.3",
+				"@codemirror/theme-one-dark": "^6.1.3",
+				"@openwebwork/codemirror-lang-pg": "^0.0.4",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -2808,10 +2808,10 @@
 				"cm6-theme-nord": "^0.2.0",
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
-				"codemirror": "^6.0.1",
-				"codemirror-lang-mt": "^0.0.3",
-				"codemirror-lang-perl": "^0.1.6",
-				"style-mod": "^4.1.2",
+				"codemirror": "^6.0.2",
+				"codemirror-lang-mt": "^0.0.4",
+				"codemirror-lang-perl": "^0.1.7",
+				"style-mod": "^4.1.3",
 				"thememirror": "^2.0.1"
 			}
 		},
@@ -3123,26 +3123,26 @@
 			}
 		},
 		"codemirror-lang-mt": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.3.tgz",
-			"integrity": "sha512-OC2qG6GQI96BTgKzD4XVJd8fLOTyeB0pb7gy41BHjqot2gES6Bi/3esIgTygYUxw/SspMNSZnQZdWHPmD7/YYA==",
+			"version": "0.0.4",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.4.tgz",
+			"integrity": "sha512-8jKq4H0JG/mZQwz8TaV1KP1PBL14UKj9icpIB2ZwQ05e+MlvvJbt4Q6DoSXHghbP++4frzDkgRgIDZjMJ3I0+Q==",
 			"requires": {
 				"@codemirror/lang-css": "^6.3.1",
-				"@codemirror/lang-html": "^6.4.9",
-				"@codemirror/lang-javascript": "^6.2.3",
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/lang-html": "^6.4.11",
+				"@codemirror/lang-javascript": "^6.2.4",
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"codemirror-lang-perl": {
-			"version": "0.1.6",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.6.tgz",
-			"integrity": "sha512-cYBmCQa7/itIRNx1AHfn9OQkInJQpL0sqCoikJXhQZwYNOHFSMd0L16pofEOU/1/f+s7CPA+XucUrNr/f1qigQ==",
+			"version": "0.1.7",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.7.tgz",
+			"integrity": "sha512-GxGVpHIUVzVnsJDd7zpkm5S+t+mgFI+XAY4jOmocaUMRuCsPzLLbYX9VJ6LkFY00bJDwrtKSS503lSsocX46xQ==",
 			"requires": {
-				"@codemirror/language": "^6.11.0",
-				"@lezer/highlight": "^1.2.1",
-				"@lezer/lr": "^1.4.2"
+				"@codemirror/language": "^6.11.3",
+				"@lezer/highlight": "^1.2.3",
+				"@lezer/lr": "^1.4.4"
 			}
 		},
 		"colord": {
@@ -3916,9 +3916,9 @@
 			"dev": true
 		},
 		"style-mod": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.2.tgz",
-			"integrity": "sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw=="
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+			"integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="
 		},
 		"stylehacks": {
 			"version": "7.0.6",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^7.0.0",
-		"@openwebwork/pg-codemirror-editor": "^0.0.5",
+		"@openwebwork/pg-codemirror-editor": "^0.0.6",
 		"bootstrap": "~5.3.7",
 		"flatpickr": "^4.6.13",
 		"iframe-resizer": "^4.4.2",


### PR DESCRIPTION
The `@openwebwork/pg-codemirror-editor` and its dependency packages `@openwebwork/codemirror-lang-pg`, `codemirror-lang-perl`, and `codemirror-lang-mt` have all had all dependencies updated, and the bracket matching issue reported in https://github.com/openwebwork/codemirror-lang-pg/issues/1 fixed.

The resulting changes have also been published.

This just updates webwork2's dependency so that those updated packages can be used by webwork2.

Note, I did take some liberty by pushing the updates for the `@openwebwork/pg-codemirror-editor` and
`@openwebwork/codemirror-lang-perl` packages without going through the pull request process.  But with the tiered depencies here that would be tedious to go through the approval process from bottom to top.