### PR TITLE
Allow viewing achievement items when acting as another user.

### DIFF
--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -59,9 +59,6 @@ sub UserItems ($c, $userName, $set, $records) {
 	# Return unless achievement items are enabled.
 	return unless $ce->{achievementsEnabled} && $ce->{achievementItemsEnabled};
 
-	# When acting as another user, achievement items can be listed but not used.
-	return if $set && $userName ne $c->param('user');
-
 	# Return unless the user has global achievement data.
 	my $globalUserAchievement = $c->{globalData} // $db->getGlobalUserAchievement($userName);
 	return unless $globalUserAchievement && $globalUserAchievement->frozen_hash;
@@ -69,6 +66,9 @@ sub UserItems ($c, $userName, $set, $records) {
 	my $globalData  = thaw_base64($globalUserAchievement->frozen_hash);
 	my $use_item_id = $c->param('use_achievement_item_id') // '';
 	my @items;
+
+	# When acting as another user, achievement items can be listed but not used.
+	$use_item_id = '' if $userName ne $c->param('user');
 
 	for my $item (@{ +ITEMS }) {
 		next unless $globalData->{$item};

--- a/templates/ContentGenerator/ProblemSet/auxiliary_tools.html.ep
+++ b/templates/ContentGenerator/ProblemSet/auxiliary_tools.html.ep
@@ -34,6 +34,7 @@
 									% my ($item, $form) = @$_;
 									<dt class="fs-4"><%= $item->name %></dt>
 									<dd class="mx-3 mb-4">
+									% if (param('user') eq param('effectiveUser')) {
 										<%= form_for current_route, method => 'POST', name => 'use_reward', begin =%>
 											<%= hidden_field 'use_achievement_item_id' => $item->id %>
 											<%= $form %>
@@ -43,6 +44,17 @@
 													value="<%= maketext('Use [_1]', $item->remaining_title($c)) %>">
 											% }
 										<%= end =%>
+									% } else {
+										<%= $form %>
+										<span class="d-inline-block set-id-tooltip"
+											tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
+											data-bs-title="<%=maketext('You cannot use achievement rewards '
+																		. 'when acting as another user.') %>">
+											<button class="btn btn-primary" type="button" disabled>
+												<%= maketext('Use [_1]', $item->remaining_title($c)) %>
+											</button>
+										</span>
+									% }
 									</dd>
 								% }
 							</dl>
@@ -53,13 +65,6 @@
 					</div>
 				</div>
 			</div>
-		% } elsif (param('user') ne param('effectiveUser')) {
-			<span class="d-inline-block set-id-tooltip" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
-				data-bs-title="<%=maketext('You cannot use achievement rewards when acting as another user.') %>">
-				<button class="btn btn-primary" type="button" disabled>
-					<%= maketext('Use Achievement Reward') %>
-				</button>
-			</span>
 		% } else {
 			<span class="d-inline-block set-id-tooltip" tabindex="0" data-bs-toggle="tooltip" data-bs-placement="top"
 				data-bs-title="<%=maketext('No achievement rewards are available for this assignment.') %>">


### PR DESCRIPTION
Instead of greying out the "Use Achievement Reward" button when acting as another user, which only lists the available achievement items to use, grey out the actual use button to let an instructor be able to view which items a student could use on that assignment.

It is still not possible to actually use an achievement as another user if that button was active, and further the form tags are also removed from the list of items.

This address #2856.