### PR TITLE
Configure rpc endpoints to disable cookies for specific courses/users.

### DIFF
--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -251,8 +251,21 @@ hardcopy:
   preserve_temp_files: 0
 
 # Set this to 1 to allow the html2xml and render_rpc endpoints to disable
-# cookies and thus skip two factor authentication. This should never be enabled
-# for a typical webwork server.  This should only be enabled if you want to
-# allow serving content via these endpoints to links in external websites with
-# usernames and passwords embedded in them such as for PreTeXt textbooks.
+# cookies and thus skip two factor authentication for all courses. To disable
+# cookies for a single course, set this to a hash whose keys are the course
+# IDs with a value of 1. Further to only disable cookies for specific users
+# in a course, set the course ID to a hash whose keys are user IDs with a
+# value of 1. For example:
+# allow_unsecured_rpc:
+#   # Disable cookies for full PreTeXt course.
+#   PreTeXt: 1
+#   # Disable cookies for specific users in a course.
+#   courseID:
+#     user1ID: 1
+#     user2ID: 1
+#
+# This should never be enabled for a typical webwork server.  This should only be
+# enabled if you want to allow serving content via these endpoints to links in
+# external websites with usernames and passwords embedded in them such as for
+# PreTeXt textbooks.
 allow_unsecured_rpc: 0

--- a/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
@@ -21,14 +21,34 @@ use WebworkWebservice;
 
 sub initializeRoute ($c, $routeCaptures) {
 	$c->{rpc} = 1;
+	my $allow_unsecured_rpc = $c->config('allow_unsecured_rpc');
+	my $disable_cookies     = 0;
+
+	if ($allow_unsecured_rpc) {
+		if (ref($allow_unsecured_rpc) eq 'HASH') {
+			my $courseID = $c->param('courseID');
+			if ($courseID && $allow_unsecured_rpc->{$courseID}) {
+				if (ref($allow_unsecured_rpc->{$courseID}) eq 'HASH') {
+					my $userID = $c->param('user');
+					if ($userID && $allow_unsecured_rpc->{$courseID}{$userID}) {
+						$disable_cookies = 1;
+					}
+				} else {
+					$disable_cookies = 1;
+				}
+			}
+		} else {
+			$disable_cookies = 1;
+		}
+	}
 
 	$c->stash(disable_cookies => 1)
-		if $c->current_route eq 'render_rpc' && $c->param('disableCookies') && $c->config('allow_unsecured_rpc');
+		if $c->current_route eq 'render_rpc' && $c->param('disableCookies') && $disable_cookies;
 
 	# This provides compatibility for legacy html2xml parameters.
 	# This should be deleted when the html2xml endpoint is removed.
 	if ($c->current_route eq 'html2xml') {
-		$c->stash(disable_cookies => 1) if $c->config('allow_unsecured_rpc');
+		$c->stash(disable_cookies => 1) if $disable_cookies;
 		for ([ 'userID', 'user' ], [ 'course_password', 'passwd' ], [ 'session_key', 'key' ]) {
 			$c->param($_->[1], $c->param($_->[0])) if defined $c->param($_->[0]) && !defined $c->param($_->[1]);
 		}


### PR DESCRIPTION
Add option to allow the `allow_unsecured_rpc` option to be a hash of course ids, which can be set to 0 or 1 to disable cookies only for that course. Further, the course id could also be a hash of user ids that can be set to 0 or 1 to disable cookies only for the specified user id.