### PR TITLE
Add message when navigation is not allowed and LTI is not configured.

### DIFF
--- a/templates/ContentGenerator/ProblemSets.html.ep
+++ b/templates/ContentGenerator/ProblemSets.html.ep
@@ -5,10 +5,14 @@
 % unless ($authz->hasPermissions(param('user'), 'navigation_allowed')) {
 	<div class="alert alert-danger">
 		<b>
-			<%== maketext('You must access assignments from your Course Management System ([_1]).',
-				$ce->{LTI}{ $ce->{LTIVersion} }{LMS_url}
-					? link_to($ce->{LTI}{ $ce->{LTIVersion} }{LMS_name} => $ce->{LTI}{ $ce->{LTIVersion} }{LMS_url})
-					: $ce->{LTI}{ $ce->{LTIVersion} }{LMS_name}) =%>
+			% if ($ce->{LTI}) {
+				<%== maketext('You must access assignments from your Course Management System ([_1]).',
+					$ce->{LTI}{ $ce->{LTIVersion} }{LMS_url}
+						? link_to($ce->{LTI}{ $ce->{LTIVersion} }{LMS_name} => $ce->{LTI}{ $ce->{LTIVersion} }{LMS_url})
+						: $ce->{LTI}{ $ce->{LTIVersion} }{LMS_name}) =%>
+			% } else {
+				<%= maketext('You do not have permission to list assignments in this course.') %>
+			% }
 		</b>
 	</div>
 	% last;


### PR DESCRIPTION
Instead of erroring out due to hash keys not existing, just give a message "You do not have permission to list assignments in this course." when when a user doesn't have the `navigation_allowed` permission but `LTI` is not configured.

I ran across this issue with a user I use to render problems via `unsecured_rpc` in a course where I disabled `navigation` for the public user to disable as much access to the course as I could for the public user.