### PR TITLE
Fix the MathQuill usage on the problem grader page.

### DIFF
--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -8,7 +8,7 @@
 	<%= javascript getAssetURL($ce, 'node_modules/iframe-resizer/js/iframeResizer.min.js') =%>
 	<%= javascript getAssetURL($ce, 'js/Essay/essay.js'), defer => undef =%>
 	% if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
-		<%= javascript getAssetURL($ce, 'node_modules/mathquill/dist/mathquill.js'), defer => undef =%>
+		<%= javascript getAssetURL($ce, 'node_modules/@openwebwork/mathquill/dist/mathquill.js'), defer => undef =%>
 		<%= javascript getAssetURL($ce, 'js/MathQuill/mqeditor.js'), defer => undef =%>
 	% } elsif ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
 		<%= javascript getAssetURL($ce, "js/MathView/$ce->{pg}{options}{mathViewLocale}"), defer => undef =%>
@@ -19,7 +19,7 @@
 % content_for css => begin
 	<%= stylesheet getAssetURL($ce, 'js/Problem/problem.css') =%>
 	% if ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathQuill') {
-		<%= stylesheet getAssetURL($ce, 'node_modules/mathquill/dist/mathquill.css') =%>
+		<%= stylesheet getAssetURL($ce, 'node_modules/@openwebwork/mathquill/dist/mathquill.css') =%>
 		<%= stylesheet getAssetURL($ce, 'js/MathQuill/mqeditor.css') =%>
 	% } elsif ($ce->{pg}{specialPGEnvironmentVars}{entryAssist} eq 'MathView') {
 		<%= stylesheet getAssetURL($ce, 'js/MathView/mathview.css') =%>


### PR DESCRIPTION
When MathQuill was switched to a published npm package instead of being used from the Github repository, the `node_modules` location changed. This was all updated on the PG side of things, but I forgot to do it for the problem grader (which is the only place MathQuill is used for webwork2).