### PR TITLE
Improvements for the problem renderer on the problem grader page.

### DIFF
--- a/htdocs/js/ProblemGrader/problemgrader.js
+++ b/htdocs/js/ProblemGrader/problemgrader.js
@@ -15,7 +15,8 @@
 			problemSeed: selectedUser.dataset.problemSeed,
 			set_id: document.getElementsByName('hidden_set_id')[0]?.value,
 			probNum: document.getElementsByName('hidden_problem_id')[0]?.value,
-			processAnswers: 1
+			processAnswers: 1,
+			WWcorrectAns: 1
 		};
 
 		if (selectedUser.dataset.versionId) ro.version_id = selectedUser.dataset.versionId;

--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -77,7 +77,7 @@
 								ref($_->{problem}) =~ /::ProblemVersion/
 									? (
 										version_id    => $_->{problem}->version_id,
-										answer_prefix => sprintf('Q%04d_', $_->{problemNumber} + 1)
+										answer_prefix => sprintf('Q%04d_', $_->{problem}->problem_id)
 									)
 									: (),
 							}

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -102,6 +102,9 @@
 					%= hidden_field showFooter                   => $showFooter
 					%= hidden_field extra_header_text            => $extra_header_text
 					%= hidden_field problem_data                 => $problem_data
+					% if ($ws->{inputs_ref}{answerPrefix}) {
+						%= hidden_field answerPrefix => $ws->{inputs_ref}{answerPrefix}
+					% }
 					% if ($formatName eq 'debug' && $ws->{inputs_ref}{clientDebug}) {
 						%= hidden_field clientDebug => $ws->{inputs_ref}{clientDebug}
 					% }


### PR DESCRIPTION
First, this makes it so that feedback is shown on initial render.  This occurs both on initial page load (for the initially selected user), and also occurs when a different user is selected from the dropdown.
    
Second, this fixes some issues with tests and answers.  The test answer prefix needs to be preserved in the form so that checking answers works.  Also, the `ProblemGrader.html.ep` template was constructing the quiz prefix from the problem number and should be using the `problem_id` (which is what the GatewayQuiz.pm module uses).  That means the last answers were not working at all for tests with random problem order.