### PR TITLE
Configurable feedback email links show problem grader.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -81,6 +81,11 @@ $mail{feedbackSubjectFormat} = '[WWfeedback] course:%c user:%u{ set:%s}{ prob:%p
 #  2: as in 1, plus the problem environment (debugging data)
 $mail{feedbackVerbosity}     = 1;
 
+# If this is 1, then the links included in feedback emails when feedback is sent
+# from a problem will open the problem grader when followed. If this is 0, then
+# the problem grader will not be open when those links are followed.
+$mail{linksOpenProblemGrader} = 1;
+
 # Should the studentID be included in the feedback email when feedbackVerbosity > 0:
 # The default is yes
 $blockStudentIDinFeedback = 0;

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -61,6 +61,11 @@ $mail{feedbackRecipients}    = [
 	#'prof2@yourserver.yourdomain.edu',
 ];
 
+# If this is 1, then the links included in feedback emails when feedback is sent
+# from a problem will open the problem grader when followed. If this is 0, then
+# the problem grader will not be open when those links are followed.
+#$mail{linksOpenProblemGrader} = 0;
+
 # Should the studentID be included in the feedback email when feedbackVerbosity > 0:
 # The default is yes. Uncomment the line below to block it from being included.
 # Blocking it from being included is recommended if the studentID is "personal"

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -888,6 +888,17 @@ sub getConfigValues ($ce) {
 				),
 				type => 'boolean'
 			},
+			{
+				var  => 'mail{linksOpenProblemGrader}',
+				doc  => x('Feedback links open problem grader'),
+				doc2 => x(
+					'If this is true, then the links included in feedback emails sent from a problem will have the '
+						. 'problem grader open when followed. If this is false, then the problem grader will not '
+						. 'be open when those links are followed. The problem grader may still be opened in any '
+						. 'case by using the "Show Problem Grader" button.'
+				),
+				type => 'boolean'
+			},
 		],
 	];
 

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -357,7 +357,7 @@ sub generateURLs ($c, %params) {
 				for my $name ('displayMode', 'showCorrectAnswers', 'showHints', 'showOldAnswers', 'showSolutions') {
 					$args{$name} = [ $c->param($name) ] if defined $c->param($name) && $c->param($name) ne '';
 				}
-				$args{showProblemGrader} = 1;
+				$args{showProblemGrader} = 1 if $c->ce->{mail}{linksOpenProblemGrader};
 			} else {
 				$routePath = $c->url_for('problem_list', setID => $params{set_id});
 			}


### PR DESCRIPTION
This adds a new course configuration option that allows the instructor to choose if the problem grader will be open or not when the links sent in a feedback email from a problem are followed.

I am finding that to be rather obtrusive, and not something that I ever want.  I know I am not alone on this.