### PR TITLE
Fix sets manager import form selection multiple default option selected issue.

### DIFF
--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -145,14 +145,23 @@
 			const number = parseInt(numSelect.options[numSelect.selectedIndex]?.value ?? '1');
 			const importSourceSelect = document.problemsetlist['action.import.source'];
 			if (importSourceSelect) {
-				if (number === 1 && !importSourceSelect.value) importSourceSelect.options[0].selected = true;
 				importSourceSelect.size = number;
-				importSourceSelect.multiple = number > 1 ? true : false;
-				if (number > 1) importSourceSelect.options[0].selected = false;
+				if (number === 1) {
+					if (!importSourceSelect.value) importSourceSelect.options[0].selected = true;
+					importSourceSelect.options[0].textContent =
+						importSourceSelect.dataset.selectSingleText ?? 'Select filename below';
+					importSourceSelect.multiple = false;
+				} else {
+					importSourceSelect.options[0].textContent =
+						importSourceSelect.dataset.selectMultipleText ?? 'Select filename below';
+					importSourceSelect.multiple = true;
+					importSourceSelect.options[0].selected = false;
+				}
 			}
 			const importNameInput = document.problemsetlist['action.import.name'];
 			if (importNameInput) {
-				importNameInput.value = number > 1 ? '(taken from filenames)' : '';
+				importNameInput.value =
+					number > 1 ? (importNameInput.dataset.multipleFilesText ?? '(taken from filenames)') : '';
 				importNameInput.readOnly = number > 1 ? true : false;
 				importNameInput.disabled = number > 1 ? true : false;
 			}

--- a/templates/ContentGenerator/Instructor/ProblemSetList/import_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/import_form.html.ep
@@ -15,11 +15,15 @@
 			class => 'col-form-label col-form-label-sm col-md-auto' =%>
 		<div class="col-auto">
 			<%= select_field 'action.import.source' => [
-					[ maketext('Select filenames below') => '', selected => undef, disabled => undef ],
+					[ maketext('Select filename below') => '', selected => undef, disabled => undef ],
 					@$setDefList
 				],
 				id => 'import_source_select', class => 'form-select form-select-sm', dir => 'ltr',
 				size => param('action.import.number') || 1,
+				data => {
+					select_multiple_text => maketext('Select filenames below'),
+					select_single_text => maketext('Select filename below')
+				},
 				defined param('action.import.number') && param('action.import.number') ne '1'
 				? (multiple => undef)
 				: () =%>
@@ -30,7 +34,7 @@
 			class => 'col-form-label col-form-label-sm col-md-auto' =%>
 		<div class="col-auto">
 			<%= text_field 'action.import.name' => '', id => 'import_text', class => 'form-control form-control-sm',
-				dir => 'ltr' =%>
+				dir => 'ltr', data => { multiple_files_text => maketext('(taken from filenames)') } =%>
 		</div>
 	</div>
 	<div class="row mb-2">


### PR DESCRIPTION
Currently when the sets manager page loads the "Import how many sets?" select has "a single set" initially selected and the "Import from where?" select has "Select filenames below" selected.  But then if you change the first select to "multiple sets" the "Import from where?" select still has "Select filenames below" selected.  Furthermore, if you then click on that select and use shift-down arrow to select multiple sets, that first disabled option stays selected.  Then form validation fails for that option since it has no value if you click the "Import" button.

This just makes it so that when you switch from the "Import how many sets?" select from "a single set" to "multiple sets", that first option in the "Import from where?" select is immediately unselected.

There is also a little clean up of this section of JavaScript code.  The elements with id `import_source_select` and name `action.import.number` are actually the same element, so no need to find them in the DOM twice. Also ensure the elements exist and are found before trying to work with them. More of this is needed in this file, but this is probably good enough for now.