### PR TITLE
Fix the label for the import date shift input.

### DIFF
--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -251,6 +251,10 @@
 
 				// Make the alternate input left-to-right even for right-to-left languages.
 				this.altInput.dir = 'ltr';
+
+				// Move the id of the now hidden input onto the added input so the labels still work.
+				this.altInput.id = this.input.id;
+				this.input.removeAttribute('id');
 			},
 			parseDate(datestr, format) {
 				// Deal with the case of a unix timestamp.  The timezone needs to be adjusted back as this is for


### PR DESCRIPTION
The input that is initally inserted into the page has the id that the label points to.  However, that input is hidden and replaced with the visible input for the flatpickr date selector, and so the label does not work.  This moves the id of the original and now hidden input onto the visible flatpickr input.

This is the same technique used for other date/time inputs in the `htdocs/js/DatePicker/datepicker.js` file, and should have been implemented in this special case as well.