### PR TITLE
Fix an LTI grade passback issue.

### DIFF
--- a/lib/WeBWorK/Utils/Sets.pm
+++ b/lib/WeBWorK/Utils/Sets.pm
@@ -107,7 +107,7 @@ sub grade_set ($db, $set, $studentName, $setIsVersioned = 0, $wantProblemDetails
 }
 
 sub grade_gateway ($db, $setName, $studentName) {
-	my $bestSetData = [ 0, 0 ];
+	my $bestSetData = [ 0, 0, [] ];
 
 	my @setVersions = $db->getSetVersionsWhere({ user_id => $studentName, set_id => { like => "$setName,v\%" } });
 	for (@setVersions) {


### PR DESCRIPTION
The issue occurs when the `$LTIGradeMode` is "course", `$LTIGradeOnSubmit` is 1, `$LTISendScoresAfterDate` is "reduced_scoring_datae', and `$LTISendGradesEarlyThreshold` is "attempted".

In this case if a user grades a test and receives a score of 0 (and all versions of this test have a score of 0), then the `grade_gateway` method returns the default `$bestSetData` array defined at the beginning of the method with only two elements.  It does not have the array of problem records.  So when the `getSetPassbackScore` method gets the return value and assigns it to `($totalRight, $total, $problemRecords, $setVersions)` the set versions that are returned end up assigned to the `$problemRecords` variable.  That causes an exception when the `setAttempted` method tries to call the `attempted` method on a set version which does not have that method.

So just add an empty array as the third value in the default `$bsetSetData` array.  This works in all calling scenarios.

This fixes the issue posted at https://forums.openwebwork.org/mod/forum/discuss.php?d=8798.