### PR TITLE
Add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -6,11 +6,10 @@
 
 | Version | Supported          |
 | ------- | ------------------ |
-| 2.20   | :white_check_mark:  |
-| 2.19   | :x:                 |
-| 2.18   | :x:                 |
-| 2.17   | :x:                 |
-| <= 2.16   | :x:                 |
+| [`2.20`](https://github.com/openwebwork/webwork2/releases/tag/WeBWorK-2.20)    | :white_check_mark: |
+| [`2.19`](https://github.com/openwebwork/webwork2/releases/tag/WeBWorK-2.19)    | :white_check_mark: |
+| [`2.18`](https://github.com/openwebwork/webwork2/releases/tag/WeBWorK-2.18)    | :white_check_mark: |
+| <=[`2.17`](https://github.com/openwebwork/webwork2/releases/tag/WeBWorK-2.17)  | :x:                |
 
 ## Reporting a Vulnerability
 
@@ -19,7 +18,7 @@
 Rather, use the following email to report any security vulnerabilities:
 
 ```
-<email_here>
+thewebworkproject@gmail.com
 ```
 
 We will respond to all security reports within `<number>` days.


### PR DESCRIPTION
There’s currently no SECURITY.md in the repository root. Since WeBWorK is used by multiple universities for graded assignments, having a clear security reporting path matters—publicly disclosed vulnerabilities could impact the integrity of assignments and course outcomes.

I recommend adding a standard SECURITY.md to enable GitHub vulnerability reporting and to provide clear guidance on how to responsibly report issues (what details to include, expected response times, and where to report). GitHub’s guidance is here:
https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/adding-a-security-policy-to-your-repository

PS: The file changed is an example, and should be replaced with the actual security policy.