### PR TITLE
Allow colons in filter values.

### DIFF
--- a/lib/WeBWorK/Utils/FilterRecords.pm
+++ b/lib/WeBWorK/Utils/FilterRecords.pm
@@ -182,7 +182,7 @@ sub filterRecords {
 	my @filteredRecords = $intersect ? @records : ();
 	if ($intersect) {
 		for my $filter (@filtersToUse) {
-			my ($name, $value) = split(/:/, $filter);
+			my ($name, $value) = split(/:/, $filter, 2);
 			# permission level is handled differently
 			if ($name eq 'permission') {
 				@filteredRecords =
@@ -194,7 +194,7 @@ sub filterRecords {
 	} else {
 		for my $record (@records) {
 			for my $filter (@filtersToUse) {
-				my ($name, $value) = split(/:/, $filter);
+				my ($name, $value) = split(/:/, $filter, 2);
 				# permission level is handled differently
 				if ($name eq 'permission' && $permissionName{ $permissionLevels{ $record->user_id } } eq $value) {
 					push @filteredRecords, $record;


### PR DESCRIPTION
The format for a filter in the scrolling record lists is `filterName:filtervalue`.  When the filters are applied the name and value are slit on the colon.  Now if the filter value contains a colon, then the current code splits that value as well, and since only two variables are saved in the return value, the rest goes off into the abyss.  This just adds the optional limit to the `split` call so that the colon in the value is not split.

This fixes issue #2885.