### PR TITLE
Fix three issues with display of answers on the problem grader page.

### DIFF
--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -178,16 +178,21 @@
 										) %>">
 											% if ($answerTypes[$i] && $answerTypes[$i] eq 'essay') {
 												% # If the answer is an essay answer then display it line by line.
-												<div class="past-answer">
-													<%= c(split /\n/, $answers[$i])->join('<br>') =%>
-												</div>
+												% my @lines = split /\n/, $answers[$i];
+												% for (0 .. $#lines - 1) {
+													<%= $lines[$_] =%><br>
+												% }
+												<%= $lines[-1] =%>
 											% } elsif ($answerTypes[$i] && $answerTypes[$i] eq 'Value (Formula)') {
 												% # If its a formula then mark it as tex for MathJax.
 												`<%= $answers[$i] %>`
-												</div>
 											% } else {
 												% # If it isn't an essay or a formula then show it as text.
-												<%= $answers[$i] %>
+												% my @parts = split("&#9070;", $answers[$i]);
+												% for (0 .. $#parts - 1) {
+													<%= $parts[$_] =%>&#9070;\
+												% }
+												<%= $parts[-1] =%>
 											% }
 										</div>
 									% }


### PR DESCRIPTION
First, if an answer is a checkbox answer with multiple parts checked, then the `&#9070;` character is not handled.  This needs the same processing as is done on the past answers page for this.

Second, the essay answers can not be put into a `Mojo::Collection` and joined with `<br>` tags.  The result of that is a `Mojo::ByteStream` which means that it is not escaped.  That was the original point since the `<br>` tags cannot be escaped.  However, the answers must be escaped so that answers like `<script>alert('xss attack')</script>` are not executed.  So a for loop similar to that used for the checkbox answers must be used.  Note that these answers were also wrapped in a redundant `<div>` tag with the same class as the containing `<div>` that is still there, and that was removed.

Third, there was a dangling end `</div>` tag for formula answers that was removed.