### PR TITLE
Refactor check_modules script

### DIFF
--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -544,6 +544,8 @@ my %modulesList = (
 	}
 );
 
+my %cpanm_package = ('ubuntu' => 'cpanminus', 'rhel' => 'perl-App-cpanminus');
+
 my @programList = qw(
 	convert
 	curl
@@ -631,10 +633,10 @@ sub determine_distribution {
 			}
 		}
 		close $fh;
-		if ($os_attrs{'id'} =~ 'ubuntu' || $os_attrs{'id_like'} =~ 'ubuntu') {
+		if ($os_attrs{'id'} =~ 'ubuntu' || ($os_attrs{'id_like'} && $os_attrs{'id_like'} =~ 'ubuntu')) {
 			$packagetype = 'ubuntu';
 			return 1;
-		} elsif ($os_attrs{'id'} =~ 'fedora' || $os_attrs{'id_like'} =~ 'fedora') {
+		} elsif ($os_attrs{'id'} =~ 'fedora' || ($os_attrs{'id_like'} && $os_attrs{'id_like'} =~ 'fedora')) {
 			$packagetype = 'rhel';
 			return 1;
 		}
@@ -695,6 +697,8 @@ sub check_modules {
 			if (@missing_packages) {
 				say $packagemgrcommand{$packagetype} . join(' ', @missing_packages) . "\n";
 			}
+			say 'If the cpanm command is not installed, you can try installing it using the following command:' . "\n";
+			say $packagemgrcommand{$packagetype} . $cpanm_package{$packagetype};
 		}
 		say 'Exiting as this is required to check the database driver and programs.';
 		exit 0;

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -29,11 +29,13 @@ Specify your linux distribution.  Currently supported options are
 
 =item C<ubuntu>
 
-Tested on ubuntu 24. May work for other distributions using the apt package manager 
+Tested on ubuntu 24. May work for other distributions using the apt package
+manager 
 
 =item C<rhel>
 
-For RedHat Enterprise Linux and equivalents with the EPEL and CodeReady Builder repositories enabled (e.g. Rocky Linux, Oracle Linux)
+For RedHat Enterprise Linux and equivalents with the EPEL and CodeReady
+Builder repositories enabled (e.g. Rocky Linux, Oracle Linux)
 
 =back
 

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -40,13 +40,13 @@ my %modulesList = (
 	'Archive::Tar' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Archive-Tar'
+			'rhel'   => 'perl-Archive-Tar'
 		}
 	},
 	'Archive::Zip' => {
 		'package' => {
 			'ubuntu' => 'libarchive-zip-perl',
-			'rhel' => 'perl-Archive-Zip'
+			'rhel'   => 'perl-Archive-Zip'
 		}
 	},
 	'Archive::Zip::SimpleZip' => {
@@ -57,49 +57,49 @@ my %modulesList = (
 	'Benchmark' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Benchmark'
+			'rhel'   => 'perl-Benchmark'
 		}
 	},
 	'Carp' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Carp'
+			'rhel'   => 'perl-Carp'
 		}
 	},
 	'Class::Accessor' => {
 		'package' => {
 			'ubuntu' => 'libclass-accessor-perl',
-			'rhel' => 'perl-Class-Accessor'
+			'rhel'   => 'perl-Class-Accessor'
 		}
 	},
 	'Crypt::JWT' => {
 		'package' => {
 			'ubuntu' => 'libcrypt-jwt-perl',
-			'rhel' => 'perl-Crypt-JWT'
+			'rhel'   => 'perl-Crypt-JWT'
 		}
 	},
 	'Crypt::PK::RSA' => {
 		'package' => {
 			'ubuntu' => 'libcryptx-perl',
-			'rhel' => 'perl-CryptX'
+			'rhel'   => 'perl-CryptX'
 		}
 	},
 	'DBI' => {
 		'package' => {
 			'ubuntu' => 'libdbi-perl',
-			'rhel' => 'perl-DBI'
+			'rhel'   => 'perl-DBI'
 		}
 	},
 	'Data::Dump' => {
 		'package' => {
 			'ubuntu' => 'libdata-dump-perl',
-			'rhel' => 'perl-Data-Dump'
+			'rhel'   => 'perl-Data-Dump'
 		}
 	},
 	'Data::Dumper' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Data-Dumper'
+			'rhel'   => 'perl-Data-Dumper'
 		}
 	},
 	'Data::Structure::Util' => {
@@ -110,49 +110,49 @@ my %modulesList = (
 	'Data::UUID' => {
 		'package' => {
 			'ubuntu' => 'libossp-uuid-perl',
-			'rhel' => 'perl-Data-UUID'
+			'rhel'   => 'perl-Data-UUID'
 		}
 	},
 	'Date::Format' => {
 		'package' => {
 			'ubuntu' => 'libtimedate-perl',
-			'rhel' => 'perl-TimeDate'
+			'rhel'   => 'perl-TimeDate'
 		}
 	},
 	'Date::Parse' => {
 		'package' => {
 			'ubuntu' => 'libtimedate-perl',
-			'rhel' => 'perl-TimeDate'
+			'rhel'   => 'perl-TimeDate'
 		}
 	},
 	'DateTime' => {
 		'package' => {
 			'ubuntu' => 'libdatetime-perl',
-			'rhel' => 'perl-DateTime'
+			'rhel'   => 'perl-DateTime'
 		}
 	},
 	'Digest::MD5' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Digest-MD5'
+			'rhel'   => 'perl-Digest-MD5'
 		}
 	},
 	'Digest::SHA' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Digest-SHA'
+			'rhel'   => 'perl-Digest-SHA'
 		}
 	},
 	'Email::Address::XS' => {
 		'package' => {
 			'ubuntu' => 'libemail-address-xs-perl',
-			'rhel' => 'perl-Email-Address-XS'
+			'rhel'   => 'perl-Email-Address-XS'
 		}
 	},
 	'Email::Sender::Transport::SMTP' => {
 		'package' => {
 			'ubuntu' => 'libemail-sender-perl',
-			'rhel' => 'perl-Email-Sender'
+			'rhel'   => 'perl-Email-Sender'
 		}
 	},
 	'Email::Stuffer' => {
@@ -163,67 +163,67 @@ my %modulesList = (
 	'Errno' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Errno'
+			'rhel'   => 'perl-Errno'
 		}
 	},
 	'Exception::Class' => {
 		'package' => {
 			'ubuntu' => 'libexception-class-perl',
-			'rhel' => 'perl-Exception-Class'
+			'rhel'   => 'perl-Exception-Class'
 		}
 	},
 	'File::Copy' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-Copy'
+			'rhel'   => 'perl-File-Copy'
 		}
 	},
 	'File::Copy::Recursive' => {
 		'package' => {
 			'ubuntu' => 'libfile-copy-recursive-perl',
-			'rhel' => 'perl-File-Copy-Recursive'
+			'rhel'   => 'perl-File-Copy-Recursive'
 		}
 	},
 	'File::Fetch' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-Fetch'
+			'rhel'   => 'perl-File-Fetch'
 		}
 	},
 	'File::Find' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-Find'
+			'rhel'   => 'perl-File-Find'
 		}
 	},
 	'File::Find::Rule' => {
 		'package' => {
 			'ubuntu' => 'libfile-find-rule-perl',
-			'rhel' => 'perl-File-Find-Rule'
+			'rhel'   => 'perl-File-Find-Rule'
 		}
 	},
 	'File::Path' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-Path'
+			'rhel'   => 'perl-File-Path'
 		}
 	},
 	'File::Spec' => {
 		'package' => {
 			'ubuntu' => 'perl-base',
-			'rhel' => 'perl-PathTools'
+			'rhel'   => 'perl-PathTools'
 		}
 	},
 	'File::Temp' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-Temp'
+			'rhel'   => 'perl-File-Temp'
 		}
 	},
 	'File::stat' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-File-stat'
+			'rhel'   => 'perl-File-stat'
 		}
 	},
 	'Future::AsyncAwait' => {
@@ -235,7 +235,7 @@ my %modulesList = (
 	'GD' => {
 		'package' => {
 			'ubuntu' => 'libgd-perl',
-			'rhel' => 'perl-GD'
+			'rhel'   => 'perl-GD'
 		}
 	},
 	'GD::Barcode::QRcode' => {
@@ -246,19 +246,19 @@ my %modulesList = (
 	'Getopt::Long' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Getopt-Long'
+			'rhel'   => 'perl-Getopt-Long'
 		}
 	},
 	'Getopt::Std' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Getopt-Std'
+			'rhel'   => 'perl-Getopt-Std'
 		}
 	},
 	'HTML::Entities' => {
 		'package' => {
 			'ubuntu' => 'libhtml-parser-perl',
-			'rhel' => 'perl-HTML-Parser'
+			'rhel'   => 'perl-HTML-Parser'
 		}
 	},
 	'HTTP::Async' => {
@@ -269,7 +269,7 @@ my %modulesList = (
 	'IO::File' => {
 		'package' => {
 			'ubuntu' => 'perl-base',
-			'rhel' => 'perl-IO'
+			'rhel'   => 'perl-IO'
 		}
 	},
 	'Iterator' => {
@@ -286,7 +286,7 @@ my %modulesList = (
 		'minversion' => '6.06',
 		'package'    => {
 			'ubuntu' => 'liblwp-protocol-https-perl',
-			'rhel' => 'perl-LWP-Protocol-https'
+			'rhel'   => 'perl-LWP-Protocol-https'
 		}
 	},
 	'Locale::Maketext::Lexicon' => {
@@ -297,7 +297,7 @@ my %modulesList = (
 	'Locale::Maketext::Simple' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Locale-Maketext-Simple'
+			'rhel'   => 'perl-Locale-Maketext-Simple'
 		}
 	},
 	'MIME::Base32' => {
@@ -308,13 +308,13 @@ my %modulesList = (
 	'MIME::Base64' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-MIME-Base64'
+			'rhel'   => 'perl-MIME-Base64'
 		}
 	},
 	'Math::Random::Secure' => {
 		'package' => {
 			'ubuntu' => 'libmath-random-secure-perl',
-			'rhel' => 'perl-Math-Random-Secure'
+			'rhel'   => 'perl-Math-Random-Secure'
 		}
 	},
 	'Minion' => {
@@ -331,13 +331,13 @@ my %modulesList = (
 		'minversion' => '9.34',
 		'package'    => {
 			'ubuntu' => 'libmojolicious-perl',
-			'rhel' => 'perl-Mojolicious'
+			'rhel'   => 'perl-Mojolicious'
 		}
 	},
 	'Mojolicious::Plugin::NotYAMLConfig' => {
 		'package' => {
 			'ubuntu' => 'libmojolicious-perl',
-			'rhel' => 'perl-Mojolicious'
+			'rhel'   => 'perl-Mojolicious'
 		}
 	},
 	'Mojolicious::Plugin::RenderFile' => {
@@ -348,25 +348,25 @@ my %modulesList = (
 	'Net::IP' => {
 		'package' => {
 			'ubuntu' => 'libnet-ip-perl',
-			'rhel' => 'perl-Net-IP'
+			'rhel'   => 'perl-Net-IP'
 		}
 	},
 	'Net::OAuth' => {
 		'package' => {
 			'ubuntu' => 'libnet-oauth-perl',
-			'rhel' => 'perl-Net-OAuth'
+			'rhel'   => 'perl-Net-OAuth'
 		}
 	},
 	'Opcode' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Opcode'
+			'rhel'   => 'perl-Opcode'
 		}
 	},
 	'PHP::Serialization' => {
 		'package' => {
 			'ubuntu' => 'libphp-serialization-perl',
-			'rhel' => 'perl-PHP-Serialization'
+			'rhel'   => 'perl-PHP-Serialization'
 		}
 	},
 	'Pandoc' => {
@@ -377,31 +377,31 @@ my %modulesList = (
 	'Perl::Critic' => {
 		'package' => {
 			'ubuntu' => 'libperl-critic-perl',
-			'rhel' => 'perl-Perl-Critic'
+			'rhel'   => 'perl-Perl-Critic'
 		}
 	},
 	'Perl::Tidy' => {
 		'package' => {
 			'ubuntu' => 'perltidy',
-			'rhel' => 'perltidy'
+			'rhel'   => 'perltidy'
 		}
 	},
 	'Pod::Simple::Search' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Pod-Simple'
+			'rhel'   => 'perl-Pod-Simple'
 		}
 	},
 	'Pod::Simple::XHTML' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Pod-Simple'
+			'rhel'   => 'perl-Pod-Simple'
 		}
 	},
 	'Pod::Usage' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Pod-Usage'
+			'rhel'   => 'perl-Pod-Usage'
 		}
 	},
 	'Pod::WSDL' => {
@@ -412,14 +412,14 @@ my %modulesList = (
 	'SOAP::Lite' => {
 		'package' => {
 			'ubuntu' => 'libsoap-lite-perl',
-			'rhel' => 'perl-SOAP-Lite'
+			'rhel'   => 'perl-SOAP-Lite'
 		}
 	},
 	'SQL::Abstract' => {
 		'minversion' => '2',
 		'package'    => {
 			'ubuntu' => 'libsql-abstract-perl',
-			'rhel' => 'perl-SQL-Abstract'
+			'rhel'   => 'perl-SQL-Abstract'
 		}
 	},
 	'SVG' => {
@@ -430,79 +430,79 @@ my %modulesList = (
 	'Scalar::Util' => {
 		'package' => {
 			'ubuntu' => 'perl-base',
-			'rhel' => 'perl-Scalar-List-Utils'
+			'rhel'   => 'perl-Scalar-List-Utils'
 		}
 	},
 	'Socket' => {
 		'package' => {
 			'ubuntu' => 'perl-base',
-			'rhel' => 'perl-Socket'
+			'rhel'   => 'perl-Socket'
 		}
 	},
 	'String::ShellQuote' => {
 		'package' => {
 			'ubuntu' => 'libstring-shellquote-perl',
-			'rhel' => 'perl-String-ShellQuote'
+			'rhel'   => 'perl-String-ShellQuote'
 		}
 	},
 	'Text::CSV' => {
 		'package' => {
 			'ubuntu' => 'libtext-csv-perl',
-			'rhel' => 'perl-Text-CSV'
+			'rhel'   => 'perl-Text-CSV'
 		}
 	},
 	'Text::Wrap' => {
 		'package' => {
 			'ubuntu' => 'perl-base',
-			'rhel' => 'perl-Text-Tabs+Wrap'
+			'rhel'   => 'perl-Text-Tabs+Wrap'
 		}
 	},
 	'Tie::IxHash' => {
 		'package' => {
 			'ubuntu' => 'libtie-ixhash-perl',
-			'rhel' => 'perl-Tie-IxHash'
+			'rhel'   => 'perl-Tie-IxHash'
 		}
 	},
 	'Time::HiRes' => {
 		'package' => {
 			'ubuntu' => 'perl',
-			'rhel' => 'perl-Time-HiRes'
+			'rhel'   => 'perl-Time-HiRes'
 		}
 	},
 	'Time::Zone' => {
 		'package' => {
 			'ubuntu' => 'libtimedate-perl',
-			'rhel' => 'perl-TimeDate'
+			'rhel'   => 'perl-TimeDate'
 		}
 	},
 	'Types::Serialiser' => {
 		'package' => {
 			'ubuntu' => 'libtypes-serialiser-perl',
-			'rhel' => 'perl-Types-Serialiser'
+			'rhel'   => 'perl-Types-Serialiser'
 		}
 	},
 	'URI::Escape' => {
 		'package' => {
 			'ubuntu' => 'liburi-perl',
-			'rhel' => 'perl-URI'
+			'rhel'   => 'perl-URI'
 		}
 	},
 	'UUID::Tiny' => {
 		'package' => {
 			'ubuntu' => 'libuuid-tiny-perl',
-			'rhel' => 'perl-UUID-Tiny'
+			'rhel'   => 'perl-UUID-Tiny'
 		}
 	},
 	'XML::LibXML' => {
 		'package' => {
 			'ubuntu' => 'libxml-libxml-perl',
-			'rhel' => 'perl-XML-LibXML'
+			'rhel'   => 'perl-XML-LibXML'
 		}
 	},
 	'XML::Parser' => {
 		'package' => {
 			'ubuntu' => 'libxml-parser-perl',
-			'rhel' => 'perl-XML-Parser'
+			'rhel'   => 'perl-XML-Parser'
 		}
 	},
 	'XML::Parser::EasyTree' => {
@@ -513,13 +513,13 @@ my %modulesList = (
 	'XML::Writer' => {
 		'package' => {
 			'ubuntu' => 'libxml-writer-perl',
-			'rhel' => 'perl-XML-Writer'
+			'rhel'   => 'perl-XML-Writer'
 		}
 	},
 	'YAML::XS' => {
 		'package' => {
 			'ubuntu' => 'libyaml-libyaml-perl',
-			'rhel' => 'perl-YAML-LibYAML'
+			'rhel'   => 'perl-YAML-LibYAML'
 		}
 	}
 );
@@ -545,10 +545,10 @@ my @programList = qw(
 my ($test_modules, $test_programs, $packagetype, $show_help);
 
 GetOptions(
-	'm|modules'       => \$test_modules,
-	'p|programs'      => \$test_programs,
+	'm|modules'        => \$test_modules,
+	'p|programs'       => \$test_programs,
 	'd|distribution=s' => \$packagetype,
-	'h|help'          => \$show_help,
+	'h|help'           => \$show_help,
 );
 
 pod2usage(2) if $show_help;
@@ -621,7 +621,7 @@ sub check_modules {
 		say '';
 		say 'Some required modules were not found, could not be loaded, or were not at the sufficient version.';
 		if (@missing_modules || @missing_packages) {
-			say 'You can try to install the missing modules with the following command(s):'."\n";
+			say 'You can try to install the missing modules with the following command(s):' . "\n";
 			if (@missing_modules) {
 				say 'sudo cpanm ' . join(' ', @missing_modules) . "\n";
 			}

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -9,15 +9,35 @@ webwork2 are installed.
 
 check_modules.pl [options]
 
- Options:
-   -m|--modules          Check that the perl modules needed by webwork2 can be loaded.
-   -p|--programs         Check that the programs needed by webwork2 exist.
-   -d|--distribution     Specify your linux distribution.  Currently supported options are
-                           'ubuntu' - tested on ubuntu 24. May work for other distributions
-				using the apt package manager
-                           'rhel' - for RedHat Enterprise Linux and equivalents with the 
-				EPEL and CodeReady Builder repositories enabled
-				(e.g. Rocky Linux, Oracle Linux)
+Options:
+
+=over 4
+
+=item C<-m|--modules>
+
+Check that the perl modules needed by webwork2 can be loaded.
+
+=item C<-p|--programs>
+
+Check that the programs needed by webwork2 exist.
+
+=item C<-d|--distribution>
+
+Specify your linux distribution.  Currently supported options are
+
+=over 4
+
+=item C<ubuntu>
+
+Tested on ubuntu 24. May work for other distributions using the apt package manager 
+
+=item C<rhel>
+
+For RedHat Enterprise Linux and equivalents with the EPEL and CodeReady Builder repositories enabled (e.g. Rocky Linux, Oracle Linux)
+
+=back
+
+=back
 
 Both programs and modules are checked if no options are given.
 

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -38,7 +38,7 @@ my %modulesList = (
 		package => { deb => 'libarchive-zip-perl', },
 	},
 	'Archive::Zip::SimpleZip' => {},
-	'Benchmark' => {
+	'Benchmark'               => {
 		package => { deb => 'perl-modules', },
 	},
 	'Carp' => {
@@ -126,7 +126,7 @@ my %modulesList = (
 		package => { deb => 'perl-modules', },
 	},
 	'Future::AsyncAwait' => {
-		package => { deb => 'libfuture-asyncawait-perl', },
+		package    => { deb => 'libfuture-asyncawait-perl', },
 		minversion => 0.52,
 	},
 	'GD' => {
@@ -163,7 +163,7 @@ my %modulesList = (
 		package => { deb => 'perl-modules', },
 	},
 	'LWP::Protocol::https' => {
-		package => { deb => 'liblwp-protocol-https-perl', },
+		package    => { deb => 'liblwp-protocol-https-perl', },
 		minversion => 6.06,
 	},
 	'MIME::Base32' => {
@@ -182,7 +182,7 @@ my %modulesList = (
 		package => { deb => 'libminion-backend-sqlite-perl', },
 	},
 	'Mojolicious' => {
-		package => { deb => 'libmojolicious-perl', },
+		package    => { deb => 'libmojolicious-perl', },
 		minversion => 9.34,
 	},
 	'Mojolicious::Plugin::NotYAMLConfig' => {
@@ -234,7 +234,7 @@ my %modulesList = (
 		package => { deb => 'perl-base', },
 	},
 	'SQL::Abstract' => {
-		package => { deb => 'libsql-abstract-perl', },
+		package    => { deb => 'libsql-abstract-perl', },
 		minversion => 2.000000,
 	},
 	'String::ShellQuote' => {

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -30,90 +30,258 @@ use feature 'say';
 use Getopt::Long qw(:config bundling);
 use Pod::Usage;
 
-my @modulesList = qw(
-	Archive::Tar
-	Archive::Zip
-	Archive::Zip::SimpleZip
-	Benchmark
-	Carp
-	Class::Accessor
-	Crypt::JWT
-	Crypt::PK::RSA
-	Data::Dump
-	Data::Dumper
-	Data::Structure::Util
-	Data::UUID
-	Date::Format
-	Date::Parse
-	DateTime
-	DBI
-	Digest::MD5
-	Digest::SHA
-	Email::Address::XS
-	Email::Sender::Transport::SMTP
-	Email::Stuffer
-	Errno
-	Exception::Class
-	File::Copy
-	File::Copy::Recursive
-	File::Fetch
-	File::Find
-	File::Find::Rule
-	File::Path
-	File::Spec
-	File::stat
-	File::Temp
-	Future::AsyncAwait
-	GD
-	GD::Barcode::QRcode
-	Getopt::Long
-	Getopt::Std
-	HTML::Entities
-	HTTP::Async
-	IO::File
-	Iterator
-	Iterator::Util
-	Locale::Maketext::Lexicon
-	Locale::Maketext::Simple
-	LWP::Protocol::https
-	MIME::Base32
-	MIME::Base64
-	Math::Random::Secure
-	Minion
-	Minion::Backend::SQLite
-	Mojolicious
-	Mojolicious::Plugin::NotYAMLConfig
-	Mojolicious::Plugin::RenderFile
-	Net::IP
-	Net::OAuth
-	Opcode
-	Pandoc
-	Perl::Critic
-	Perl::Tidy
-	PHP::Serialization
-	Pod::Simple::Search
-	Pod::Simple::XHTML
-	Pod::Usage
-	Pod::WSDL
-	Scalar::Util
-	SOAP::Lite
-	Socket
-	SQL::Abstract
-	String::ShellQuote
-	SVG
-	Text::CSV
-	Text::Wrap
-	Tie::IxHash
-	Time::HiRes
-	Time::Zone
-	Types::Serialiser
-	URI::Escape
-	UUID::Tiny
-	XML::LibXML
-	XML::Parser
-	XML::Parser::EasyTree
-	XML::Writer
-	YAML::XS
+my %modulesList = (
+	'Archive::Tar' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Archive::Zip' => {
+		package => { deb => 'libarchive-zip-perl', },
+	},
+	'Archive::Zip::SimpleZip' => {},
+	'Benchmark' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Carp' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Class::Accessor' => {
+		package => { deb => 'libclass-accessor-perl', },
+	},
+	'Crypt::JWT' => {
+		package => { deb => 'libcrypt-jwt-perl', },
+	},
+	'Crypt::PK::RSA' => {
+		package => { deb => 'libcryptx-perl', },
+	},
+	'Data::Dump' => {
+		package => { deb => 'libdata-dump-perl', },
+	},
+	'Data::Dumper' => {
+		package => { deb => 'libperl', },
+	},
+	'Data::Structure::Util' => {
+		package => { deb => 'libdata-structure-util-perl', },
+	},
+	'Data::UUID' => {
+		package => { deb => 'libossp-uuid-perl', },
+	},
+	'Date::Format' => {
+		package => { deb => 'libtimedate-perl', },
+	},
+	'Date::Parse' => {
+		package => { deb => 'libtimedate-perl', },
+	},
+	'DateTime' => {
+		package => { deb => 'libdatetime-perl', },
+	},
+	'DBI' => {
+		package => { deb => 'libdbi-perl', },
+	},
+	'Digest::MD5' => {
+		package => { deb => 'libperl', },
+	},
+	'Digest::SHA' => {
+		package => { deb => 'libperl', },
+	},
+	'Email::Address::XS' => {
+		package => { deb => 'libemail-address-xs-perl', },
+	},
+	'Email::Sender::Transport::SMTP' => {
+		package => { deb => 'libemail-sender-perl', },
+	},
+	'Email::Stuffer' => {
+		package => { deb => 'libemail-stuffer-perl', },
+	},
+	'Errno' => {
+		package => { deb => 'libperl', },
+	},
+	'Exception::Class' => {
+		package => { deb => 'libexception-class-perl', },
+	},
+	'File::Copy' => {
+		package => { deb => 'perl-modules', },
+	},
+	'File::Copy::Recursive' => {
+		package => { deb => 'libfile-copy-recursive-perl', },
+	},
+	'File::Fetch' => {
+		package => { deb => 'perl-modules', },
+	},
+	'File::Find' => {
+		package => { deb => 'perl-modules', },
+	},
+	'File::Find::Rule' => {
+		package => { deb => 'libfile-find-rule-perl', },
+	},
+	'File::Path' => {
+		package => { deb => 'perl-modules', },
+	},
+	'File::Spec' => {
+		package => { deb => 'perl-base', },
+	},
+	'File::stat' => {
+		package => { deb => 'perl-modules', },
+	},
+	'File::Temp' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Future::AsyncAwait' => {
+		package => { deb => 'libfuture-asyncawait-perl', },
+		minversion => 0.52,
+	},
+	'GD' => {
+		package => { deb => 'libgd-perl', },
+	},
+	'GD::Barcode::QRcode' => {
+		package => { deb => 'libgd-barcode-perl', },
+	},
+	'Getopt::Long' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Getopt::Std' => {
+		package => { deb => 'perl-modules', },
+	},
+	'HTML::Entities' => {
+		package => { deb => 'libhtml-parser-perl', },
+	},
+	'HTTP::Async' => {
+		package => { deb => 'libhttp-async-perl', },
+	},
+	'IO::File' => {
+		package => { deb => 'perl-base', },
+	},
+	'Iterator' => {
+		package => { deb => 'libiterator-perl', },
+	},
+	'Iterator::Util' => {
+		package => { deb => 'libiterator-util-perl', },
+	},
+	'Locale::Maketext::Lexicon' => {
+		package => { deb => 'liblocale-maketext-lexicon-perl', },
+	},
+	'Locale::Maketext::Simple' => {
+		package => { deb => 'perl-modules', },
+	},
+	'LWP::Protocol::https' => {
+		package => { deb => 'liblwp-protocol-https-perl', },
+		minversion => 6.06,
+	},
+	'MIME::Base32' => {
+		package => { deb => 'libmime-base32-perl', },
+	},
+	'MIME::Base64' => {
+		package => { deb => 'libperl', },
+	},
+	'Math::Random::Secure' => {
+		package => { deb => 'libmath-random-secure-perl', },
+	},
+	'Minion' => {
+		package => { deb => 'libminion-perl', },
+	},
+	'Minion::Backend::SQLite' => {
+		package => { deb => 'libminion-backend-sqlite-perl', },
+	},
+	'Mojolicious' => {
+		package => { deb => 'libmojolicious-perl', },
+		minversion => 9.34,
+	},
+	'Mojolicious::Plugin::NotYAMLConfig' => {
+		package => { deb => 'libmojolicious-perl', },
+	},
+	'Mojolicious::Plugin::RenderFile' => {
+		package => { deb => 'libmojolicious-plugin-renderfile-perl', },
+	},
+	'Net::IP' => {
+		package => { deb => 'libnet-ip-perl', },
+	},
+	'Net::OAuth' => {
+		package => { deb => 'libnet-oauth-perl', },
+	},
+	'Opcode' => {
+		package => { deb => 'libperl', },
+	},
+	'Pandoc' => {
+		package => { deb => 'libpandoc-wrapper-perl', },
+	},
+	'Perl::Critic' => {
+		package => { deb => 'libperl-critic-perl', },
+	},
+	'Perl::Tidy' => {
+		package => { deb => 'perltidy', },
+	},
+	'PHP::Serialization' => {
+		package => { deb => 'libphp-serialization-perl', },
+	},
+	'Pod::Simple::Search' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Pod::Simple::XHTML' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Pod::Usage' => {
+		package => { deb => 'perl-modules', },
+	},
+	'Pod::WSDL' => {
+		package => { deb => 'libpod-wsdl-perl', },
+	},
+	'Scalar::Util' => {
+		package => { deb => 'perl-base', },
+	},
+	'SOAP::Lite' => {
+		package => { deb => 'libsoap-lite-perl', },
+	},
+	'Socket' => {
+		package => { deb => 'perl-base', },
+	},
+	'SQL::Abstract' => {
+		package => { deb => 'libsql-abstract-perl', },
+		minversion => 2.000000,
+	},
+	'String::ShellQuote' => {
+		package => { deb => 'libstring-shellquote-perl', },
+	},
+	'SVG' => {
+		package => { deb => 'libsvg-perl', },
+	},
+	'Text::CSV' => {
+		package => { deb => 'libtext-csv-perl', },
+	},
+	'Text::Wrap' => {
+		package => { deb => 'perl-base', },
+	},
+	'Tie::IxHash' => {
+		package => { deb => 'libtie-ixhash-perl', },
+	},
+	'Time::HiRes' => {
+		package => { deb => 'libperl', },
+	},
+	'Time::Zone' => {
+		package => { deb => 'libtimedate-perl', },
+	},
+	'Types::Serialiser' => {
+		package => { deb => 'libtypes-serialiser-perl', },
+	},
+	'URI::Escape' => {
+		package => { deb => 'liburi-perl', },
+	},
+	'UUID::Tiny' => {
+		package => { deb => 'libuuid-tiny-perl', },
+	},
+	'XML::LibXML' => {
+		package => { deb => 'libxml-libxml-perl', },
+	},
+	'XML::Parser' => {
+		package => { deb => 'libxml-parser-perl', },
+	},
+	'XML::Parser::EasyTree' => {
+		package => { deb => 'libxml-parser-easytree-perl', },
+	},
+	'XML::Writer' => {
+		package => { deb => 'libxml-writer-perl', },
+	},
+	'YAML::XS' => {
+		package => { deb => 'libyaml-libyaml-perl', },
+	},
 );
 
 my %moduleVersion = (
@@ -196,7 +364,7 @@ sub check_modules {
 		use strict 'refs';
 	};
 
-	for my $module (@modulesList) {
+	for my $module (keys(%modulesList)) {
 		$checkModule->($module);
 	}
 

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -32,256 +32,490 @@ use Pod::Usage;
 
 my %modulesList = (
 	'Archive::Tar' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Archive-Tar'
+		}
 	},
 	'Archive::Zip' => {
-		package => { deb => 'libarchive-zip-perl', },
+		'package' => {
+			'deb' => 'libarchive-zip-perl',
+			'rpm' => 'perl-Archive-Zip'
+		}
 	},
-	'Archive::Zip::SimpleZip' => {},
-	'Benchmark'               => {
-		package => { deb => 'perl-modules', },
+	'Archive::Zip::SimpleZip' => {
+		'package' => {
+			'rpm' => 'perl-Archive-Zip-SimpleZip'
+		}
+	},
+	'Benchmark' => {
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Benchmark'
+		}
 	},
 	'Carp' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Carp'
+		}
 	},
 	'Class::Accessor' => {
-		package => { deb => 'libclass-accessor-perl', },
+		'package' => {
+			'deb' => 'libclass-accessor-perl',
+			'rpm' => 'perl-Class-Accessor'
+		}
 	},
 	'Crypt::JWT' => {
-		package => { deb => 'libcrypt-jwt-perl', },
+		'package' => {
+			'deb' => 'libcrypt-jwt-perl',
+			'rpm' => 'perl-Crypt-JWT'
+		}
 	},
 	'Crypt::PK::RSA' => {
-		package => { deb => 'libcryptx-perl', },
-	},
-	'Data::Dump' => {
-		package => { deb => 'libdata-dump-perl', },
-	},
-	'Data::Dumper' => {
-		package => { deb => 'libperl', },
-	},
-	'Data::Structure::Util' => {
-		package => { deb => 'libdata-structure-util-perl', },
-	},
-	'Data::UUID' => {
-		package => { deb => 'libossp-uuid-perl', },
-	},
-	'Date::Format' => {
-		package => { deb => 'libtimedate-perl', },
-	},
-	'Date::Parse' => {
-		package => { deb => 'libtimedate-perl', },
-	},
-	'DateTime' => {
-		package => { deb => 'libdatetime-perl', },
+		'package' => {
+			'deb' => 'libcryptx-perl',
+			'rpm' => 'perl-CryptX'
+		}
 	},
 	'DBI' => {
-		package => { deb => 'libdbi-perl', },
+		'package' => {
+			'deb' => 'libdbi-perl',
+			'rpm' => 'perl-DBI'
+		}
+	},
+	'Data::Dump' => {
+		'package' => {
+			'deb' => 'libdata-dump-perl',
+			'rpm' => 'perl-Data-Dump'
+		}
+	},
+	'Data::Dumper' => {
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Data-Dumper'
+		}
+	},
+	'Data::Structure::Util' => {
+		'package' => {
+			'deb' => 'libdata-structure-util-perl'
+		}
+	},
+	'Data::UUID' => {
+		'package' => {
+			'deb' => 'libossp-uuid-perl',
+			'rpm' => 'perl-Data-UUID'
+		}
+	},
+	'Date::Format' => {
+		'package' => {
+			'deb' => 'libtimedate-perl',
+			'rpm' => 'perl-TimeDate'
+		}
+	},
+	'Date::Parse' => {
+		'package' => {
+			'deb' => 'libtimedate-perl',
+			'rpm' => 'perl-TimeDate'
+		}
+	},
+	'DateTime' => {
+		'package' => {
+			'deb' => 'libdatetime-perl',
+			'rpm' => 'perl-DateTime'
+		}
 	},
 	'Digest::MD5' => {
-		package => { deb => 'libperl', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Digest-MD5'
+		}
 	},
 	'Digest::SHA' => {
-		package => { deb => 'libperl', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Digest-SHA'
+		}
 	},
 	'Email::Address::XS' => {
-		package => { deb => 'libemail-address-xs-perl', },
+		'package' => {
+			'deb' => 'libemail-address-xs-perl',
+			'rpm' => 'perl-Email-Address-XS'
+		}
 	},
 	'Email::Sender::Transport::SMTP' => {
-		package => { deb => 'libemail-sender-perl', },
+		'package' => {
+			'deb' => 'libemail-sender-perl',
+			'rpm' => 'perl-Email-Sender'
+		}
 	},
 	'Email::Stuffer' => {
-		package => { deb => 'libemail-stuffer-perl', },
+		'package' => {
+			'deb' => 'libemail-stuffer-perl'
+		}
 	},
 	'Errno' => {
-		package => { deb => 'libperl', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Errno'
+		}
 	},
 	'Exception::Class' => {
-		package => { deb => 'libexception-class-perl', },
+		'package' => {
+			'deb' => 'libexception-class-perl',
+			'rpm' => 'perl-Exception-Class'
+		}
 	},
 	'File::Copy' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-Copy'
+		}
 	},
 	'File::Copy::Recursive' => {
-		package => { deb => 'libfile-copy-recursive-perl', },
+		'package' => {
+			'deb' => 'libfile-copy-recursive-perl',
+			'rpm' => 'perl-File-Copy-Recursive'
+		}
 	},
 	'File::Fetch' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-Fetch'
+		}
 	},
 	'File::Find' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-Find'
+		}
 	},
 	'File::Find::Rule' => {
-		package => { deb => 'libfile-find-rule-perl', },
+		'package' => {
+			'deb' => 'libfile-find-rule-perl',
+			'rpm' => 'perl-File-Find-Rule'
+		}
 	},
 	'File::Path' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-Path'
+		}
 	},
 	'File::Spec' => {
-		package => { deb => 'perl-base', },
-	},
-	'File::stat' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-base',
+			'rpm' => 'perl-PathTools'
+		}
 	},
 	'File::Temp' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-Temp'
+		}
+	},
+	'File::stat' => {
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-File-stat'
+		}
 	},
 	'Future::AsyncAwait' => {
-		package    => { deb => 'libfuture-asyncawait-perl', },
-		minversion => 0.52,
+		'minversion' => '0.52',
+		'package'    => {
+			'deb' => 'libfuture-asyncawait-perl'
+		}
 	},
 	'GD' => {
-		package => { deb => 'libgd-perl', },
+		'package' => {
+			'deb' => 'libgd-perl',
+			'rpm' => 'perl-GD'
+		}
 	},
 	'GD::Barcode::QRcode' => {
-		package => { deb => 'libgd-barcode-perl', },
+		'package' => {
+			'deb' => 'libgd-barcode-perl'
+		}
 	},
 	'Getopt::Long' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Getopt-Long'
+		}
 	},
 	'Getopt::Std' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Getopt-Std'
+		}
 	},
 	'HTML::Entities' => {
-		package => { deb => 'libhtml-parser-perl', },
+		'package' => {
+			'deb' => 'libhtml-parser-perl',
+			'rpm' => 'perl-HTML-Parser'
+		}
 	},
 	'HTTP::Async' => {
-		package => { deb => 'libhttp-async-perl', },
+		'package' => {
+			'deb' => 'libhttp-async-perl'
+		}
 	},
 	'IO::File' => {
-		package => { deb => 'perl-base', },
+		'package' => {
+			'deb' => 'perl-base',
+			'rpm' => 'perl-IO'
+		}
 	},
 	'Iterator' => {
-		package => { deb => 'libiterator-perl', },
+		'package' => {
+			'deb' => 'libiterator-perl',
+		}
 	},
 	'Iterator::Util' => {
-		package => { deb => 'libiterator-util-perl', },
-	},
-	'Locale::Maketext::Lexicon' => {
-		package => { deb => 'liblocale-maketext-lexicon-perl', },
-	},
-	'Locale::Maketext::Simple' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'libiterator-util-perl'
+		}
 	},
 	'LWP::Protocol::https' => {
-		package    => { deb => 'liblwp-protocol-https-perl', },
-		minversion => 6.06,
+		'minversion' => '6.06',
+		'package'    => {
+			'deb' => 'liblwp-protocol-https-perl',
+			'rpm' => 'perl-LWP-Protocol-https'
+		}
+	},
+	'Locale::Maketext::Lexicon' => {
+		'package' => {
+			'deb' => 'liblocale-maketext-lexicon-perl'
+		}
+	},
+	'Locale::Maketext::Simple' => {
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Locale-Maketext-Simple'
+		}
 	},
 	'MIME::Base32' => {
-		package => { deb => 'libmime-base32-perl', },
+		'package' => {
+			'deb' => 'libmime-base32-perl'
+		}
 	},
 	'MIME::Base64' => {
-		package => { deb => 'libperl', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-MIME-Base64'
+		}
 	},
 	'Math::Random::Secure' => {
-		package => { deb => 'libmath-random-secure-perl', },
+		'package' => {
+			'deb' => 'libmath-random-secure-perl',
+			'rpm' => 'perl-Math-Random-Secure'
+		}
 	},
 	'Minion' => {
-		package => { deb => 'libminion-perl', },
+		'package' => {
+			'deb' => 'libminion-perl'
+		}
 	},
 	'Minion::Backend::SQLite' => {
-		package => { deb => 'libminion-backend-sqlite-perl', },
+		'package' => {
+			'deb' => 'libminion-backend-sqlite-perl'
+		}
 	},
 	'Mojolicious' => {
-		package    => { deb => 'libmojolicious-perl', },
-		minversion => 9.34,
+		'minversion' => '9.34',
+		'package'    => {
+			'deb' => 'libmojolicious-perl',
+			'rpm' => 'perl-Mojolicious'
+		}
 	},
 	'Mojolicious::Plugin::NotYAMLConfig' => {
-		package => { deb => 'libmojolicious-perl', },
+		'package' => {
+			'deb' => 'libmojolicious-perl',
+			'rpm' => 'perl-Mojolicious'
+		}
 	},
 	'Mojolicious::Plugin::RenderFile' => {
-		package => { deb => 'libmojolicious-plugin-renderfile-perl', },
+		'package' => {
+			'deb' => 'libmojolicious-plugin-renderfile-perl'
+		}
 	},
 	'Net::IP' => {
-		package => { deb => 'libnet-ip-perl', },
+		'package' => {
+			'deb' => 'libnet-ip-perl',
+			'rpm' => 'perl-Net-IP'
+		}
 	},
 	'Net::OAuth' => {
-		package => { deb => 'libnet-oauth-perl', },
+		'package' => {
+			'deb' => 'libnet-oauth-perl',
+			'rpm' => 'perl-Net-OAuth'
+		}
 	},
 	'Opcode' => {
-		package => { deb => 'libperl', },
-	},
-	'Pandoc' => {
-		package => { deb => 'libpandoc-wrapper-perl', },
-	},
-	'Perl::Critic' => {
-		package => { deb => 'libperl-critic-perl', },
-	},
-	'Perl::Tidy' => {
-		package => { deb => 'perltidy', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Opcode'
+		}
 	},
 	'PHP::Serialization' => {
-		package => { deb => 'libphp-serialization-perl', },
+		'package' => {
+			'deb' => 'libphp-serialization-perl',
+			'rpm' => 'perl-PHP-Serialization'
+		}
+	},
+	'Pandoc' => {
+		'package' => {
+			'deb' => 'libpandoc-wrapper-perl'
+		}
+	},
+	'Perl::Critic' => {
+		'package' => {
+			'deb' => 'libperl-critic-perl',
+			'rpm' => 'perl-Perl-Critic'
+		}
+	},
+	'Perl::Tidy' => {
+		'package' => {
+			'deb' => 'perltidy',
+			'rpm' => 'perltidy'
+		}
 	},
 	'Pod::Simple::Search' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Pod-Simple'
+		}
 	},
 	'Pod::Simple::XHTML' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Pod-Simple'
+		}
 	},
 	'Pod::Usage' => {
-		package => { deb => 'perl-modules', },
+		'package' => {
+			'deb' => 'perl-modules',
+			'rpm' => 'perl-Pod-Usage'
+		}
 	},
 	'Pod::WSDL' => {
-		package => { deb => 'libpod-wsdl-perl', },
-	},
-	'Scalar::Util' => {
-		package => { deb => 'perl-base', },
+		'package' => {
+			'deb' => 'libpod-wsdl-perl'
+		}
 	},
 	'SOAP::Lite' => {
-		package => { deb => 'libsoap-lite-perl', },
-	},
-	'Socket' => {
-		package => { deb => 'perl-base', },
+		'package' => {
+			'deb' => 'libsoap-lite-perl',
+			'rpm' => 'perl-SOAP-Lite'
+		}
 	},
 	'SQL::Abstract' => {
-		package    => { deb => 'libsql-abstract-perl', },
-		minversion => 2.000000,
-	},
-	'String::ShellQuote' => {
-		package => { deb => 'libstring-shellquote-perl', },
+		'minversion' => '2',
+		'package'    => {
+			'deb' => 'libsql-abstract-perl',
+			'rpm' => 'perl-SQL-Abstract'
+		}
 	},
 	'SVG' => {
-		package => { deb => 'libsvg-perl', },
+		'package' => {
+			'deb' => 'libsvg-perl',
+		}
+	},
+	'Scalar::Util' => {
+		'package' => {
+			'deb' => 'perl-base',
+			'rpm' => 'perl-Scalar-List-Utils'
+		}
+	},
+	'Socket' => {
+		'package' => {
+			'deb' => 'perl-base',
+			'rpm' => 'perl-Socket'
+		}
+	},
+	'String::ShellQuote' => {
+		'package' => {
+			'deb' => 'libstring-shellquote-perl',
+			'rpm' => 'perl-String-ShellQuote'
+		}
 	},
 	'Text::CSV' => {
-		package => { deb => 'libtext-csv-perl', },
+		'package' => {
+			'deb' => 'libtext-csv-perl',
+			'rpm' => 'perl-Text-CSV'
+		}
 	},
 	'Text::Wrap' => {
-		package => { deb => 'perl-base', },
+		'package' => {
+			'deb' => 'perl-base',
+			'rpm' => 'perl-Text-Tabs+Wrap'
+		}
 	},
 	'Tie::IxHash' => {
-		package => { deb => 'libtie-ixhash-perl', },
+		'package' => {
+			'deb' => 'libtie-ixhash-perl',
+			'rpm' => 'perl-Tie-IxHash'
+		}
 	},
 	'Time::HiRes' => {
-		package => { deb => 'libperl', },
+		'package' => {
+			'deb' => 'libperl',
+			'rpm' => 'perl-Time-HiRes'
+		}
 	},
 	'Time::Zone' => {
-		package => { deb => 'libtimedate-perl', },
+		'package' => {
+			'deb' => 'libtimedate-perl',
+			'rpm' => 'perl-TimeDate'
+		}
 	},
 	'Types::Serialiser' => {
-		package => { deb => 'libtypes-serialiser-perl', },
+		'package' => {
+			'deb' => 'libtypes-serialiser-perl',
+			'rpm' => 'perl-Types-Serialiser'
+		}
 	},
 	'URI::Escape' => {
-		package => { deb => 'liburi-perl', },
+		'package' => {
+			'deb' => 'liburi-perl',
+			'rpm' => 'perl-URI'
+		}
 	},
 	'UUID::Tiny' => {
-		package => { deb => 'libuuid-tiny-perl', },
+		'package' => {
+			'deb' => 'libuuid-tiny-perl',
+			'rpm' => 'perl-UUID-Tiny'
+		}
 	},
 	'XML::LibXML' => {
-		package => { deb => 'libxml-libxml-perl', },
+		'package' => {
+			'deb' => 'libxml-libxml-perl',
+			'rpm' => 'perl-XML-LibXML'
+		}
 	},
 	'XML::Parser' => {
-		package => { deb => 'libxml-parser-perl', },
+		'package' => {
+			'deb' => 'libxml-parser-perl',
+			'rpm' => 'perl-XML-Parser'
+		}
 	},
 	'XML::Parser::EasyTree' => {
-		package => { deb => 'libxml-parser-easytree-perl', },
+		'package' => {
+			'deb' => 'libxml-parser-easytree-perl'
+		}
 	},
 	'XML::Writer' => {
-		package => { deb => 'libxml-writer-perl', },
+		'package' => {
+			'deb' => 'libxml-writer-perl',
+			'rpm' => 'perl-XML-Writer'
+		}
 	},
 	'YAML::XS' => {
-		package => { deb => 'libyaml-libyaml-perl', },
-	},
+		'package' => {
+			'deb' => 'libyaml-libyaml-perl',
+			'rpm' => 'perl-YAML-LibYAML'
+		}
+	}
 );
 
 my %moduleVersion = (

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -12,6 +12,9 @@ check_modules.pl [options]
  Options:
    -m|--modules          Check that the perl modules needed by webwork2 can be loaded.
    -p|--programs         Check that the programs needed by webwork2 exist.
+   -k|--packagetype      Specify what type of packages your system uses.
+                           For debian-based systems (e.g. Ubuntu), use 'deb'
+                           For Red Hat-based systems (e.g. RHEL, Oracle), use 'rpm'
 
 Both programs and modules are checked if no options are given.
 
@@ -518,14 +521,6 @@ my %modulesList = (
 	}
 );
 
-my %moduleVersion = (
-	'Future::AsyncAwait'   => 0.52,
-	'IO::Socket::SSL'      => 2.007,
-	'LWP::Protocol::https' => 6.06,
-	'Mojolicious'          => 9.34,
-	'SQL::Abstract'        => 2.000000
-);
-
 my @programList = qw(
 	convert
 	curl
@@ -544,18 +539,28 @@ my @programList = qw(
 	dvipng
 );
 
-my ($test_modules, $test_programs, $show_help);
+my ($test_modules, $test_programs, $packagetype, $show_help);
 
 GetOptions(
-	'm|modules'  => \$test_modules,
-	'p|programs' => \$test_programs,
-	'h|help'     => \$show_help,
+	'm|modules'       => \$test_modules,
+	'p|programs'      => \$test_programs,
+	'k|packagetype=s' => \$packagetype,
+	'h|help'          => \$show_help,
 );
+
 pod2usage(2) if $show_help;
+
+if ($packagetype && $packagetype ne 'rpm' && $packagetype ne 'deb') {
+	die 'packagetype must be one of \'deb\' or \'rpm\'';
+}
+
+my %packagemgrcommand = ('deb' => 'sudo apt install ', 'rpm' => 'sudo dnf install ');
 
 $test_modules = $test_programs = 1 unless $test_programs || $test_modules;
 
 my @PATH = split(/:/, $ENV{PATH});
+
+my (@missing_packages, @missing_modules);
 
 check_modules() if $test_modules;
 say ''          if $test_modules && $test_programs;
@@ -584,6 +589,13 @@ sub check_modules {
 			my $file = ($module =~ s|::|/|gr) . '.pm';
 			if ($@ =~ /Can't locate $file in \@INC/) {
 				say "** $module not found in \@INC";
+				if ($packagetype) {
+					if ($modulesList{$module}{package}{$packagetype}) {
+						push(@missing_packages, $modulesList{$module}{package}{$packagetype});
+					} else {
+						push(@missing_modules, $module);
+					}
+				}
 			} else {
 				say "** $module found, but failed to load: $@";
 			}
@@ -605,6 +617,15 @@ sub check_modules {
 	if ($moduleNotFound) {
 		say '';
 		say 'Some required modules were not found, could not be loaded, or were not at the sufficient version.';
+		if (@missing_modules || @missing_packages) {
+			say 'You can try to install the missing modules with the following command(s)';
+			if (@missing_modules) {
+				say 'sudo cpanm ' . join(' ', @missing_modules);
+			}
+			if (@missing_packages) {
+				say $packagemgrcommand{$packagetype} . join(' ', @missing_packages);
+			}
+		}
 		say 'Exiting as this is required to check the database driver and programs.';
 		exit 0;
 	}

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -12,9 +12,12 @@ check_modules.pl [options]
  Options:
    -m|--modules          Check that the perl modules needed by webwork2 can be loaded.
    -p|--programs         Check that the programs needed by webwork2 exist.
-   -k|--packagetype      Specify what type of packages your system uses.
-                           For debian-based systems (e.g. Ubuntu), use 'deb'
-                           For Red Hat-based systems (e.g. RHEL, Oracle), use 'rpm'
+   -d|--distribution     Specify your linux distribution.  Currently supported options are
+                           'ubuntu' - tested on ubuntu 24. May work for other distributions
+				using the apt package manager
+                           'rhel' - for RedHat Enterprise Linux and equivalents with the 
+				EPEL and CodeReady Builder repositories enabled
+				(e.g. Rocky Linux, Oracle Linux)
 
 Both programs and modules are checked if no options are given.
 
@@ -36,487 +39,487 @@ use Pod::Usage;
 my %modulesList = (
 	'Archive::Tar' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Archive-Tar'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Archive-Tar'
 		}
 	},
 	'Archive::Zip' => {
 		'package' => {
-			'deb' => 'libarchive-zip-perl',
-			'rpm' => 'perl-Archive-Zip'
+			'ubuntu' => 'libarchive-zip-perl',
+			'rhel' => 'perl-Archive-Zip'
 		}
 	},
 	'Archive::Zip::SimpleZip' => {
 		'package' => {
-			'rpm' => 'perl-Archive-Zip-SimpleZip'
+			'rhel' => 'perl-Archive-Zip-SimpleZip'
 		}
 	},
 	'Benchmark' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Benchmark'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Benchmark'
 		}
 	},
 	'Carp' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Carp'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Carp'
 		}
 	},
 	'Class::Accessor' => {
 		'package' => {
-			'deb' => 'libclass-accessor-perl',
-			'rpm' => 'perl-Class-Accessor'
+			'ubuntu' => 'libclass-accessor-perl',
+			'rhel' => 'perl-Class-Accessor'
 		}
 	},
 	'Crypt::JWT' => {
 		'package' => {
-			'deb' => 'libcrypt-jwt-perl',
-			'rpm' => 'perl-Crypt-JWT'
+			'ubuntu' => 'libcrypt-jwt-perl',
+			'rhel' => 'perl-Crypt-JWT'
 		}
 	},
 	'Crypt::PK::RSA' => {
 		'package' => {
-			'deb' => 'libcryptx-perl',
-			'rpm' => 'perl-CryptX'
+			'ubuntu' => 'libcryptx-perl',
+			'rhel' => 'perl-CryptX'
 		}
 	},
 	'DBI' => {
 		'package' => {
-			'deb' => 'libdbi-perl',
-			'rpm' => 'perl-DBI'
+			'ubuntu' => 'libdbi-perl',
+			'rhel' => 'perl-DBI'
 		}
 	},
 	'Data::Dump' => {
 		'package' => {
-			'deb' => 'libdata-dump-perl',
-			'rpm' => 'perl-Data-Dump'
+			'ubuntu' => 'libdata-dump-perl',
+			'rhel' => 'perl-Data-Dump'
 		}
 	},
 	'Data::Dumper' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Data-Dumper'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Data-Dumper'
 		}
 	},
 	'Data::Structure::Util' => {
 		'package' => {
-			'deb' => 'libdata-structure-util-perl'
+			'ubuntu' => 'libdata-structure-util-perl'
 		}
 	},
 	'Data::UUID' => {
 		'package' => {
-			'deb' => 'libossp-uuid-perl',
-			'rpm' => 'perl-Data-UUID'
+			'ubuntu' => 'libossp-uuid-perl',
+			'rhel' => 'perl-Data-UUID'
 		}
 	},
 	'Date::Format' => {
 		'package' => {
-			'deb' => 'libtimedate-perl',
-			'rpm' => 'perl-TimeDate'
+			'ubuntu' => 'libtimedate-perl',
+			'rhel' => 'perl-TimeDate'
 		}
 	},
 	'Date::Parse' => {
 		'package' => {
-			'deb' => 'libtimedate-perl',
-			'rpm' => 'perl-TimeDate'
+			'ubuntu' => 'libtimedate-perl',
+			'rhel' => 'perl-TimeDate'
 		}
 	},
 	'DateTime' => {
 		'package' => {
-			'deb' => 'libdatetime-perl',
-			'rpm' => 'perl-DateTime'
+			'ubuntu' => 'libdatetime-perl',
+			'rhel' => 'perl-DateTime'
 		}
 	},
 	'Digest::MD5' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Digest-MD5'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Digest-MD5'
 		}
 	},
 	'Digest::SHA' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Digest-SHA'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Digest-SHA'
 		}
 	},
 	'Email::Address::XS' => {
 		'package' => {
-			'deb' => 'libemail-address-xs-perl',
-			'rpm' => 'perl-Email-Address-XS'
+			'ubuntu' => 'libemail-address-xs-perl',
+			'rhel' => 'perl-Email-Address-XS'
 		}
 	},
 	'Email::Sender::Transport::SMTP' => {
 		'package' => {
-			'deb' => 'libemail-sender-perl',
-			'rpm' => 'perl-Email-Sender'
+			'ubuntu' => 'libemail-sender-perl',
+			'rhel' => 'perl-Email-Sender'
 		}
 	},
 	'Email::Stuffer' => {
 		'package' => {
-			'deb' => 'libemail-stuffer-perl'
+			'ubuntu' => 'libemail-stuffer-perl'
 		}
 	},
 	'Errno' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Errno'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Errno'
 		}
 	},
 	'Exception::Class' => {
 		'package' => {
-			'deb' => 'libexception-class-perl',
-			'rpm' => 'perl-Exception-Class'
+			'ubuntu' => 'libexception-class-perl',
+			'rhel' => 'perl-Exception-Class'
 		}
 	},
 	'File::Copy' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-Copy'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-Copy'
 		}
 	},
 	'File::Copy::Recursive' => {
 		'package' => {
-			'deb' => 'libfile-copy-recursive-perl',
-			'rpm' => 'perl-File-Copy-Recursive'
+			'ubuntu' => 'libfile-copy-recursive-perl',
+			'rhel' => 'perl-File-Copy-Recursive'
 		}
 	},
 	'File::Fetch' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-Fetch'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-Fetch'
 		}
 	},
 	'File::Find' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-Find'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-Find'
 		}
 	},
 	'File::Find::Rule' => {
 		'package' => {
-			'deb' => 'libfile-find-rule-perl',
-			'rpm' => 'perl-File-Find-Rule'
+			'ubuntu' => 'libfile-find-rule-perl',
+			'rhel' => 'perl-File-Find-Rule'
 		}
 	},
 	'File::Path' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-Path'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-Path'
 		}
 	},
 	'File::Spec' => {
 		'package' => {
-			'deb' => 'perl-base',
-			'rpm' => 'perl-PathTools'
+			'ubuntu' => 'perl-base',
+			'rhel' => 'perl-PathTools'
 		}
 	},
 	'File::Temp' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-Temp'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-Temp'
 		}
 	},
 	'File::stat' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-File-stat'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-File-stat'
 		}
 	},
 	'Future::AsyncAwait' => {
 		'minversion' => '0.52',
 		'package'    => {
-			'deb' => 'libfuture-asyncawait-perl'
+			'ubuntu' => 'libfuture-asyncawait-perl'
 		}
 	},
 	'GD' => {
 		'package' => {
-			'deb' => 'libgd-perl',
-			'rpm' => 'perl-GD'
+			'ubuntu' => 'libgd-perl',
+			'rhel' => 'perl-GD'
 		}
 	},
 	'GD::Barcode::QRcode' => {
 		'package' => {
-			'deb' => 'libgd-barcode-perl'
+			'ubuntu' => 'libgd-barcode-perl'
 		}
 	},
 	'Getopt::Long' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Getopt-Long'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Getopt-Long'
 		}
 	},
 	'Getopt::Std' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Getopt-Std'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Getopt-Std'
 		}
 	},
 	'HTML::Entities' => {
 		'package' => {
-			'deb' => 'libhtml-parser-perl',
-			'rpm' => 'perl-HTML-Parser'
+			'ubuntu' => 'libhtml-parser-perl',
+			'rhel' => 'perl-HTML-Parser'
 		}
 	},
 	'HTTP::Async' => {
 		'package' => {
-			'deb' => 'libhttp-async-perl'
+			'ubuntu' => 'libhttp-async-perl'
 		}
 	},
 	'IO::File' => {
 		'package' => {
-			'deb' => 'perl-base',
-			'rpm' => 'perl-IO'
+			'ubuntu' => 'perl-base',
+			'rhel' => 'perl-IO'
 		}
 	},
 	'Iterator' => {
 		'package' => {
-			'deb' => 'libiterator-perl',
+			'ubuntu' => 'libiterator-perl',
 		}
 	},
 	'Iterator::Util' => {
 		'package' => {
-			'deb' => 'libiterator-util-perl'
+			'ubuntu' => 'libiterator-util-perl'
 		}
 	},
 	'LWP::Protocol::https' => {
 		'minversion' => '6.06',
 		'package'    => {
-			'deb' => 'liblwp-protocol-https-perl',
-			'rpm' => 'perl-LWP-Protocol-https'
+			'ubuntu' => 'liblwp-protocol-https-perl',
+			'rhel' => 'perl-LWP-Protocol-https'
 		}
 	},
 	'Locale::Maketext::Lexicon' => {
 		'package' => {
-			'deb' => 'liblocale-maketext-lexicon-perl'
+			'ubuntu' => 'liblocale-maketext-lexicon-perl'
 		}
 	},
 	'Locale::Maketext::Simple' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Locale-Maketext-Simple'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Locale-Maketext-Simple'
 		}
 	},
 	'MIME::Base32' => {
 		'package' => {
-			'deb' => 'libmime-base32-perl'
+			'ubuntu' => 'libmime-base32-perl'
 		}
 	},
 	'MIME::Base64' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-MIME-Base64'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-MIME-Base64'
 		}
 	},
 	'Math::Random::Secure' => {
 		'package' => {
-			'deb' => 'libmath-random-secure-perl',
-			'rpm' => 'perl-Math-Random-Secure'
+			'ubuntu' => 'libmath-random-secure-perl',
+			'rhel' => 'perl-Math-Random-Secure'
 		}
 	},
 	'Minion' => {
 		'package' => {
-			'deb' => 'libminion-perl'
+			'ubuntu' => 'libminion-perl'
 		}
 	},
 	'Minion::Backend::SQLite' => {
 		'package' => {
-			'deb' => 'libminion-backend-sqlite-perl'
+			'ubuntu' => 'libminion-backend-sqlite-perl'
 		}
 	},
 	'Mojolicious' => {
 		'minversion' => '9.34',
 		'package'    => {
-			'deb' => 'libmojolicious-perl',
-			'rpm' => 'perl-Mojolicious'
+			'ubuntu' => 'libmojolicious-perl',
+			'rhel' => 'perl-Mojolicious'
 		}
 	},
 	'Mojolicious::Plugin::NotYAMLConfig' => {
 		'package' => {
-			'deb' => 'libmojolicious-perl',
-			'rpm' => 'perl-Mojolicious'
+			'ubuntu' => 'libmojolicious-perl',
+			'rhel' => 'perl-Mojolicious'
 		}
 	},
 	'Mojolicious::Plugin::RenderFile' => {
 		'package' => {
-			'deb' => 'libmojolicious-plugin-renderfile-perl'
+			'ubuntu' => 'libmojolicious-plugin-renderfile-perl'
 		}
 	},
 	'Net::IP' => {
 		'package' => {
-			'deb' => 'libnet-ip-perl',
-			'rpm' => 'perl-Net-IP'
+			'ubuntu' => 'libnet-ip-perl',
+			'rhel' => 'perl-Net-IP'
 		}
 	},
 	'Net::OAuth' => {
 		'package' => {
-			'deb' => 'libnet-oauth-perl',
-			'rpm' => 'perl-Net-OAuth'
+			'ubuntu' => 'libnet-oauth-perl',
+			'rhel' => 'perl-Net-OAuth'
 		}
 	},
 	'Opcode' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Opcode'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Opcode'
 		}
 	},
 	'PHP::Serialization' => {
 		'package' => {
-			'deb' => 'libphp-serialization-perl',
-			'rpm' => 'perl-PHP-Serialization'
+			'ubuntu' => 'libphp-serialization-perl',
+			'rhel' => 'perl-PHP-Serialization'
 		}
 	},
 	'Pandoc' => {
 		'package' => {
-			'deb' => 'libpandoc-wrapper-perl'
+			'ubuntu' => 'libpandoc-wrapper-perl'
 		}
 	},
 	'Perl::Critic' => {
 		'package' => {
-			'deb' => 'libperl-critic-perl',
-			'rpm' => 'perl-Perl-Critic'
+			'ubuntu' => 'libperl-critic-perl',
+			'rhel' => 'perl-Perl-Critic'
 		}
 	},
 	'Perl::Tidy' => {
 		'package' => {
-			'deb' => 'perltidy',
-			'rpm' => 'perltidy'
+			'ubuntu' => 'perltidy',
+			'rhel' => 'perltidy'
 		}
 	},
 	'Pod::Simple::Search' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Pod-Simple'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Pod-Simple'
 		}
 	},
 	'Pod::Simple::XHTML' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Pod-Simple'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Pod-Simple'
 		}
 	},
 	'Pod::Usage' => {
 		'package' => {
-			'deb' => 'perl-modules',
-			'rpm' => 'perl-Pod-Usage'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Pod-Usage'
 		}
 	},
 	'Pod::WSDL' => {
 		'package' => {
-			'deb' => 'libpod-wsdl-perl'
+			'ubuntu' => 'libpod-wsdl-perl'
 		}
 	},
 	'SOAP::Lite' => {
 		'package' => {
-			'deb' => 'libsoap-lite-perl',
-			'rpm' => 'perl-SOAP-Lite'
+			'ubuntu' => 'libsoap-lite-perl',
+			'rhel' => 'perl-SOAP-Lite'
 		}
 	},
 	'SQL::Abstract' => {
 		'minversion' => '2',
 		'package'    => {
-			'deb' => 'libsql-abstract-perl',
-			'rpm' => 'perl-SQL-Abstract'
+			'ubuntu' => 'libsql-abstract-perl',
+			'rhel' => 'perl-SQL-Abstract'
 		}
 	},
 	'SVG' => {
 		'package' => {
-			'deb' => 'libsvg-perl',
+			'ubuntu' => 'libsvg-perl',
 		}
 	},
 	'Scalar::Util' => {
 		'package' => {
-			'deb' => 'perl-base',
-			'rpm' => 'perl-Scalar-List-Utils'
+			'ubuntu' => 'perl-base',
+			'rhel' => 'perl-Scalar-List-Utils'
 		}
 	},
 	'Socket' => {
 		'package' => {
-			'deb' => 'perl-base',
-			'rpm' => 'perl-Socket'
+			'ubuntu' => 'perl-base',
+			'rhel' => 'perl-Socket'
 		}
 	},
 	'String::ShellQuote' => {
 		'package' => {
-			'deb' => 'libstring-shellquote-perl',
-			'rpm' => 'perl-String-ShellQuote'
+			'ubuntu' => 'libstring-shellquote-perl',
+			'rhel' => 'perl-String-ShellQuote'
 		}
 	},
 	'Text::CSV' => {
 		'package' => {
-			'deb' => 'libtext-csv-perl',
-			'rpm' => 'perl-Text-CSV'
+			'ubuntu' => 'libtext-csv-perl',
+			'rhel' => 'perl-Text-CSV'
 		}
 	},
 	'Text::Wrap' => {
 		'package' => {
-			'deb' => 'perl-base',
-			'rpm' => 'perl-Text-Tabs+Wrap'
+			'ubuntu' => 'perl-base',
+			'rhel' => 'perl-Text-Tabs+Wrap'
 		}
 	},
 	'Tie::IxHash' => {
 		'package' => {
-			'deb' => 'libtie-ixhash-perl',
-			'rpm' => 'perl-Tie-IxHash'
+			'ubuntu' => 'libtie-ixhash-perl',
+			'rhel' => 'perl-Tie-IxHash'
 		}
 	},
 	'Time::HiRes' => {
 		'package' => {
-			'deb' => 'libperl',
-			'rpm' => 'perl-Time-HiRes'
+			'ubuntu' => 'perl',
+			'rhel' => 'perl-Time-HiRes'
 		}
 	},
 	'Time::Zone' => {
 		'package' => {
-			'deb' => 'libtimedate-perl',
-			'rpm' => 'perl-TimeDate'
+			'ubuntu' => 'libtimedate-perl',
+			'rhel' => 'perl-TimeDate'
 		}
 	},
 	'Types::Serialiser' => {
 		'package' => {
-			'deb' => 'libtypes-serialiser-perl',
-			'rpm' => 'perl-Types-Serialiser'
+			'ubuntu' => 'libtypes-serialiser-perl',
+			'rhel' => 'perl-Types-Serialiser'
 		}
 	},
 	'URI::Escape' => {
 		'package' => {
-			'deb' => 'liburi-perl',
-			'rpm' => 'perl-URI'
+			'ubuntu' => 'liburi-perl',
+			'rhel' => 'perl-URI'
 		}
 	},
 	'UUID::Tiny' => {
 		'package' => {
-			'deb' => 'libuuid-tiny-perl',
-			'rpm' => 'perl-UUID-Tiny'
+			'ubuntu' => 'libuuid-tiny-perl',
+			'rhel' => 'perl-UUID-Tiny'
 		}
 	},
 	'XML::LibXML' => {
 		'package' => {
-			'deb' => 'libxml-libxml-perl',
-			'rpm' => 'perl-XML-LibXML'
+			'ubuntu' => 'libxml-libxml-perl',
+			'rhel' => 'perl-XML-LibXML'
 		}
 	},
 	'XML::Parser' => {
 		'package' => {
-			'deb' => 'libxml-parser-perl',
-			'rpm' => 'perl-XML-Parser'
+			'ubuntu' => 'libxml-parser-perl',
+			'rhel' => 'perl-XML-Parser'
 		}
 	},
 	'XML::Parser::EasyTree' => {
 		'package' => {
-			'deb' => 'libxml-parser-easytree-perl'
+			'ubuntu' => 'libxml-parser-easytree-perl'
 		}
 	},
 	'XML::Writer' => {
 		'package' => {
-			'deb' => 'libxml-writer-perl',
-			'rpm' => 'perl-XML-Writer'
+			'ubuntu' => 'libxml-writer-perl',
+			'rhel' => 'perl-XML-Writer'
 		}
 	},
 	'YAML::XS' => {
 		'package' => {
-			'deb' => 'libyaml-libyaml-perl',
-			'rpm' => 'perl-YAML-LibYAML'
+			'ubuntu' => 'libyaml-libyaml-perl',
+			'rhel' => 'perl-YAML-LibYAML'
 		}
 	}
 );
@@ -544,17 +547,17 @@ my ($test_modules, $test_programs, $packagetype, $show_help);
 GetOptions(
 	'm|modules'       => \$test_modules,
 	'p|programs'      => \$test_programs,
-	'k|packagetype=s' => \$packagetype,
+	'd|distribution=s' => \$packagetype,
 	'h|help'          => \$show_help,
 );
 
 pod2usage(2) if $show_help;
 
-if ($packagetype && $packagetype ne 'rpm' && $packagetype ne 'deb') {
-	die 'packagetype must be one of \'deb\' or \'rpm\'';
+if ($packagetype && $packagetype ne 'rhel' && $packagetype ne 'ubuntu') {
+	die 'packagetype must be one of \'ubuntu\' or \'rhel\'';
 }
 
-my %packagemgrcommand = ('deb' => 'sudo apt install ', 'rpm' => 'sudo dnf install ');
+my %packagemgrcommand = ('ubuntu' => 'sudo apt install ', 'rhel' => 'sudo dnf install ');
 
 $test_modules = $test_programs = 1 unless $test_programs || $test_modules;
 
@@ -618,12 +621,12 @@ sub check_modules {
 		say '';
 		say 'Some required modules were not found, could not be loaded, or were not at the sufficient version.';
 		if (@missing_modules || @missing_packages) {
-			say 'You can try to install the missing modules with the following command(s)';
+			say 'You can try to install the missing modules with the following command(s):'."\n";
 			if (@missing_modules) {
-				say 'sudo cpanm ' . join(' ', @missing_modules);
+				say 'sudo cpanm ' . join(' ', @missing_modules) . "\n";
 			}
 			if (@missing_packages) {
-				say $packagemgrcommand{$packagetype} . join(' ', @missing_packages);
+				say $packagemgrcommand{$packagetype} . join(' ', @missing_packages) . "\n";
 			}
 		}
 		say 'Exiting as this is required to check the database driver and programs.';

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -353,18 +353,18 @@ sub check_modules {
 			} else {
 				say "** $module found, but failed to load: $@";
 			}
-		} elsif (defined($moduleVersion{$module})
-			&& version->parse(${ $module . '::VERSION' }) < version->parse($moduleVersion{$module}))
+		} elsif (defined($modulesList{$module}{'minversion'})
+			&& version->parse(${ $module . '::VERSION' }) < version->parse($modulesList{$module}{'minversion'}))
 		{
 			$moduleNotFound = 1;
-			say "** $module found, but not version $moduleVersion{$module} or better";
+			say "** $module found, but not version $modulesList{$module}{'minversion'} or better";
 		} else {
 			say "   $module found and loaded";
 		}
 		use strict 'refs';
 	};
 
-	for my $module (keys(%modulesList)) {
+	for my $module (sort keys(%modulesList)) {
 		$checkModule->($module);
 	}
 

--- a/bin/check_modules.pl
+++ b/bin/check_modules.pl
@@ -577,6 +577,14 @@ if ($packagetype && $packagetype ne 'rhel' && $packagetype ne 'ubuntu') {
 	die 'packagetype must be one of \'ubuntu\' or \'rhel\'';
 }
 
+if (!$packagetype) {
+	if (determine_distribution()) {
+		say 'Distribution was not specified.  Detected that the distribution is ' . $packagetype . ' or equivalent.';
+	} else {
+		say 'Distribution was not specified and could not be detected. Use the -d option to specify your distribution.';
+	}
+}
+
 my %packagemgrcommand = ('ubuntu' => 'sudo apt install ', 'rhel' => 'sudo dnf install ');
 
 $test_modules = $test_programs = 1 unless $test_programs || $test_modules;
@@ -595,6 +603,45 @@ sub which {
 		return "$path/$program" if -e "$path/$program";
 	}
 	return;
+}
+
+sub determine_distribution {
+	my %os_attrs;
+
+	#code adapted from Sys::OsRelease
+	if (open my $fh, "<", '/etc/os-release') {
+		while (my $line = <$fh>) {
+			chomp $line;    # remove trailing nl
+			if (substr($line, -1, 1) eq "\r") {
+				$line = substr($line, 0, -1);    # remove trailing cr
+			}
+
+			# skip comments and blank lines
+			if ($line =~ /^ \s+ #/x or $line =~ /^ \s+ $/x) {
+				next;
+			}
+
+			# read attribute assignment lines
+			if ($line =~ /^ ([A-Z0-9_]+) = "(.*)" $/x
+				or $line =~ /^ ([A-Z0-9_]+) = '(.*)' $/x
+				or $line =~ /^ ([A-Z0-9_]+) = (.*) $/x)
+			{
+				next if $1 eq "_config";    # don't overwrite _config
+				$os_attrs{ lc($1) } = $2;
+			}
+		}
+		close $fh;
+		if ($os_attrs{'id'} =~ 'ubuntu' || $os_attrs{'id_like'} =~ 'ubuntu') {
+			$packagetype = 'ubuntu';
+			return 1;
+		} elsif ($os_attrs{'id'} =~ 'fedora' || $os_attrs{'id_like'} =~ 'fedora') {
+			$packagetype = 'rhel';
+			return 1;
+		}
+	} else {
+		return 0;
+	}
+
 }
 
 sub check_modules {


### PR DESCRIPTION
Update the the `check_modules.pl` script to add the name of the Debian and RedHat package for perl packages where available.
This adds another flag when calling the script, where the user can specify if they are on a deb- or rpm-based system, and the output will suggest a command for installing any missing packages.
