### PR TITLE
Fix importing of JITAR sets.

### DIFF
--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -197,8 +197,8 @@ sub importSetsFromDef ($ce, $db, $setDefFiles, $existingSets = undef, $assign = 
 				showMeAnother     => $rh_problem->{showMeAnother},
 				showHintsAfter    => $rh_problem->{showHintsAfter},
 				prPeriod          => $rh_problem->{prPeriod},
-				attToOpenChildren => $rh_problem->{attToOpenChildren},
-				countsParentGrade => $rh_problem->{countsParentGrade}
+				attToOpenChildren => $rh_problem->{att_to_open_children},
+				countsParentGrade => $rh_problem->{counts_parent_grade}
 			);
 		}
 


### PR DESCRIPTION
The settings `att_to_open_children` and `counts_parent_grade` were not being transferred from the set definition file due to incorrect casing used.  Thanks to @hal4stvf for pointing this out.

Part of the problem here is the mix of snake case and cammel case.  The set definition file, the problem table in the database, and the default value from `defaults.config` use `att_to_open_children`.  However, the `addProblemToSet` method expects the argument of `attToOpenChildren`. We need to eliminate snake case usage altogether.  It is the most annoying case to type (`shift _ t` takes three keystrokes but `shift t` only takes two).  But even worse is mixing these different casing schemes, particularly as is done in this case.

This fixes issue #2897.