### PR TITLE
Update `webwork.maa.org` links.

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -9,4 +9,4 @@ community_bridge: # Replace with a single Community Bridge project-name e.g., cl
 liberapay: # Replace with a single Liberapay username
 issuehunt: # Replace with a single IssueHunt username
 otechie: # Replace with a single Otechie username
-custom: ["https://webwork.maa.org/wiki"]
+custom: ['https://wiki.openwebwork.org/wiki']

--- a/README.md
+++ b/README.md
@@ -1,34 +1,45 @@
+# Welcome to WeBWorK
+
                                        WeBWorK
                          Online Homework Delivery System
                                    Version 2.*
                         Branch:  github.com/openwebwork
 
-             https://webwork.maa.org/wiki/Release_notes_for_WeBWorK_2.20
+             https://wiki.openwebwork.org/wiki/Release_notes_for_WeBWorK_2.20
                     Copyright 2000-2025, The WeBWorK Project
                              https://openwebwork.org/
                               All rights reserved.
 
-# Welcome to WeBWorK
-
-WeBWorK is an open-source online homework system for math and sciences courses. WeBWorK is supported by the MAA and the NSF and comes with an Open Problem Library (OPL) of over 30,000 homework problems. Problems in the OPL target most lower division undergraduate math courses, some advanced courses and some other STEM subjects. Supported courses include college algebra, discrete mathematics, probability and statistics, single and multivariable calculus, differential equations, linear algebra and complex analysis.  Find out more at the main WeBWorK [webpage](https://openwebwork.org).
+WeBWorK is an open-source online homework system for math and sciences courses. WeBWorK is supported by the MAA and the
+NSF and comes with an Open Problem Library (OPL) of over 30,000 homework problems. Problems in the OPL target most lower
+division undergraduate math courses, some advanced courses and some other STEM subjects. Supported courses include
+college algebra, discrete mathematics, probability and statistics, single and multivariable calculus, differential
+equations, linear algebra and complex analysis. Find out more at the main WeBWorK [webpage](https://openwebwork.org).
 
 ## Information for Users
 
-New users interested in getting started with their own WeBWorK server, or instructors looking to learn more about how to use WeBWorK in their classes, should take a look at one of the following resources:
+New users interested in getting started with their own WeBWorK server, or instructors looking to learn more about how to
+use WeBWorK in their classes, should take a look at one of the following resources:
 
-*  The [WeBWorK project home page](https://openwebwork.org/) - General information and resources including announcements of events and important project news
-*  [WeBWorK wiki](https://webwork.maa.org/wiki/Main_Page) - The main WeBWorK wiki
-*  [Installing WeBWorK](https://webwork.maa.org/wiki/Manual_Installation_Guides) - Installing WeBWorK
-*  [Instructors](https://webwork.maa.org/wiki/Instructors) - Information for Instructors
-*  [Problem Authors](https://webwork.maa.org/wiki/Authors) - Information for Problem Authors
-*  [Forum](http://webwork.maa.org/moodle/mod/forum/index.php?id=3) - The WeBWorK Forum for getting help from the community
-*  [Frequently Asked Questions](https://github.com/openwebwork/webwork2/wiki/Frequently-Asked-Questions) - A list of frequently asked questions.
+- The [WeBWorK project home page](https://openwebwork.org/) - General information and resources including announcements
+  of events and important project news
+- [WeBWorK wiki](https://wiki.openwebwork.org/wiki/Main_Page) - The main WeBWorK wiki
+- [Installing WeBWorK](https://wiki.openwebwork.org/wiki/Manual_Installation_Guides) - Installing WeBWorK
+- [Instructors](https://wiki.openwebwork.org/wiki/Instructors) - Information for Instructors
+- [Problem Authors](https://wiki.openwebwork.org/wiki/Authors) - Information for Problem Authors
+- [Forum](https://forums.openwebwork.org/mod/forum/index.php?id=3) - The WeBWorK Forum for getting help from the
+  community
+- [Frequently Asked Questions](https://github.com/openwebwork/webwork2/wiki/Frequently-Asked-Questions) - A list of
+  frequently asked questions.
 
 ## Information for Downloading
 
-* Installation manuals can be found at https://webwork.maa.org/wiki/Category:Installation_Manuals
+- See the [installation manuals](https://wiki.openwebwork.org/wiki/Category:Installation_Manuals).
 
 ## Information For Developers
 
-* People interested in developing new features for WeBWorK can start at https://webwork.maa.org/wiki/Category:Developers, or start a [discussion on GitHub](https://github.com/openwebwork/webwork2/discussions) to engage with the current developers.
-* People interested in developing new problems for WeBWorK should visit [Problem Authors](http://webwork.maa.org/wiki/Authors).
+- People interested in developing new features for WeBWorK can start at the wiki
+  [development page](https://wiki.openwebwork.org/wiki/Category:Developers), or start a
+  [discussion on GitHub](https://github.com/openwebwork/webwork2/discussions) to engage with the current developers.
+- People interested in developing new problems for WeBWorK should visit the wiki
+  [problem authoring page](https://wiki.openwebwork.org/wiki/Authors).

--- a/bin/upgrade-database-to-utf8mb4.pl
+++ b/bin/upgrade-database-to-utf8mb4.pl
@@ -32,7 +32,7 @@ latin1 to utf8mb4.
 Upgrade webwork course database tables from latin1 to utf8mb4.
 
 This script assumes that you have already properly configured the database to
-work with the utf8mb4 character set.  See L<https://webwork.maa.org/wiki/Converting_the_webwork_database_from_the_latin1_to_the_utf8mb4_character_set#Check_what_the_default_character_set_is_for_MySQL_on_your_new_or_upgraded_server>.
+work with the utf8mb4 character set.  See L<https://wiki.openwebwork.org/wiki/Converting_the_webwork_database_from_the_latin1_to_the_utf8mb4_character_set#Check_what_the_default_character_set_is_for_MySQL_on_your_new_or_upgraded_server>.
 
 Also, make sure to upgrade the course via webwork2/admin "Upgrade Courses"
 before running this script for the course.

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -327,9 +327,6 @@ $webworkDirs{themes}     = "$webworkDirs{htdocs}/themes";
 # Location of localization directory.
 $webworkDirs{localize} = "$webworkDirs{root}/lib/WeBWorK/Localize";
 
-# URL of general WeBWorK documentation.
-$webworkURLs{docs}          = "https://webwork.maa.org";
-
 # URLs for new issues in Github.
 $webworkURLs{webwork2BugReporter} = "https://github.com/openwebwork/webwork2/issues/new";
 $webworkURLs{OPLBugReporter}      = "https://github.com/openwebwork/webwork-open-problem-library/issues/new";
@@ -343,14 +340,12 @@ $webworkURLs{wwSecurityAnnounce} = "https://groups.google.com/g/ww-security-anno
 $webworkSecListManagers = 'ww-security-announce+managers@googlegroups.com';
 
 # URLs in the Wiki
-$webworkURLs{WikiMain}      = "https://webwork.maa.org/wiki/";
-$webworkURLs{SiteMap}       = "https://webwork.maa.org/wiki/WeBWorK_Sites";
+$webworkURLs{WikiMain} = "https://wiki.openwebwork.org/wiki";
+$webworkURLs{SiteMap}  = "https://wiki.openwebwork.org/wiki/WeBWorK_Sites";
 
 # URL for help buttons on the PGProblemEditor pages:
-$webworkURLs{MathObjectsHelpURL}      ='https://webwork.maa.org/wiki/Category:MathObjects';
-$webworkURLs{PGLabHelpURL}            ='https://demo.webwork.rochester.edu/webwork2/wikiExamples/MathObjectsLabs2/2?login_practice_user=true';
-$webworkURLs{PGMLHelpURL}             ='https://demo.webwork.rochester.edu/webwork2/cervone_course/PGML/1?login_practice_user=true';
-$webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Authors';
+$webworkURLs{MathObjectsHelpURL} = 'https://wiki.openwebwork.org/wiki/Category:MathObjects';
+$webworkURLs{AuthorHelpURL}      = 'https://wiki.openwebwork.org/wiki/Category:Authors';
 
 # Location of CSS
 # $webworkURLs{stylesheet}    = "$webworkURLs{htdocs}/css/${defaultTheme}.css";
@@ -366,7 +361,7 @@ $webworkURLs{AuthorHelpURL}           ='https://webwork.maa.org/wiki/Category:Au
 # The problemLibrary configuration data should now be set in localOverrides.conf
 
 # For configuration instructions, see:
-# https://webwork.maa.org/wiki/Open_Problem_Library
+# https://wiki.openwebwork.org/wiki/Open_Problem_Library
 # The directory containing the open problem library files.
 # Set the root to "" if no problem
 

--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -149,7 +149,7 @@ $mail{feedbackRecipients}    = [
 
 
 # For configuration instructions, see:
-# http://webwork.maa.org/wiki/Open_Problem_Library
+# https://wiki.openwebwork.org/wiki/Open_Problem_Library
 # The directory containing the open problem library files. Set to "" if no problem
 # library is installed.
 # NationalProblemLibrary (NPL) has been renamed to OpenProblemLibrary (OPL)
@@ -402,7 +402,7 @@ $mail{feedbackRecipients}    = [
 
 # Alternate locations -- this allows you to place temporary files in a location
 # that is not backed up and is the recommended set up for most installations.
-# See http://webwork.maa.org/wiki/Store_WeBWorK%27s_temporary_files_in_a_separate_directory_or_partition
+# See https://wiki.openwebwork.org/wiki/Store_WeBWorK's_temporary_files_in_a_separate_directory_or_partition
 # for more information.   Note that the wwtmp directory (or partition) should be
 # created under Apache's main server document root which is usually
 # /var/www/html. If this is in a different location on your system, edit the
@@ -428,7 +428,7 @@ $mail{feedbackRecipients}    = [
 
 # To enable Rserve (the R statistical server) in WeBWorK, uncomment the
 # following line.  The R server needs to be installed and running in order for
-# this to work.  See http://webwork.maa.org/wiki/R_in_WeBWorK for more info.
+# this to work.  See https://wiki.openwebwork.org/wiki/R_in_WeBWorK for more info.
 
 #$pg{specialPGEnvironmentVars}{Rserve} = {host => "localhost"};
 

--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -322,7 +322,7 @@ $job_queue{database_dsn} = "sqlite:$webwork_dir/DATA/webwork2_job_queue.db";
 # The problemLibrary configuration data should now be set in localOverrides.conf
 
 # For configuration instructions, see:
-# http://webwork.maa.org/wiki/National_Problem_Library
+# https://wiki.openwebwork.org/wiki/Open_Problem_Library
 # The directory containing the Open Problem Library files.
 # Set the root to "" if no problem
 # library is installed. Use version 2.0 for the NPL and use the version 2.5  for the OPL.

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -298,7 +298,7 @@ EOS
 				}
 
 				# Blackboard seems to return this when there is no prior grade.
-				# See: https://webwork.maa.org/moodle/mod/forum/discuss.php?d=5002
+				# See: https://forums.openwebwork.org/mod/forum/discuss.php?d=5002
 				$priorScore = '' if $priorScore eq 'success';
 
 				# Do not update the score if there is no significant change. Note that the cases where the webwork score

--- a/lib/WeBWorK/Authen/Shibboleth.pm
+++ b/lib/WeBWorK/Authen/Shibboleth.pm
@@ -11,7 +11,7 @@ To use this module copy C<conf/authen_shibboleth.conf.dist> to
 C<conf/authen_shibboleth.dist>, and uncomment the line in C<conf/localOverrides.conf>
 that reads C<include("conf/authen_shibboleth.conf");>.
 
-Refer to the L<external Shibboleth authentication|http://webwork.maa.org/wiki/External_(Shibboleth)_Authentication>
+Refer to the L<external Shibboleth authentication|https://wiki.openwebwork.org/wiki/External_(Shibboleth)_Authentication>
 documentation on the WeBWorK wiki and the instructions in the comments of the
 C<conf/authen_shibboleth.conf.dist> file.
 

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -172,7 +172,6 @@ sub constructPGOptions ($ce, $user, $set, $problem, $psvn, $formFields, $transla
 	$options{templateDirectory} = "$ce->{courseDirs}{templates}/";
 	$options{tempDirectory}     = "$ce->{courseDirs}{html_temp}/";
 	$options{tempURL}           = "$ce->{courseURLs}{html_temp}/";
-	$options{webworkDocsURL}    = "$ce->{webworkURLs}{docs}/";
 	$options{localHelpURL}      = "$ce->{pg}{URLs}{localHelpURL}/";
 	$options{MathJaxURL}        = $ce->{webworkURLs}{MathJax};
 	$options{server_root_url}   = $ce->{server_root_url} || '';


### PR DESCRIPTION
In most cases the `webwork.maa.org` links have been updated to their new locations.  However, there are some exceptions and other things noted below.

In addition to updating links in the `README.md` file, the file was generally cleaned up and issues reported by markdown lint fixed.

For example, a markdown file must have a single top level header and it must be the first line of the file.  So the `Welcome to WeBWorK` header was moved before the license.  I would actually like to remove the license from the file as well.  It is not standard practice to include that here.  It is in the `LICENSE` file.  That should be enough. Perhaps a link to the license could be here instead?

Also, the bare links were replaced with markdown links with link text instead of directly showing the URL.

The `webwork.maa.org` links in the files in the
`courses.dist/modelCourse/templates/setDemo` directory were not updated. I have another plan for the `Demo` set that will be in a future pull request.

The `$webworkURLs{docs}` configuration variable (in `defaults.config`) was not updated, but was deleted. The only place that was used was to pass that to PG in `lib/WeBWorK/Utils/Rendering.pm`.  However, PG doesn't use that.  So that usage was removed as well.