### PR TITLE
Add completed time to test output.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1309,7 +1309,8 @@ async sub pre_header_initialize ($c) {
 	} elsif ($endTime > $set->due_date) {
 		$c->{exceededAllowedTime} = 1;
 	}
-	$c->{elapsedTime} = int(($endTime - $set->open_date) / 0.6 + 0.5) / 100;
+	$c->{elapsedTime}   = int(($endTime - $set->open_date) / 0.6 + 0.5) / 100;
+	$c->{completedTime} = $c->formatDateTime($endTime, $ce->{studentDateDisplayFormat});
 
 	# Get the number of attempts and number of remaining attempts.
 	$c->{attemptNumber} =

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -334,6 +334,8 @@
 		<div class="alert alert-warning p-1">
 			<%= maketext('Time taken on test: [_1] min ([_2] min allowed).',
 				$c->{elapsedTime}, sprintf('%.0f', 10 * ($c->{set}->due_date - $c->{set}->open_date) / 6) / 100) %>
+			<br>
+			<%= maketext('Test completed on [_1].', $c->{completedTime}) %>
 		</div>
 	% } elsif ($c->{exceededAllowedTime} && $c->{recordedScore} != 0) {
 		<div class="alert alert-warning p-1">


### PR DESCRIPTION
Add the submit time next to the time taken on completed test versions. My use case for this is being able to see the time a test ended and compare it to the time work was submitted to my lms when grading written work with a test.