### PR TITLE
Clarify messages in extension achievement items when reduced scoring is enabled

### DIFF
--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -65,7 +65,8 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+						'Because the deadline has already passed you will only '
+							. 'receive reduced credit during this extension.'
 					)
 				)
 			)->join('');

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend a close date by 24 hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(after between);
+use WeBWorK::Utils::DateTime qw(before after between);
 
 use constant ONE_DAY => 86400;
 
@@ -25,14 +25,63 @@ sub can_use ($self, $set, $records) {
 
 sub print_form ($self, $set, $records, $c) {
 	my $randomization_statement = after($set->due_date) ? $c->maketext('All problems will be rerandomized.') : '';
-	return $c->tag(
-		'p',
-		$c->maketext(
-			'Extend the close date of this assignment to [_1] (an additional 24 hours). [_2]',
-			$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat}),
-			$randomization_statement
-		)
-	);
+	if ($set->enable_reduced_scoring) {
+		if (before($set->reduced_scoring_date + ONE_DAY)) {
+			return $c->c(
+				$c->tag('p', $c->maketext('Extend the deadline by 24 hours. [_1]', $randomization_statement)),
+				$c->tag(
+					'ul',
+					$c->c(
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive full credit until [_1].',
+								$c->formatDateTime(
+									$set->reduced_scoring_date + ONE_DAY,
+									$c->ce->{studentDateDisplayFormat}
+								)
+							)
+						),
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive reduced credit until [_1].',
+								$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+							)
+						)
+					)->join('')
+				),
+			)->join('');
+		} else {
+			return $c->c(
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Extend the reduced credit deadline of this assignment to [_1] (an additional 24 hours). [_2]',
+						$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat}),
+						$randomization_statement
+					)
+				),
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+					)
+				)
+			)->join('');
+		}
+
+	} else {
+		return $c->tag(
+			'p',
+			$c->maketext(
+				'Extend the close date of this assignment to [_1] (an additional 24 hours). [_2]',
+				$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat}),
+				$randomization_statement
+			)
+		);
+	}
+
 }
 
 sub use_item ($self, $set, $records, $c) {

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend the close date on a test
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(before between);
 
 use constant ONE_DAY => 86400;
 
@@ -12,8 +12,7 @@ sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDateGW',
 		name        => x('Amulet of Extension'),
-		description =>
-			x('Extends the close date of a test by 24 hours. Note: The test must still be open for this to work.')
+		description => x('Extends the close date of a test by 24 hours.')
 	}, $class;
 }
 
@@ -25,13 +24,60 @@ sub can_use ($self, $set, $records) {
 }
 
 sub print_form ($self, $set, $records, $c) {
-	return $c->tag(
-		'p',
-		$c->maketext(
-			'Extend the close date of this test to [_1] (an additional 24 hours).',
-			$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
-		)
-	);
+	if ($set->enable_reduced_scoring) {
+		if (before($set->reduced_scoring_date + ONE_DAY)) {
+			return $c->c(
+				$c->tag('p', $c->maketext('Extend the deadline by 24 hours.')),
+				$c->tag(
+					'ul',
+					$c->c(
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive full credit until [_1].',
+								$c->formatDateTime(
+									$set->reduced_scoring_date + ONE_DAY,
+									$c->ce->{studentDateDisplayFormat}
+								)
+							)
+						),
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive reduced credit until [_1].',
+								$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+							)
+						)
+					)->join('')
+				),
+			)->join('');
+		} else {
+			return $c->c(
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Extend the reduced credit deadline of this assignment to [_1] (an additional 24 hours).',
+						$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+					)
+				),
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+					)
+				)
+			)->join('');
+		}
+
+	} else {
+		return $c->tag(
+			'p',
+			$c->maketext(
+				'Extend the close date of this assignment to [_1] (an additional 24 hours).',
+				$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+			)
+		);
+	}
 }
 
 sub use_item ($self, $set, $records, $c) {

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -63,7 +63,8 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+						'Because the deadline has already passed you will only '
+							. 'receive reduced credit during this extension.'
 					)
 				)
 			)->join('');

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -14,7 +14,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub can_use($self, $set, $records) {
+sub can_use ($self, $set, $records) {
 	return 0
 		unless $set->assignment_type eq 'default'
 		&& after($set->open_date);

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -14,7 +14,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub can_use($self, $set, $records) {
+sub can_use ($self, $set, $records) {
 	return 0
 		unless $set->assignment_type eq 'default'
 		&& after($set->open_date);

--- a/lib/WeBWorK/AchievementItems/ResurrectGW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectGW.pm
@@ -19,7 +19,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub can_use($self, $set, $records) {
+sub can_use ($self, $set, $records) {
 	return $set->assignment_type =~ /gateway/
 		&& (after($set->due_date) || ($set->reduced_scoring_date && after($set->reduced_scoring_date)));
 	# TODO: Check if a new version can be created, and only allow using this reward in that case.

--- a/lib/WeBWorK/AchievementItems/ResurrectHW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectHW.pm
@@ -16,7 +16,7 @@ sub new ($class) {
 	}, $class;
 }
 
-sub can_use($self, $set, $records) {
+sub can_use ($self, $set, $records) {
 	return $set->assignment_type eq 'default'
 		&& (after($set->due_date) || ($set->reduced_scoring_date && after($set->reduced_scoring_date)));
 }

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -65,7 +65,8 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+						'Because the deadline has already passed you will only '
+							. 'receive reduced credit during this extension.'
 					)
 				)
 			)->join('');

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -4,7 +4,7 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend a close date by 48 hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(after between);
+use WeBWorK::Utils::DateTime qw(before after between);
 
 use constant TWO_DAYS => 172800;
 
@@ -25,14 +25,62 @@ sub can_use ($self, $set, $records) {
 
 sub print_form ($self, $set, $records, $c) {
 	my $randomization_statement = after($set->due_date) ? $c->maketext('All problems will be rerandomized.') : '';
-	return $c->tag(
-		'p',
-		$c->maketext(
-			'Extend the close date of this assignment to [_1] (an additional 48 hours). [_2]',
-			$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat}),
-			$randomization_statement
-		)
-	);
+	if ($set->enable_reduced_scoring) {
+		if (before($set->reduced_scoring_date + TWO_DAYS)) {
+			return $c->c(
+				$c->tag('p', $c->maketext('Extend the deadline by 48hours. [_1]', $randomization_statement)),
+				$c->tag(
+					'ul',
+					$c->c(
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive full credit until [_1].',
+								$c->formatDateTime(
+									$set->reduced_scoring_date + TWO_DAYS,
+									$c->ce->{studentDateDisplayFormat}
+								)
+							)
+						),
+						$c->tag(
+							'li',
+							$c->maketext(
+								'You will be able to receive reduced credit until [_1].',
+								$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat})
+							)
+						)
+					)->join('')
+				),
+			)->join('');
+		} else {
+			return $c->c(
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Extend the reduced credit deadline of this assignment to [_1] (an additional 48 hours). [_2]',
+						$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat}),
+						$randomization_statement
+					)
+				),
+				$c->tag(
+					'p',
+					$c->maketext(
+						'Because the deadline has already passed you will only receive reduced credit during this extension.'
+					)
+				)
+			)->join('');
+		}
+
+	} else {
+		return $c->tag(
+			'p',
+			$c->maketext(
+				'Extend the close date of this assignment to [_1] (an additional 48 hours). [_2]',
+				$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat}),
+				$randomization_statement
+			)
+		);
+	}
 }
 
 sub use_item ($self, $set, $records, $c) {


### PR DESCRIPTION
The messages for extension items only talked about the due date, which would be confusing to students, as they would probably associate "due date" with the full-credit deadline.  This clarifies what will happen to both the reduced credit date and the close date, trying to use similar terminology to the messages at the top of the set.