### PR TITLE
Fix an issue with adding and updating users when the accomodation_time_factor is not set.

### DIFF
--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -436,11 +436,17 @@ sub abort_transaction {
 
 BEGIN {
 	*User            = gen_schema_accessor("user");
-	*newUser         = gen_new("user");
 	*countUsersWhere = gen_count_where("user");
 	*existsUserWhere = gen_exists_where("user");
 	*listUsersWhere  = gen_list_where("user");
 	*getUsersWhere   = gen_get_records_where("user");
+}
+
+sub newUser {
+	my ($self, @data) = @_;
+	my $user = $self->{user}{record}->new(@data);
+	$user->accommodation_time_factor(1) unless defined $user->accommodation_time_factor;
+	return $user;
 }
 
 sub countUsers { return scalar shift->listUsers(@_) }


### PR DESCRIPTION
The `gen_new` method is not sufficient to create the new method for database tables with default values for columns.  So the `newUser` method needs to be created manually and make sure the default is set.
    
This was reported in issue #2910, and fixes that issue and most likely other places where users are added or updated without explicitly setting the `accomodation_time_factor`.