### PR TITLE
make grades page show true problem number

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -7,7 +7,7 @@ WeBWorK::ContentGenerator::Grades - Display statistics by user.
 
 =cut
 
-use WeBWorK::Utils                    qw(wwRound);
+use WeBWorK::Utils                    qw(wwRound max);
 use WeBWorK::Utils::DateTime          qw(after);
 use WeBWorK::Utils::JITAR             qw(jitar_id_to_seq);
 use WeBWorK::Utils::Sets              qw(grade_set format_set_name_display);
@@ -181,21 +181,21 @@ sub displayStudentStats ($c, $studentID) {
 	my $courseTotalRight = 0;
 
 	for my $setID (@allSetIDs) {
-		my $set = $db->getGlobalSet($setID);
-		my $num_of_problems;
-		# For jitar sets we only display grades for top level problems, so we need to count how many there are.
+		my $set            = $db->getGlobalSet($setID);
+		my $max_problem_id = 0;
+		# For jitar sets we only display grades for top level problems, so we need to filter.
 		if ($set && $set->assignment_type() eq 'jitar') {
 			my @problemIDs = $db->listGlobalProblems($setID);
 			for my $problemID (@problemIDs) {
 				my @seq = jitar_id_to_seq($problemID);
-				$num_of_problems++ if ($#seq == 0);
+				$max_problem_id = $seq[0] if ($#seq == 0 && $seq[0] > $max_problem_id);
 			}
 		} else {
-			# For other sets we just count the number of problems.
-			$num_of_problems = $db->countGlobalProblems($setID);
+			# For other sets we just get the largest problem ID.
+			$max_problem_id = max($db->listGlobalProblems($setID));
 		}
 		$max_problems =
-			$set && after($set->open_date) && $max_problems < $num_of_problems ? $num_of_problems : $max_problems;
+			$set && after($set->open_date) && $max_problems < $max_problem_id ? $max_problem_id : $max_problems;
 	}
 
 	# Variables to help compute gateway scores.
@@ -320,9 +320,23 @@ sub displayStudentStats ($c, $studentID) {
 			$show_problem_scores = 0;
 		}
 
+		my @skipped;
 		for my $i (0 .. $max_problems - 1) {
 			my $score      = defined $problem_scores->[$i] && $show_problem_scores ? $problem_scores->[$i] : '';
 			my $is_correct = $score =~ /^\d+$/ && compute_unreduced_score($ce, $problem_records->[$i], $set) == 1;
+			my $j;
+			if ($setIsVersioned) {
+				$j = $i;
+			} else {
+				$j = $problem_records->[$i]{problem_id} // 0;
+				if ($set && $set->assignment_type() eq 'jitar') {
+					my @seq = jitar_id_to_seq($j);
+					$j = $#seq == 0 ? $seq[0] : 0;
+				}
+				my @new_skipped = ($i + 1 .. $j - 1 - scalar @skipped);
+				push(@skipped,          @new_skipped);
+				push(@html_prob_scores, ($c->tag('td', class => 'problem-data')) x scalar @new_skipped);
+			}
 			push(
 				@html_prob_scores,
 				$c->tag(
@@ -341,6 +355,7 @@ sub displayStudentStats ($c, $studentID) {
 					)->join('')
 				)
 			);
+			last if ($i + scalar @skipped == $max_problems - 1);
 		}
 
 		# Get percentage correct.


### PR DESCRIPTION
Suppose there is an assignment with exercises that were originally numbered 1-10. Then an instructor deleted numbers 2 and 7, and did not renumber the problems in the assignment. Prior to the change here, the grades page shows scores for "number 1" through "number 8". But of course, "number 8" is labeled "number 10" when the student visits the set, and so on.

So this change makes it so that in the Grades page, the score for "number 10" is under the 10 column, and so on. In columns 2 and 7, there will be an empty cell.

So it will be with regular sets and jitar sets. But this PR should not change anything with tests. For those, it's too complicated to try to change the current behavior because of how exercises can be presented in a random order. I'm not even sure that other things don't break if an instructor deletes an exercise from a test template or test version. If someone thinks this should happen with tests as well, I will need help making that happen.

This is a preliminary PR so that later, I can make the cells link to the problem number in question.

