### PR TITLE
Remove student statistics.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Index.pm
@@ -80,13 +80,6 @@ sub pre_header_initialize ($c) {
 		} else {
 			push @error, E_ONE_SET;
 		}
-	} elsif (defined $c->param('user_stats')) {
-		if ($nusers == 1) {
-			$route = 'instructor_user_statistics';
-			$args{userID} = $firstUserID;
-		} else {
-			push @error, E_ONE_USER;
-		}
 	} elsif (defined $c->param('set_stats')) {
 		if ($nsets == 1) {
 			$route = 'instructor_set_statistics';

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -43,9 +43,7 @@ sub initialize ($c) {
 		)
 	];
 
-	if ($c->current_route eq 'instructor_user_statistics') {
-		$c->{studentID} = $c->stash('userID');
-	} elsif ($c->current_route =~ /^instructor_(set|problem)_statistics$/) {
+	if ($c->current_route =~ /^instructor_(set|problem)_statistics$/) {
 		my $setRecord = $db->getGlobalSet($c->stash('setID'));
 		return unless $setRecord;
 		$c->{setRecord} = $setRecord;
@@ -67,9 +65,7 @@ sub page_title ($c) {
 
 	my $setID = $c->stash('setID') || '';
 
-	if ($c->current_route eq 'instructor_user_statistics') {
-		return $c->maketext('Statistics for student [_1]', $c->{studentID});
-	} elsif ($c->current_route eq 'instructor_set_statistics') {
+	if ($c->current_route eq 'instructor_set_statistics') {
 		return $c->maketext('Statistics for [_1]', $c->tag('span', dir => 'ltr', format_set_name_display($setID)));
 	} elsif ($c->current_route eq 'instructor_problem_statistics') {
 		return $c->maketext(
@@ -79,7 +75,7 @@ sub page_title ($c) {
 		);
 	}
 
-	return $c->maketext('Statistics');
+	return $c->maketext('Set Statistics');
 }
 
 sub siblings ($c) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -22,27 +22,6 @@ sub initialize ($c) {
 	# Check permissions
 	return unless $c->authz->hasPermissions($user, 'access_instructor_tools');
 
-	# Cache a list of all users except set level proctors and practice users, and restrict to the sections or
-	# recitations that are allowed for the user if such restrictions are defined.  This list is sorted by last_name,
-	# then first_name, then user_id.  This is used in multiple places in this module, and is guaranteed to be used at
-	# least once.  So it is done here to prevent extra database access.
-	$c->{student_records} = [
-		$db->getUsersWhere(
-			{
-				user_id => [ -and => { not_like => 'set_id:%' }, { not_like => "$ce->{practiceUserPrefix}\%" } ],
-				$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
-				? (
-					-or => [
-						$ce->{viewable_sections}{$user}    ? (section    => $ce->{viewable_sections}{$user})    : (),
-						$ce->{viewable_recitations}{$user} ? (recitation => $ce->{viewable_recitations}{$user}) : ()
-					]
-					)
-				: ()
-			},
-			[qw/last_name first_name user_id/]
-		)
-	];
-
 	if ($c->current_route =~ /^instructor_(set|problem)_statistics$/) {
 		my $setRecord = $db->getGlobalSet($c->stash('setID'));
 		return unless $setRecord;
@@ -55,6 +34,30 @@ sub initialize ($c) {
 			return unless $problemRecord;
 			$c->{problemRecord} = $problemRecord;
 		}
+
+		# Cache a list of all users except set level proctors and practice users, and restrict to the sections
+		# or recitations that are allowed for the user if such restrictions are defined.  This list is sorted by
+		# last_name, then first_name, then user_id.  This is used in multiple places in this module, and is used
+		# on every page except the main page, so it is done here to prevent extra database access.
+		$c->{student_records} = [
+			$db->getUsersWhere(
+				{
+					user_id =>
+						[ -and => { not_like => 'set_id:%' }, { not_like => "$ce->{practiceUserPrefix}\%" } ],
+					$ce->{viewable_sections}{$user} || $ce->{viewable_recitations}{$user}
+					? (
+						-or => [
+							$ce->{viewable_sections}{$user} ? (section => $ce->{viewable_sections}{$user}) : (),
+							$ce->{viewable_recitations}{$user}
+							? (recitation => $ce->{viewable_recitations}{$user})
+							: ()
+						]
+						)
+					: ()
+				},
+				[qw/last_name first_name user_id/]
+			)
+		];
 	}
 
 	return;
@@ -79,8 +82,7 @@ sub page_title ($c) {
 }
 
 sub siblings ($c) {
-	# Stats and StudentProgress share this template.
-	return $c->include('ContentGenerator/Instructor/Stats/siblings', header => $c->maketext('Statistics'));
+	return $c->include('ContentGenerator/Instructor/Stats/siblings');
 }
 
 # Apply the currently selected filter to the student records, and return a reference to the

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -68,8 +68,7 @@ sub page_title ($c) {
 }
 
 sub siblings ($c) {
-	# Stats and StudentProgress share this template.
-	return $c->include('ContentGenerator/Instructor/Stats/siblings', header => $c->maketext('Student Progress'));
+	return $c->include('ContentGenerator/Instructor/StudentProgress/siblings');
 }
 
 # Display student progress table

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -87,7 +87,6 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
  instructor_statistics               /$courseID/instructor/stats
  instructor_set_statistics           /$courseID/instructor/stats/set/$setID
  instructor_problem_statistics       /$courseID/instructor/stats/set/$setID/$problemID
- instructor_user_statistics          /$courseID/instructor/stats/student/$userID
 
  instructor_progress                 /$courseID/instructor/progress
  instructor_set_progress             /$courseID/instructor/progress/set/$setID
@@ -491,7 +490,7 @@ my %routeParameters = (
 	},
 	instructor_statistics => {
 		title    => x('Statistics'),
-		children => [qw(instructor_set_statistics instructor_user_statistics)],
+		children => [qw(instructor_set_statistics)],
 		module   => 'Instructor::Stats',
 		path     => '/stats'
 	},
@@ -505,11 +504,6 @@ my %routeParameters = (
 		title  => '[_3]',
 		module => 'Instructor::Stats',
 		path   => '/<problemID:num>'
-	},
-	instructor_user_statistics => {
-		title  => '[_1]',
-		module => 'Instructor::Stats',
-		path   => '/student/#userID'
 	},
 	instructor_progress => {
 		title    => x('Student Progress'),

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -221,31 +221,8 @@
 			% # Statistics
 			<li class="list-group-item nav-item">
 				<%= $makelink->('instructor_statistics') %>
-				% if ($userID ne $eUserID || defined $setID || defined $urlUserID) {
-				<ul class="nav flex-column">
-					% if (defined $urlUserID) {
-						<li class="nav-item">
-							<%= $makelink->(
-								'instructor_user_statistics',
-								text     => $urlUserID,
-								captures => { userID => $urlUserID },
-								link_attrs => { dir => 'ltr' }
-							) %>
-						</li>
-					% }
-					% if ($userID ne $eUserID && (!defined $urlUserID || $urlUserID ne $eUserID)) {
-						<li class="nav-item">
-							<%=	$makelink->(
-								'instructor_user_statistics',
-								text     => $eUserID,
-								captures => { userID => $eUserID },
-								active   => current_route eq 'instructor_user_statistics'
-									&& !defined $urlUserID,
-								link_attrs => { dir => 'ltr' }
-							) %>
-						</li>
-					% }
-					% if (defined $setID) {
+				% if (defined $setID) {
+					<ul class="nav flex-column">
 						<li class="nav-item" dir="ltr">
 							<%= $makelink->(
 								'instructor_set_statistics',
@@ -270,8 +247,7 @@
 								</ul>
 							</li>
 						% }
-					% }
-				</ul>
+					</ul>
 				% }
 			</li>
 			% # Student Progress

--- a/templates/ContentGenerator/Instructor/Stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats.html.ep
@@ -1,20 +1,22 @@
 % use WeBWorK::Utils qw(getAssetURL);
+% use WeBWorK::Utils::Sets qw(format_set_name_display);
 %
 % unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
 	<div class="alert alert-danger p-1"><%= maketext('You are not authorized to access instructor tools') %></div>
 	% last;
 % }
 %
-% if (current_route eq 'instructor_user_statistics') {
-	% # Stats and StudentProgress share this template.
-	<%= include 'ContentGenerator/Instructor/Stats/student_stats' =%>
-% } elsif (current_route eq 'instructor_set_statistics') {
+% if (current_route eq 'instructor_set_statistics') {
 	<%= $c->set_stats =%>
 % } elsif (current_route eq 'instructor_problem_statistics') {
 	<%= $c->problem_stats =%>
 % } else {
-	% # Stats and StudentProgress share this template also.
-	<%= include 'ContentGenerator/Instructor/Stats/index',
-		set_header     => maketext('View statistics by set'),
-		student_header => maketext('View statistics by student') =%>
+	<ul dir="ltr">
+		% for ($db->listGlobalSetsWhere({}, 'set_id')) {
+			<li>
+				<%= link_to format_set_name_display($_->[0]) =>
+					$c->systemLink(url_for("instructor_set_statistics", setID => $_->[0])) =%>
+			</li>
+		% }
+	</ul>
 % }

--- a/templates/ContentGenerator/Instructor/Stats/siblings.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/siblings.html.ep
@@ -1,6 +1,3 @@
-% # Note that this template is used by both WeBWorK::ContentGenerator::Instructor::Stats and
-% # WeBWorK::ContentGenerator::Instructor::StudentProgress.
-%
 % use WeBWorK::Utils::JITAR qw(jitar_id_to_seq);
 % use WeBWorK::Utils::Sets qw(format_set_name_display);
 %
@@ -9,24 +6,8 @@
 % }
 %
 <div class="info-box bg-light">
-	<h2><%= $header %></h2>
-	% if (current_route =~ /^instructor_user_/) {
-		<ul class="nav flex-column problem-list">
-			% for (@{ $c->{student_records} }) {
-				<li class="nav-item">
-					<%= tag 'a',
-						$_->user_id eq $c->{studentID}
-						? (class => 'nav-link active')
-						: (
-							href => $c->systemLink(url_for(current_route, userID => $_->user_id)),
-							class => 'nav-link'
-						), begin =%>
-						<%= $_->last_name =%>, <%= $_->first_name %> (<%= $_->user_id %>)
-					<% end =%>
-				</li>
-			% }
-		</ul>
-	% } elsif (current_route eq 'instructor_problem_statistics') {
+	<h2><%= maketext('Statistics') %></h2>
+	% if (current_route eq 'instructor_problem_statistics') {
 		<ul class="nav flex-column problem-list">
 			% for (map { $_->[1] } $db->listGlobalProblemsWhere({ set_id => stash->{setID} }, 'problem_id')) {
 				<li class="nav-item">
@@ -46,22 +27,8 @@
 			% }
 		</ul>
 	% } else {
-		<ul class="nav flex-column problem-list" dir="ltr">
-			% for (map { $_->[0] } $db->listGlobalSetsWhere({}, 'set_id')) {
-				<li class="nav-item">
-					<%= tag 'a',
-						defined stash('setID') && $_ eq stash('setID') ? (class => 'nav-link active')
-						: (
-							href => $c->systemLink(
-								url_for(current_route =~ s/instructor_(progress|statistics)/instructor_set_$1/r,
-									setID => $_),
-								params => param('filter') ? { filter => param('filter') } : {}
-							),
-							class => 'nav-link'
-						),
-						format_set_name_display($_) =%>
-				</li>
-			% }
-		</ul>
+		% # Shared with StudentProgress siblings.
+		<%= include 'ContentGenerator/Instructor/Stats/siblings_set_list',
+			set_link_route => 'instructor_set_statistics' =%>
 	% }
 </div>

--- a/templates/ContentGenerator/Instructor/Stats/siblings_set_list.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/siblings_set_list.html.ep
@@ -1,0 +1,18 @@
+% # This is shared between Stats and StudentProgress siblings page to list all sets.
+%
+<ul class="nav flex-column problem-list" dir="ltr">
+	% for (map { $_->[0] } $db->listGlobalSetsWhere({}, 'set_id')) {
+		<li class="nav-item">
+			<%= tag 'a',
+				defined stash('setID') && $_ eq stash('setID') ? (class => 'nav-link active')
+				: (
+					href => $c->systemLink(
+						url_for($set_link_route, setID => $_),
+						params => param('filter') ? { filter => param('filter') } : {}
+					),
+					class => 'nav-link'
+				),
+				format_set_name_display($_) =%>
+		</li>
+	% }
+</ul>

--- a/templates/ContentGenerator/Instructor/StudentProgress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress.html.ep
@@ -4,13 +4,9 @@
 % }
 %
 % if (current_route eq 'instructor_user_progress') {
-	% # Stats and StudentProgress share this template.
-	<%= include 'ContentGenerator/Instructor/Stats/student_stats' =%>
+	<%= include 'ContentGenerator/Instructor/StudentProgress/student_progress' =%>
 % } elsif (current_route eq 'instructor_set_progress') {
 	<%= $c->displaySets =%>
 % } else {
-	% # Stats and StudentProgress share this template also.
-	<%= include 'ContentGenerator/Instructor/Stats/index',
-		set_header     => maketext('View student progress by set'),
-		student_header => maketext('View student progress by student') =%>
+	<%= include 'ContentGenerator/Instructor/StudentProgress/index' =%>
 % }

--- a/templates/ContentGenerator/Instructor/StudentProgress/index.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/index.html.ep
@@ -1,9 +1,4 @@
-% # Note that this template is used by both WeBWorK::ContentGenerator::Instructor::Stats and
-% # WeBWorK::ContentGenerator::Instructor::StudentProgress.
-%
 % use WeBWorK::Utils::Sets qw(format_set_name_display);
-%
-% my $type = current_route =~ s/instructor_//r;
 %
 % stash->{footerWidthClass} = 'col-lg-10 col-sm-12';
 %
@@ -11,12 +6,12 @@
 	<div class="col-lg-5 col-sm-6 mb-2">
 		<div class="card h-100">
 			<div class="card-body p-2">
-				<h2 class="card-title text-center fs-3"><%= $set_header %></h2>
+				<h2 class="card-title text-center fs-3"><%= maketext('View student progress by set') %></h2>
 				<ul dir="ltr">
 					% for ($db->listGlobalSetsWhere({}, 'set_id')) {
 						<li>
 							<%= link_to format_set_name_display($_->[0]) =>
-								$c->systemLink(url_for("instructor_set_$type", setID => $_->[0])) =%>
+								$c->systemLink(url_for("instructor_set_progress", setID => $_->[0])) =%>
 						</li>
 					% }
 				</ul>
@@ -26,12 +21,12 @@
 	<div class="col-lg-5 col-sm-6 mb-2">
 		<div class="card h-100">
 			<div class="card-body p-2">
-				<h2 class="card-title text-center fs-3"><%= $student_header %></h2>
+				<h2 class="card-title text-center fs-3"><%= maketext('View student progress by student') %></h2>
 				<ul>
 					% for (@{ $c->{student_records} }) {
 						<li>
 							<%= link_to $_->last_name . ', ' . $_->first_name . ' (' . $_->user_id . ')' =>
-								$c->systemLink(url_for("instructor_user_$type", userID   => $_->user_id)) =%>
+								$c->systemLink(url_for("instructor_user_progress", userID   => $_->user_id)) =%>
 						</li>
 					% }
 				</ul>

--- a/templates/ContentGenerator/Instructor/StudentProgress/siblings.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/siblings.html.ep
@@ -1,0 +1,30 @@
+% use WeBWorK::Utils::Sets qw(format_set_name_display);
+%
+% unless ($authz->hasPermissions(param('user'), 'access_instructor_tools')) {
+	% last;
+% }
+%
+<div class="info-box bg-light">
+	<h2><%= maketext('Student Progress') %></h2>
+	% if (current_route eq 'instructor_user_progress') {
+		<ul class="nav flex-column problem-list">
+			% for (@{ $c->{student_records} }) {
+				<li class="nav-item">
+					<%= tag 'a',
+						$_->user_id eq $c->{studentID}
+						? (class => 'nav-link active')
+						: (
+							href => $c->systemLink(url_for(current_route, userID => $_->user_id)),
+							class => 'nav-link'
+						), begin =%>
+						<%= $_->last_name =%>, <%= $_->first_name %> (<%= $_->user_id %>)
+					<% end =%>
+				</li>
+			% }
+		</ul>
+	% } else {
+		% # Shared with Stats siblings.
+		<%= include 'ContentGenerator/Instructor/Stats/siblings_set_list',
+			set_link_route => 'instructor_set_progress' =%>
+	% }
+</div>

--- a/templates/ContentGenerator/Instructor/StudentProgress/student_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/student_progress.html.ep
@@ -1,6 +1,3 @@
-% # Note that this template is used by both WeBWorK::ContentGenerator::Instructor::Stats and
-% # WeBWorK::ContentGenerator::Instructor::StudentProgress.
-%
 % use WeBWorK::ContentGenerator::Grades;
 %
 % my $studentRecord = $db->getUser($c->{studentID});

--- a/templates/HelpFiles/InstructorStats.html.ep
+++ b/templates/HelpFiles/InstructorStats.html.ep
@@ -1,14 +1,9 @@
 % layout 'help_macro';
 % title maketext('Statistics Help');
 %
-<p>
-	<%= maketext('The main page allows access to set and student statistics.  When selecting a student, their grades '
-		. 'page is shown, which lists set totals and per problem grades for each set assigned to the student.  When '
-		. 'selecting a set, various statistics and histograms are shown for the overall grades of students who are '
-		. 'currently enrolled or auditing the course.') =%>
-</p>
 <p class="mb-0">
-	<%= maketext('When viewing set statistics, the drop down menus can be used to show stats for individual sections, '
-		. 'recitations, or problems.  The overall results include all students who are assigned to the set, while the '
-		. 'individual problem results only include active (have attempted the problem) students.') =%>
+	<%= maketext('Display full set or problem statistics.  The main page lists all sets to view. When viewing '
+		. 'set statistics, the drop down menus can be used to show stats for individual sections, recitations, or '
+		. 'problems.  The overall results include all students who are assigned to the set, while the individual '
+		. 'problem results only include active (have attempted the problem) students.') =%>
 </p>


### PR DESCRIPTION
The student statistics and student progress page are identical. Remove the student statistics version of the page, since the page doesn't provide any summary of the data, and only shows a student's number of attempts and grade.