### PR TITLE
Upgrade MathJax to 4.1.1.

### DIFF
--- a/htdocs/js/MathJaxConfig/bs-color-scheme.js
+++ b/htdocs/js/MathJaxConfig/bs-color-scheme.js
@@ -13,15 +13,6 @@ for (const [immediate, extension, ready] of [
 		() => {
 			const { DraggableDialog } = MathJax._.ui.dialog.DraggableDialog;
 			switchToBSStyle(DraggableDialog.styles);
-
-			// This is a workaround for a bug in MathJax 4.1.0.  Delete this for the next version of MathJax.
-			// See https://github.com/mathjax/MathJax-src/pull/1414.
-			DraggableDialog.styles["[data-bs-theme='dark']"]['.mjx-dialog a[href]'] =
-				DraggableDialog.styles["[data-bs-theme='dark']"]['a[href]'];
-			delete DraggableDialog.styles["[data-bs-theme='dark']"]['a[href]'];
-			DraggableDialog.styles["[data-bs-theme='dark']"]['.mjx-dialog a[href]:visited'] =
-				DraggableDialog.styles["[data-bs-theme='dark']"]['a[href]:visited'];
-			delete DraggableDialog.styles["[data-bs-theme='dark']"]['a[href]:visited'];
 		}
 	],
 	[

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -15,7 +15,7 @@
 				"jquery": "^3.7.1",
 				"jquery-ui-dist": "^1.13.3",
 				"luxon": "^3.7.1",
-				"mathjax": "^4.1.0",
+				"mathjax": "^4.1.1",
 				"minisearch": "^7.1.2",
 				"shortcut-buttons-flatpickr": "^0.4.0",
 				"sortablejs": "^1.15.6"
@@ -37,7 +37,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
 			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -50,7 +49,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
 			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.4.0",
@@ -122,7 +120,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
 			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -148,7 +145,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
 			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
@@ -160,7 +156,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -182,7 +177,6 @@
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
 			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -271,7 +265,6 @@
 			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
 			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"@lezer/common": "^1.3.0"
 			}
@@ -325,9 +318,10 @@
 			"license": "MIT"
 		},
 		"node_modules/@mathjax/mathjax-newcm-font": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.0.tgz",
-			"integrity": "sha512-n10AwYubUa2hyOzxSRzkwRrgCVns083zkentryXICMPKaWT/watfvK2sUk5D9Bow9mpDfoqb5EWApuUvqnlzaw=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.1.tgz",
+			"integrity": "sha512-LeV5AWzoR7k/k2tg5mW0Ad3Jr9oK9guW/zBUIP8aoiIZcZIhvAV9dlbtUSqSe1wgEBUP1KOcJXcrE/NxOqkxlQ==",
+			"license": "Apache-2.0"
 		},
 		"node_modules/@openwebwork/codemirror-lang-pg": {
 			"version": "0.0.4",
@@ -851,7 +845,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001726",
 				"electron-to-chromium": "^1.5.173",
@@ -1557,11 +1550,12 @@
 			}
 		},
 		"node_modules/mathjax": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.0.tgz",
-			"integrity": "sha512-53eDXzxk40pS2sdI6KDCPoreY95ADaGygbi41ExKmn3FYQ+QIdpquIU90eppecelzQjf74kpScyeplVPccnIJw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.1.tgz",
+			"integrity": "sha512-NyvA8c39LUUM/m+oCg7sfA13hmw7yGkre5kiRWN9qzChCyhce39lecnbjgMA/oEUgq9Vyetk6u78apwcIXpW/A==",
+			"license": "Apache-2.0",
 			"dependencies": {
-				"@mathjax/mathjax-newcm-font": "^4.1.0"
+				"@mathjax/mathjax-newcm-font": "^4.1.1"
 			}
 		},
 		"node_modules/mdn-data": {
@@ -1690,7 +1684,6 @@
 				}
 			],
 			"license": "MIT",
-			"peer": true,
 			"dependencies": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",
@@ -2532,7 +2525,6 @@
 			"version": "6.20.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
 			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
-			"peer": true,
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2544,7 +2536,6 @@
 			"version": "6.10.0",
 			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
 			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
-			"peer": true,
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.4.0",
@@ -2611,7 +2602,6 @@
 			"version": "6.11.3",
 			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
 			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
-			"peer": true,
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
@@ -2635,7 +2625,6 @@
 			"version": "6.5.11",
 			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
 			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
-			"peer": true,
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.0.0",
@@ -2646,7 +2635,6 @@
 			"version": "6.5.2",
 			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
 			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
-			"peer": true,
 			"requires": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -2666,7 +2654,6 @@
 			"version": "6.38.8",
 			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
 			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
-			"peer": true,
 			"requires": {
 				"@codemirror/state": "^6.5.0",
 				"crelt": "^1.0.6",
@@ -2740,7 +2727,6 @@
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
 			"integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
-			"peer": true,
 			"requires": {
 				"@lezer/common": "^1.3.0"
 			}
@@ -2789,9 +2775,9 @@
 			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="
 		},
 		"@mathjax/mathjax-newcm-font": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.0.tgz",
-			"integrity": "sha512-n10AwYubUa2hyOzxSRzkwRrgCVns083zkentryXICMPKaWT/watfvK2sUk5D9Bow9mpDfoqb5EWApuUvqnlzaw=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.1.tgz",
+			"integrity": "sha512-LeV5AWzoR7k/k2tg5mW0Ad3Jr9oK9guW/zBUIP8aoiIZcZIhvAV9dlbtUSqSe1wgEBUP1KOcJXcrE/NxOqkxlQ=="
 		},
 		"@openwebwork/codemirror-lang-pg": {
 			"version": "0.0.4",
@@ -3023,7 +3009,6 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.1.tgz",
 			"integrity": "sha512-KGj0KoOMXLpSNkkEI6Z6mShmQy0bc1I+T7K9N81k4WWMrfz+6fQ6es80B/YLAeRoKvjYE1YSHHOW1qe9xIVzHw==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001726",
 				"electron-to-chromium": "^1.5.173",
@@ -3474,11 +3459,11 @@
 			"integrity": "sha512-RkRWjA926cTvz5rAb1BqyWkKbbjzCGchDUIKMCUvNi17j6f6j8uHGDV82Aqcqtzd+icoYpELmG3ksgGiFNNcNg=="
 		},
 		"mathjax": {
-			"version": "4.1.0",
-			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.0.tgz",
-			"integrity": "sha512-53eDXzxk40pS2sdI6KDCPoreY95ADaGygbi41ExKmn3FYQ+QIdpquIU90eppecelzQjf74kpScyeplVPccnIJw==",
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.1.tgz",
+			"integrity": "sha512-NyvA8c39LUUM/m+oCg7sfA13hmw7yGkre5kiRWN9qzChCyhce39lecnbjgMA/oEUgq9Vyetk6u78apwcIXpW/A==",
 			"requires": {
-				"@mathjax/mathjax-newcm-font": "^4.1.0"
+				"@mathjax/mathjax-newcm-font": "^4.1.1"
 			}
 		},
 		"mdn-data": {
@@ -3555,7 +3540,6 @@
 			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
 			"integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
 			"dev": true,
-			"peer": true,
 			"requires": {
 				"nanoid": "^3.3.11",
 				"picocolors": "^1.1.1",

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -21,7 +21,7 @@
 		"jquery": "^3.7.1",
 		"jquery-ui-dist": "^1.13.3",
 		"luxon": "^3.7.1",
-		"mathjax": "^4.1.0",
+		"mathjax": "^4.1.1",
 		"minisearch": "^7.1.2",
 		"shortcut-buttons-flatpickr": "^0.4.0",
 		"sortablejs": "^1.15.6"


### PR DESCRIPTION
The issue with link styles has been fixed, and the workaround in the `js/MathJaxConfig/bs-color-scheme.js` file removed.

The other issue with the `--mjx-bg-alpha` versus `--mjx-bg1-alpha` variable has not been fixed.  This should probably be brought to the attention of @dpvc.