### PR TITLE
Preserve the entered answer when the "Show Correct Answers" button is used.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -553,7 +553,7 @@ async sub pre_header_initialize ($c) {
 		$c->{set}->psvn,
 		$prEnabled
 			&& !$problem->{prCount}
-			&& !($c->{submitAnswers} || $previewAnswers || $checkAnswers) ? {} : $formFields,
+			&& !($c->{submitAnswers} || $previewAnswers || $checkAnswers || $showOnlyCorrectAnswers) ? {} : $formFields,
 		{
 			displayMode              => $displayMode,
 			showHints                => $will{showHints},


### PR DESCRIPTION
This is a case that was missed in #2855.  At this point on the develop branch when the "Show Correct Answers" button is used, the form fields are not submitted to PG, and so the answer disappears. This is perhaps a minor issue as this is not the answer saved in the database, but just the answer entered at the time the "Show Correct Answers" button is used which won't be saved to the database anyway.  However, it is a change in behavior. So this pull request just restores that prior behavior.

Note that if there is an answer saved in the database, then that will replace what is submitted when the "Show Correct Answers" button is used anyway.  That is how it was before, and that is the same with this.