### PR TITLE
Show set description on ProblemSet page.

### DIFF
--- a/templates/ContentGenerator/ProblemSet.html.ep
+++ b/templates/ContentGenerator/ProblemSet.html.ep
@@ -26,6 +26,11 @@
 %
 % my $set = $c->{set};
 %
+% # Show the set description if it is not empty.
+% if ($set->description =~ /\S/) {
+	<div class="alert alert-secondary"><%= $set->description %></div>
+% }
+%
 % # Stats message displays the current status of the set and states the next important date.
 <%= include 'ContentGenerator/Base/set_status', set => $set =%>
 %


### PR DESCRIPTION
This adds the set description to the ProblemSet page as discussed in #2919.

There were suggestions for a configuration option or a reveal button. In most cases I suspect the description would be short, so I just went with showing it if it is not empty. The description also cannot include any html or formatting. It will just be inserted into a single div.