### PR TITLE
PGProblemEditor: Add option to copy auxiliary files.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -704,14 +704,15 @@ sub saveFileChanges ($c, $outputFilePath, $backup = 0) {
 	}
 
 	# If the file is being saved as a new file in a new location, and the file is accompanied by auxiliary files
-	# transfer them as well.  If the file is a pg file, then assume there are auxiliary files.  Copy all files not
-	# ending in .pg from the original directory to the new one.
-	if ($c->{action} eq 'save_as' && $outputFilePath =~ /\.pg/) {
+	# transfer them as well.  If the option 'copyAuxFiles' is set and the file is a pg file, then assume there are
+	# auxiliary files.  Copy all files not ending in .pg from the original directory to the new one.
+	if ($c->{action} eq 'save_as' && $c->param('copyAuxFiles') && $outputFilePath =~ /\.pg/) {
 		my $sourceDirectory = Mojo::File->new(($c->{sourceFilePath} || '') =~ s|/[^/]+\.pg$||r);
 		my $outputDirectory = Mojo::File->new($outputFilePath              =~ s|/[^/]+\.pg$||r);
 
 		# Only perform the copy if the output directory is an actual new location.
 		if ($sourceDirectory ne $outputDirectory && -d $sourceDirectory) {
+			my $filesCopied = 0;
 			for my $file (@{ $sourceDirectory->list }) {
 				# The .pg file being edited has already been transferred. Ignore any others in the directory.
 				next if $file =~ /\.pg$/;
@@ -719,13 +720,18 @@ sub saveFileChanges ($c, $outputFilePath, $backup = 0) {
 				# Only copy regular files that are readable and that have not already been copied.
 				if (-f $file && -r $file && !-e $toPath) {
 					eval { $file->copy_to($toPath) };
-					$c->addbadmessage($c->maketext('Error copying [_1] to [_2].', $file, $toPath)) if $@;
+					if ($@) {
+						$c->addbadmessage($c->maketext('Error copying [_1] to [_2].', $file, $toPath));
+					} else {
+						$filesCopied = 1;
+					}
 				}
 			}
 			$c->addgoodmessage($c->maketext(
 				'Copied auxiliary files from [_1] to new location at [_2].',
 				$sourceDirectory, $outputDirectory
-			));
+			))
+				if $filesCopied;
 		}
 	}
 

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
@@ -52,6 +52,12 @@
 		<%= hidden_field 'action.save_as.source_file' => $c->{editFilePath} =%>
 		<%= hidden_field 'action.save_as.file_type' => $c->{file_type} =%>
 	</div>
+	<div class="form-check">
+		% param('copyAuxFiles', 1) unless defined param('copyAuxFiles');
+		<%= check_box copyAuxFiles => 1, id => 'copyAuxFiles', class => 'form-check-input' =%>
+		<%= hidden_field copyAuxFiles => 0 =%>
+		<%= label_for copyAuxFiles => maketext('Copy auxiliary files.'), class => 'form-check-label' =%>
+	</div>
 	% if ($can_add_problem_to_set) {
 		<div class="form-check">
 			<%= radio_button 'action.save_as.saveMode' => 'rename', id => 'action_save_as_saveMode_rename_id',

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -180,6 +180,11 @@
 				. 'attached to a problem set.') =%>
 		</p>
 		<p>
+			<%= maketext('When saving the problem in a new location (directory), by default all auxiliary files, such '
+				. 'as images, or other files that do not end in ".pg", will also be copied to the new location.  To '
+				. 'stop this behavior, uncheck the "Copy auxiliary files" option.') =%>
+		</p>
+		<p>
 			<%= maketext('You may want to create an unattached problem if you are using the current problem as a model '
 				. 'for a new problem. You can add the new file to a homework set from the Library Browser or via the '
 				. 'set detail page of the "Sets Manager".') =%>


### PR DESCRIPTION
When saving a problem in a new location in the PGProblemEditor, add an option to copy auxiliary files or not. Since it is not possible to determine what files are needed, all auxiliary files were copied in all cases. This allows the user to uncheck the "Copy auxiliary files" option to not copy any auxiliary files.

The default option is to copy auxiliary files which has not changed. This only allows the user to disable that if they are sure no auxiliary files are needed.

This also adds a check so the message about auxiliary files being copied only shows if at least one file was copied.

@drgrice1 I am unable to figure out how to keep this new option to stay unchecked once a user unchecks it. I used the same setup the "Create backup" option uses with a hidden field, but when I uncheck this new option, and save the file, the page checks it by default again. So I'm unsure what is going on in that case.