### PR TITLE
ProblemSets: Place set description in info button.

### DIFF
--- a/htdocs/js/System/system.js
+++ b/htdocs/js/System/system.js
@@ -74,7 +74,8 @@
 	// FIXME: These are really general purpose tooltips and not just in the homework sets editor.  So the class name
 	// should be chosen to better reflect this.
 	document.querySelectorAll('.set-id-tooltip').forEach((el) => {
-		if (el.dataset.bsTitle) new bootstrap.Tooltip(el, { fallbackPlacements: [] });
+		if (el.dataset.bsTitle)
+			new bootstrap.Tooltip(el, { fallbackPlacements: el.dataset.fallbackPlacements?.split(' ') || [] });
 	});
 
 	// Hardcopy tooltips shown on the Problem Sets page.

--- a/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
+++ b/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
@@ -17,9 +17,16 @@
 	<div class="ms-3 me-auto">
 		<div dir="ltr">
 			<%= link_to $display_name => $c->systemLink(url_for('problem_list', setID => $set->set_id)),
-				class => 'fw-bold set-id-tooltip',
-				data  => { bs_toggle => 'tooltip', bs_placement => 'right', bs_title => $set->description }
+				class => 'fw-bold'
 			=%>
+			% if ($set->description =~ /\S/) {
+				<a class="set-id-tooltip" role="button" tabindex="0" data-bs-placement="right"
+						data-bs-toggle="tooltip" data-bs-title="<%= $set->description =%>"
+						data-fallback-placements="top bottom">
+					<i class="icon fas fa-circle-info" aria-hidden="true"></i>
+					<span class="visually-hidden"><%= maketext('Assignment Description') =%></span>
+				</a>
+			% }
 		</div>
 		<div class="font-sm"><%= $status_msg %></div>
 		% if (!$set->visible && $authz->hasPermissions(param('user'), 'view_unopened_sets')) {


### PR DESCRIPTION
Move the set description from a tooltip on the link to the set to a tooltip on an info button located just right of the set link if the set description is not empty.

This adds an additional option to the `set-id-tooltip` class JavaScript that if `data-fallback-placements` is set as a spaced separated list, that list will be passed to the bootstrap Tooltip on creation.

This was suggested by @dlglin.