### PR TITLE
License clarification.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -13,19 +13,19 @@
         Software Foundation; either version 2, or (at your option)
         any later version, or
 
-        b) the "Artistic License" which comes with this package.
+        b) the "Artistic License" 1.0 which comes with this package.
 
     This program is distributed in the hope that it will be useful,
     but WITHOUT ANY WARRANTY; without even the implied warranty of
     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See either
     the GNU General Public License or the Artistic License for more details.
 
-    You should have received a copy of the Artistic License with this
-    package, in the file named "Artistic" inside the `doc` folder.  If not, we'll be glad to provide
-    one.
+    You should have received a copy of the Artistic License 1.0 with this
+    package, in the file named "Artistic" inside the `doc` folder.  If not,
+    you can find a copy at https://github.com/openwebwork/webwork2/blob/main/doc/Artistic
+    or https://perlfoundation.org/artistic-license-10.html.
 
     You should also have received a copy of the GNU General Public License
-    along with this program in the file named "Copying" inside the `doc` folder. If not, write to the
-    Free Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
-    02111-1307, USA or visit their web page on the internet at
-    http://www.gnu.org/copyleft/gpl.html.
+    along with this program in the file named "Copying" inside the `doc` folder.
+    If not, you can find a copy at https://github.com/openwebwork/webwork2/blob/main/doc/Copying
+    or https://www.gnu.org/licenses/old-licenses/gpl-2.0.html.

--- a/README.md
+++ b/README.md
@@ -1,15 +1,5 @@
 # Welcome to WeBWorK
 
-                                       WeBWorK
-                         Online Homework Delivery System
-                                   Version 2.*
-                        Branch:  github.com/openwebwork
-
-             https://wiki.openwebwork.org/wiki/Release_notes_for_WeBWorK_2.20
-                    Copyright 2000-2025, The WeBWorK Project
-                             https://openwebwork.org/
-                              All rights reserved.
-
 WeBWorK is an open-source online homework system for math and sciences courses. WeBWorK is supported by the MAA and the
 NSF and comes with an Open Problem Library (OPL) of over 30,000 homework problems. Problems in the OPL target most lower
 division undergraduate math courses, some advanced courses and some other STEM subjects. Supported courses include


### PR DESCRIPTION
Remove the copyright/license from README.md.

Clarify that the artistic license is version 1.0 and provide links to the copy on github and the perlfoundation.

Remove the old FSF physical address and provide links to the GPL license on github and a direct link to the gpl version 2 on gnu.org (since the old link resolved to version 3).