### PR TITLE
Change the version of the `bs-color-scheme.js` MathJax extension.

### DIFF
--- a/htdocs/js/MathJaxConfig/bs-color-scheme.js
+++ b/htdocs/js/MathJaxConfig/bs-color-scheme.js
@@ -1,4 +1,4 @@
-if (MathJax.loader) MathJax.loader.checkVersion('[bs-color-scheme]', '4.1.0', 'extension');
+if (MathJax.loader) MathJax.loader.checkVersion('[bs-color-scheme]', '4.1.1', 'extension');
 
 const switchToBSStyle = (obj, key = '@media (prefers-color-scheme: dark)') => {
 	obj["[data-bs-theme='dark']"] = obj[key];


### PR DESCRIPTION
Since we are now on MathJax 4.1.1 and the version specified in the `bs-color-scheme.js` file is 4.1.0, a console warning points out the version mismatch.

We will need to remember to change this every time we upgrade MathJax. Of course the extension will also need to be updated for changes to MathJax.