### PR TITLE
Rework PG error/warning/debug message handling.

### DIFF
--- a/htdocs/js/System/system.scss
+++ b/htdocs/js/System/system.scss
@@ -374,13 +374,6 @@ h1.page-title {
 	line-height: 1.4;
 }
 
-.Warnings {
-	code {
-		white-space: normal;
-		color: inherit;
-	}
-}
-
 .error-output {
 	word-wrap: break-word;
 	color: #d63384;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -813,7 +813,7 @@ there are pg errors.
 =cut
 
 sub have_warnings ($c) {
-	return $c->stash('warnings') || $c->{pgerrors};
+	return $c->stash('warnings');
 }
 
 =item exists_theme_file
@@ -1220,8 +1220,8 @@ Used to display a generic warning message at the top of the page
 =cut
 
 sub warningMessage ($c) {
-	return $c->maketext('<strong>Warning</strong>: There may be something wrong with this question. '
-			. 'Please inform your instructor including the warning messages below.');
+	return $c->maketext('<strong>Warning</strong>: WeBWorK has encountered warnings while processing your request. '
+			. 'See the warning messages below for details.');
 }
 
 =item $string = formatDateTime($date_time, $format_string, $timezone, $locale)

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -274,14 +274,15 @@ sub get_instructor_comment ($c, $problem) {
 
 async sub pre_header_initialize ($c) {
 	# Make sure these are defined for the templates.
-	$c->stash->{problems}        = [];
-	$c->stash->{pg_results}      = [];
-	$c->stash->{startProb}       = 0;
-	$c->stash->{endProb}         = 0;
-	$c->stash->{numPages}        = 0;
-	$c->stash->{pageNumber}      = 0;
-	$c->stash->{problem_numbers} = [];
-	$c->stash->{probOrder}       = [];
+	$c->stash->{problems}            = [];
+	$c->stash->{pg_results}          = [];
+	$c->stash->{startProb}           = 0;
+	$c->stash->{endProb}             = 0;
+	$c->stash->{numPages}            = 0;
+	$c->stash->{pageNumber}          = 0;
+	$c->stash->{problem_numbers}     = [];
+	$c->stash->{probOrder}           = [];
+	$c->stash->{haveProblemWarnings} = 0;
 
 	# If authz->checkSet has failed, then this set is invalid.  No need to proceeded.
 	return if $c->{invalidSet};
@@ -1447,11 +1448,6 @@ sub nav ($c, $args) {
 	return '';
 }
 
-sub warningMessage ($c) {
-	return $c->maketext('<strong>Warning</strong>: There may be something wrong with a question in this test. '
-			. 'Please inform your instructor including the warning messages below.');
-}
-
 # Evaluation utility
 # $effectiveUser is the current effective user, $set is the merged set version, $formFields is a reference to the
 # hash of parameters from the input form that need to be passed to the translator, and $mergedProblem
@@ -1510,15 +1506,13 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 		},
 	);
 
-	# Warnings in the renderPG subprocess will not be caught by the global warning handler of this process.
-	# So rewarn them and let the global warning handler take care of it.
-	warn $pg->{warnings} if $pg->{warnings};
-
 	# If the user can check answers and either this is not an answer submission or the problem_data form
 	# parameter was previously set, then set or update the problem_data form parameter.
 	$c->param('problem_data_' . $mergedProblem->problem_id => encode_json($pg->{PERSISTENCE_HASH} || '{}'))
 		if $c->{can}{checkAnswers}
 		&& (!$c->{submitAnswers} || defined $c->param('problem_data_' . $mergedProblem->problem_id));
+
+	$c->stash->{haveProblemWarnings} = 1 if $pg->{warnings} || @{ $pg->{pgwarning} // [] };
 
 	return $pg;
 }

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -594,10 +594,6 @@ async sub pre_header_initialize ($c) {
 		}
 	);
 
-	# Warnings in the renderPG subprocess will not be caught by the global warning handler of this process.
-	# So rewarn them and let the global warning handler take care of it.
-	warn $pg->{warnings} if $pg->{warnings};
-
 	debug('end pg processing');
 
 	$pg->{body_text} .= $c->hidden_field(
@@ -609,20 +605,6 @@ async sub pre_header_initialize ($c) {
 	$can{showHints}     &&= $pg->{flags}{hintExists};
 	$can{showSolutions} &&= $pg->{flags}{solutionExists};
 
-	# Record errors
-	$c->{pgdebug}          = $pg->{debug_messages}          if ref $pg->{debug_messages} eq 'ARRAY';
-	$c->{pgwarning}        = $pg->{warning_messages}        if ref $pg->{warning_messages} eq 'ARRAY';
-	$c->{pginternalerrors} = $pg->{internal_debug_messages} if ref $pg->{internal_debug_messages} eq 'ARRAY';
-	# $c->{pgerrors} is defined if any of the above are defined, and is nonzero if any are non-empty.
-	$c->{pgerrors} = @{ $c->{pgdebug} // [] } || @{ $c->{pgwarning} // [] } || @{ $c->{pginternalerrors} // [] }
-		if defined $c->{pgdebug} || defined $c->{pgwarning} || defined $c->{pginternalerrors};
-
-	# If $c->{pgerrors} is not defined, then the PG messages arrays were not defined,
-	# which means $pg->{pgcore} was not defined and the translator died.
-	warn 'Processing of this PG problem was not completed.  Probably because of a syntax error. '
-		. 'The translator died prematurely and no PG warning messages were transmitted.'
-		unless defined $c->{pgerrors};
-
 	# Store fields
 	$c->{want} = \%want;
 	$c->{can}  = \%can;
@@ -633,53 +615,6 @@ async sub pre_header_initialize ($c) {
 	$c->{scoreRecordedMessage} = await process_and_log_answer($c) || '';
 
 	return;
-}
-
-sub warnings ($c) {
-	my $output = $c->c;
-
-	# Display warning messages
-	if (!defined $c->{pgerrors}) {
-		push(
-			@$output,
-			$c->tag(
-				'div',
-				$c->c(
-					$c->tag('h3', style => 'color:red;', $c->maketext('PG question failed to render')),
-					$c->tag('p',  $c->maketext('Unable to obtain error messages from within the PG question.'))
-				)->join('')
-			)
-		);
-	} elsif ($c->{pgerrors} > 0) {
-		my @pgdebug          = @{ $c->{pgdebug}          // [] };
-		my @pgwarning        = @{ $c->{pgwarning}        // [] };
-		my @pginternalerrors = @{ $c->{pginternalerrors} // [] };
-		push(
-			@$output,
-			$c->tag(
-				'div',
-				$c->c(
-					$c->tag('h2', $c->maketext('PG question processing error messages')),
-					@pgdebug ? $c->c(
-						$c->tag('h3', $c->maketext('PG debug messages')),
-						$c->tag('p',  $c->c(@pgdebug)->join($c->tag('br')))
-					)->join('') : '',
-					@pgwarning ? $c->c(
-						$c->tag('h3', $c->maketext('PG warning messages')),
-						$c->tag('p',  $c->c(@pgwarning)->join($c->tag('br')))
-					)->join('') : '',
-					@pginternalerrors ? $c->c(
-						$c->tag('h3', $c->maketext('PG internal errors')),
-						$c->tag('p',  $c->c(@pginternalerrors)->join($c->tag('br')))
-					)->join('') : ''
-				)->join('')
-			)
-		);
-	}
-
-	push(@$output, $c->SUPER::warnings());
-
-	return $output->join('');
 }
 
 sub head ($c) {
@@ -1042,14 +977,7 @@ sub output_problem_body ($c) {
 		} else {
 			# For students render the body text of the problem with a message about error details.
 			return $c->c(
-				$c->tag(
-					'div',
-					id    => 'output_problem_body',
-					class => 'text-dark',
-					style => 'color-scheme: light',
-					data  => { bs_theme => 'light' },
-					$c->b($c->{pg}{body_text})
-				),
+				$c->tag('div', $c->b($c->{pg}{body_text})),
 				$c->include(
 					'ContentGenerator/Base/error_output',
 					error   => $c->{pg}{errors},
@@ -1534,7 +1462,8 @@ sub output_past_answer_button ($c) {
 				$c->hidden_field(selected_sets     => $c->{problem}->set_id),
 				$c->hidden_field(selected_users    => $c->{problem}->user_id),
 				$c->tag(
-					'p',
+					'div',
+					class => 'mb-3',
 					$c->submit_button(
 						$c->maketext('Show Past Answers'),
 						name  => 'action',

--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -212,29 +212,11 @@ async sub pre_header_initialize ($c) {
 		}
 	);
 
-	# Warnings in the renderPG subprocess will not be caught by the global warning handler of this process.
-	# So rewarn them and let the global warning handler take care of it.
-	warn $pg->{warnings} if $pg->{warnings};
-
 	debug('end pg processing');
 
 	# Update and fix hint/solution options after PG processing
 	$c->{can}{showHints}     &&= $pg->{flags}{hintExists};
 	$c->{can}{showSolutions} &&= $pg->{flags}{solutionExists};
-
-	# Record errors
-	$c->{pgdebug}          = $pg->{debug_messages}          if ref $pg->{debug_messages} eq 'ARRAY';
-	$c->{pgwarning}        = $pg->{warning_messages}        if ref $pg->{warning_messages} eq 'ARRAY';
-	$c->{pginternalerrors} = $pg->{internal_debug_messages} if ref $pg->{internal_debug_messages} eq 'ARRAY';
-	# $c->{pgerrors} is defined if any of the above are defined, and is nonzero if any are non-empty.
-	$c->{pgerrors} = @{ $c->{pgdebug} // [] } || @{ $c->{pgwarning} // [] } || @{ $c->{pginternalerrors} // [] }
-		if defined $c->{pgdebug} || defined $c->{pgwarning} || defined $c->{pginternalerrors};
-
-	# If $c->{pgerrors} is not defined, then the PG messages arrays were not defined,
-	# which means $pg->{pgcore} was not defined and the translator died.
-	warn 'Processing of this PG problem was not completed.  Probably because of a syntax error. '
-		. 'The translator died prematurely and no PG warning messages were transmitted.'
-		unless defined $c->{pgerrors};
 
 	$c->{pg} = $pg;
 

--- a/lib/WeBWorK/Utils/Rendering.pm
+++ b/lib/WeBWorK/Utils/Rendering.pm
@@ -252,10 +252,9 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 		};
 
 		if (ref($pg->{pgcore}) eq 'PGcore') {
-			$ret->{internal_debug_messages} = $pg->{pgcore}->get_internal_debug_messages;
-			$ret->{warning_messages}        = $pg->{pgcore}->get_warning_messages();
-			$ret->{debug_messages}          = $pg->{pgcore}->get_debug_messages();
-			$ret->{PG_ANSWERS_HASH}         = {
+			$ret->{warning_messages} = $pg->{pgcore}->get_warning_messages();
+			$ret->{debug_messages}   = $pg->{pgcore}->get_debug_messages();
+			$ret->{PG_ANSWERS_HASH}  = {
 				map {
 					$_ => {
 						response_obj => unbless($pg->{pgcore}{PG_ANSWERS_HASH}{$_}->response_obj),
@@ -269,6 +268,8 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 					keys %{ $pg->{pgcore}{PG_alias}{resource_list} }
 			};
 			$ret->{PERSISTENCE_HASH} = $pg->{pgcore}{PERSISTENCE_HASH};
+		} else {
+			$ret->{render_fail} = 1;
 		}
 
 		# Save the problem source. This is used by Caliper::Entity. Why?
@@ -277,7 +278,7 @@ sub renderPG ($c, $effectiveUser, $set, $problem, $psvn, $formFields, $translati
 		$pg->free;
 		return $ret;
 	})->catch(sub ($err) {
-		return { body_text => '', answers => {}, flags => { error_flag => 1 }, errors => $err };
+		return { body_text => '', answers => {}, render_fail => 1, flags => { error_flag => 1 }, errors => $err };
 	});
 }
 

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -258,26 +258,23 @@ async sub renderProblem {
 
 	# New version of output:
 	return {
-		text                    => $pg->{body_text},
-		header_text             => $pg->{head_text},
-		post_header_text        => $pg->{post_header_text},
-		answers                 => $pg->{answers},
-		errors                  => $pg->{errors},
-		pg_warnings             => $pg->{warnings},
-		PG_ANSWERS_HASH         => $pg->{PG_ANSWERS_HASH},
-		PERSISTENCE_HASH        => $pg->{PERSISTENCE_HASH},
-		problem_result          => $pg->{result},
-		problem_state           => $pg->{state},
-		flags                   => $pg->{flags},
-		psvn                    => $psvn,
-		problem_seed            => $problemSeed,
-		resource_list           => $pg->{resource_list},
-		warning_messages        => ref $pg->{warning_messages} eq 'ARRAY' ? $pg->{warning_messages} : [],
-		debug_messages          => ref $pg->{debug_messages} eq 'ARRAY'   ? $pg->{debug_messages}   : [],
-		internal_debug_messages => ref $pg->{internal_debug_messages} eq 'ARRAY'
-		? $pg->{internal_debug_messages}
-		: [],
-		compute_time => logTimingInfo($beginTime, Benchmark->new),
+		text             => $pg->{body_text},
+		header_text      => $pg->{head_text},
+		post_header_text => $pg->{post_header_text},
+		answers          => $pg->{answers},
+		errors           => $pg->{errors},
+		pg_warnings      => $pg->{warnings},
+		PG_ANSWERS_HASH  => $pg->{PG_ANSWERS_HASH},
+		PERSISTENCE_HASH => $pg->{PERSISTENCE_HASH},
+		problem_result   => $pg->{result},
+		problem_state    => $pg->{state},
+		flags            => $pg->{flags},
+		psvn             => $psvn,
+		problem_seed     => $problemSeed,
+		resource_list    => $pg->{resource_list},
+		warning_messages => ref $pg->{warning_messages} eq 'ARRAY' ? $pg->{warning_messages} : [],
+		debug_messages   => ref $pg->{debug_messages} eq 'ARRAY'   ? $pg->{debug_messages}   : [],
+		compute_time     => logTimingInfo($beginTime, Benchmark->new),
 	};
 }
 

--- a/templates/ContentGenerator/Base/error_output.html.ep
+++ b/templates/ContentGenerator/Base/error_output.html.ep
@@ -5,9 +5,8 @@
 % }
 <p>
 	<%= maketext(
-		'WeBWorK has encountered a software error while attempting to process this problem. It is likely that '
-		. 'there is an error in the problem itself. If you are a student, report this error message to your '
-		. 'professor to have it corrected. If you are a professor, please consult the error output below for '
+		'WeBWorK has encountered a software error. If you are a student, report this error message to your '
+		. 'instructor to have it corrected. If you are a instructor, please consult the error output below for '
 		. 'more information.'
 		) %>
 </p>

--- a/templates/ContentGenerator/Base/feedback_macro_email.html.ep
+++ b/templates/ContentGenerator/Base/feedback_macro_email.html.ep
@@ -6,6 +6,8 @@
 		% next if $key eq 'pg_object';    # Not used in internal feedback mechanism
 		<%= hidden_field $key => $value =%>
 	% }
-	<%= submit_button maketext($ce->{feedback_button_name}) || maketext('Email instructor'),
-		name => 'feedbackForm', class => 'btn btn-primary' =%>
+	<div class="mb-3">
+		<%= submit_button maketext($ce->{feedback_button_name}) || maketext('Email instructor'),
+			name => 'feedbackForm', class => 'btn btn-primary' =%>
+	</div>
 % end

--- a/templates/ContentGenerator/Base/problem_warning_and_debug_output.html.ep
+++ b/templates/ContentGenerator/Base/problem_warning_and_debug_output.html.ep
@@ -1,0 +1,34 @@
+% if ($warnings) {
+	<div class="row g-0 mb-3">
+		<div class="col-12 alert alert-danger m-0">
+			<h2><%= maketext('PG warning messages') %></h2>
+			<ul class="m-0">
+				% for (split m/\n+/, $warnings) {
+					<li><div><%== $_ %></div></li>
+				% }
+			</ul>
+		</div>
+	</div>
+% }
+% if (@$warning_messages) {
+	<div class="row g-0 mb-3">
+		<div class="col-12 alert alert-danger m-0">
+			<h2><%= maketext('PG processing warning messages') %></h2>
+			<ul class="m-0">
+				% for (@$warning_messages) {
+					<li><div><%== $_ %></div></li>
+				% }
+			</ul>
+		</div>
+	</div>
+% }
+% if (@$debug_messages) {
+	<div class="row g-0 mb-3">
+		<div class="col-12 alert alert-info m-0 overflow-x-auto">
+			<h2><%= maketext('PG debug messages') %></h2>
+			% for (@$debug_messages) {
+				<div class="my-3"><%== $_ %></div>
+			% }
+		</div>
+	</div>
+% }

--- a/templates/ContentGenerator/Base/warning_output.html.ep
+++ b/templates/ContentGenerator/Base/warning_output.html.ep
@@ -3,17 +3,15 @@
 <h2><%= maketext('WeBWorK Warnings') %></h2>
 <p>
 	<%= maketext(
-		'WeBWorK has encountered warnings while processing your request. If this occurred when viewing '
-			. 'a problem, it was likely caused by an error or ambiguity in that problem. Otherwise, it may indicate '
-			. 'a problem with the WeBWorK system itself. If you are a student, report these warnings to your '
-			. 'professor to have them corrected. If you are a professor, please consult the warning output below '
-			. 'for more information.'
+		'WeBWorK has encountered warnings while processing your request. This indicates a problem with the WeBWorK '
+			. 'system. If you are a student, report these warnings to your instructor to have them corrected. If you '
+			. 'are a instructor, please consult the warning output below for more information.'
 	) %>
 </p>
 <h3><%= maketext('Warning messages') %></h3>
 <ul>
 	% for (@$warnings) {
-		<li><code><%= $_ %></code></li>
+		<li><div><%= $_ %></div></li>
 	% }
 </ul>
 <h3><%= maketext('Request information') %></h3>

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -388,6 +388,15 @@
 	% # Problems can be shown, so output the main form and the problems.
 	% my $startTime = param('startTime') || time;
 	%
+	% if ($haveProblemWarnings) {
+		<div class="row g-0">
+			<div class="col-12 alert alert-danger">
+				<%== maketext('<strong>Warning</strong>: There may be something wrong with a problem in this test. '
+					. 'Please inform your instructor including the warning messages below the problem.') =%>
+			</div>
+		</div>
+	% }
+	%
 	<%= form_for $action, name => 'gwquiz', method => 'POST', class => 'problem-main-form mt-0', begin =%>
 		<%= $c->hidden_authen_fields =%>
 		<%= hidden_field courseID => $ce->{courseName} =%>
@@ -649,6 +658,11 @@
 						<%= WeBWorK::HTML::SingleProblemGrader->new($c, $pg, $problems->[ $probOrder->[$i] ], $c->{set})
 							->insertGrader =%>
 					% }
+					% # Show warnings for the problem if there are any.
+					<%= include 'ContentGenerator/Base/problem_warning_and_debug_output',
+						warnings         => $pg->{warnings},
+						warning_messages => ref $pg->{warning_messages} eq 'ARRAY' ? $pg->{warning_messages} : [],
+						debug_messages   => ref $pg->{debug_messages} eq 'ARRAY'   ? $pg->{debug_messages}   : [] =%>
 				</div>
 				% # Store the problem status for continued attempts recording.
 				<%= hidden_field 'probstatus' . $problems->[ $probOrder->[$i] ]{problem_id}

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -65,12 +65,34 @@
 % stash->{footerWidthClass} = 'col-lg-10';
 %
 <%== $c->post_header_text =%>
+% if ($c->{pg}{warnings} || @{ $c->{pgwarning} // [] }) {
+	<div class="row g-0 mb-2">
+		<div class="col-12 alert alert-danger m-0">
+			<%== maketext('<strong>Warning</strong>: There may be something wrong with this question. '
+				. 'Please inform your instructor including the warning messages below.') =%>
+		</div>
+	</div>
+% }
+% if (ref $c->{pg}{debug_messages} eq 'ARRAY' && @{ $c->{pg}{debug_messages} }) {
+	<div class="row g-0 mb-2">
+		<div class="col-12 alert alert-info m-0"><%== maketext('Debugging information is shown below.') %></div>
+	</div>
+% }
 <div id="custom_edit_message" class="row"><div class="col-lg-10"><%= $c->output_custom_edit_message %></div></div>
 <div class="row"><div id="output_summary" class="col-lg-10"><%= $c->output_summary %></div></div>
 <div class="row">
 	<div id="output_achievement_message" class="col-lg-10"><%= $c->output_achievement_message %></div>
 </div>
 <div class="row"><div id="output_comments" class="col-lg-10"><%= $c->output_comments %></div></div>
+% if ($c->{pg}{render_fail}) {
+	<div class="row g-0 mb-2">
+		<div class="col-10 alert alert-danger m-0">
+			<h2 style="color:red"><%= maketext('PG question failed to render') %></h2>
+			<p class="m-0"><%= maketext('Processing of this PG problem was not completed.  Probably because of a '
+				. 'syntax error. The translator died prematurely and no PG warning messages were transmitted.') %></p>
+		</div>
+	</div>
+% }
 <div class="row">
 	<div class="col-lg-10">
 		<%= form_for current_route, method => 'POST', name => 'problemMainForm',
@@ -96,3 +118,7 @@
 	<%= $c->output_past_answer_button =%>
 	<%= $c->output_email_instructor =%>
 </div>
+<%= include 'ContentGenerator/Base/problem_warning_and_debug_output',
+	warnings         => $c->{pg}{warnings},
+	warning_messages => ref $c->{pg}{warning_messages} eq 'ARRAY' ? $c->{pg}{warning_messages} : [],
+	debug_messages   => ref $c->{pg}{debug_messages} eq 'ARRAY'   ? $c->{pg}{debug_messages}   : [] =%>

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -136,63 +136,27 @@
 				% end
 			</div>
 		</div>
-		% # PG warning messages (this includes translator warnings but not translator errors).
-		% if ($rh_result->{pg_warnings}) {
-			<div class="Warnings alert alert-danger p-1">
-				<h3><%= $lh->maketext('Warning messages') %></h3>
-				<ul>
-					% for (split("\n", $rh_result->{pg_warnings})) {
-						<li><code><%== $_ %></code></li>
-					% }
-				</ul>
-			</div>
-		% }
-		% # PG warning messages generated with WARN_message.
-		% if (ref $rh_result->{warning_messages} eq 'ARRAY' && @{ $rh_result->{warning_messages} }) {
-			<div class="Warnings alert alert-danger p-1">
-				<h3><%= $lh->maketext('PG warning messages') %></h3>
-				<ul>
-					% for (@{ $rh_result->{warning_messages} }) {
-						<li><code><%== $_ %></code></li>
-					% }
-				</ul>
-			</div>
-		% }
-		% # Translator errors.
-		% if ($rh_result->{flags}{error_flag}) {
-			<div class="Warnings alert alert-danger p-1">
-				<h3>Translator errors</h3>
-				<code><%== $rh_result->{errors} %></code>
-			</div>
-		% }
+		<%= include 'ContentGenerator/Base/problem_warning_and_debug_output',
+			warnings         => $rh_result->{pg_warnings},
+			warning_messages => ref $rh_result->{warning_messages} eq 'ARRAY' ? $rh_result->{warning_messages} : [],
+			debug_messages   =>
+				$formatName eq 'debug' && ref $rh_result->{debug_messages} eq 'ARRAY'
+				? $rh_result->{debug_messages}
+				: []
+			=%>
 		% # Additional information output only for the debug format.
 		% if ($formatName eq 'debug') {
-			% # PG debug messages generated with DEBUG_message.
-			% if (@{ $rh_result->{debug_messages} }) {
-				<div class="Warnings alert alert-danger p-1">
-					<h3>PG debug messages</h3>
-					<ul>
-						% for (@{ $rh_result->{debug_messages} }) {
-							<li><code><%== $_ %></code></li>
-						% }
-					</ul>
-				</div>
-			% }
-			% # Internal debug messages generated within PGcore.
-			% if (ref $rh_result->{internal_debug_messages} eq 'ARRAY' && @{ $rh_result->{internal_debug_messages} }) {
-				<div class="Warnings alert alert-danger p-1">
-					<h3>Internal errors</h3>
-					<ul>
-						% for (@{ $rh_result->{internal_debug_messages} }) {
-							<li><code><%== $_ %></code></li>
-						% }
-					</ul>
-				</div>
-			% }
 			% if ($ws->{inputs_ref}{clientDebug}) {
 				<h3>Webwork client data</h3>
 				%== $pretty_print->($ws)
 			% }
+		% }
+		% # Translator errors.
+		% if ($rh_result->{flags}{error_flag}) {
+			<div class="alert alert-danger p-1">
+				<h3>Translator errors</h3>
+				<div><%== $rh_result->{errors} %></div>
+			</div>
 		% }
 	</div>
 	% # Show the footer unless it is explicity disabled.

--- a/templates/layouts/system.html.ep
+++ b/templates/layouts/system.html.ep
@@ -189,7 +189,7 @@
 		</div>
 		%
 		% if ($c->have_warnings) {
-			<div id="warnings" class="Warnings alert alert-danger mb-2"><%= $c->warnings %></div>
+			<div class="alert alert-danger mb-2"><%= $c->warnings %></div>
 		% }
 		% if ($c->can('message')) {
 			<div id="message_bottom" class="message"><%= $c->message %></div>


### PR DESCRIPTION
The PG messages are now dealt with completely separately from the webwork2 general warning handling. Furthermore PG warnings and debug messages are separately dealt with.

The PG `internal_debug_messages` are no longer dealt with at all.  They are unnecessary and inappropriately named, and will be removed from PG.

Also, handling of the warnings is now much more consistent in all of the different places that problems are rendered. In fact, they all use the new `templates/ContentGenerator/Base/problem_warning_and_debug_output.html.ep` template for this.

All of this output is no longer wrapped in a `code` tag.  That is the wrong thing for this. None of it is code. It also causes problems with https://github.com/openwebwork/pg/pull/1384.