### PR TITLE
Fix an issue with MathJax CHTML mode.

### DIFF
--- a/htdocs/js/MathJaxConfig/bs-color-scheme.js
+++ b/htdocs/js/MathJaxConfig/bs-color-scheme.js
@@ -56,7 +56,7 @@ for (const [immediate, extension, ready] of [
 		'output/chtml',
 		() => {
 			const { CHTML } = MathJax._.output.chtml_ts;
-			switchToBSStyle(CHTML);
+			switchToBSStyle(CHTML.commonStyles);
 			const { ChtmlMaction } = MathJax._.output.chtml.Wrappers.maction;
 			switchToBSStyle(ChtmlMaction.styles, '@media (prefers-color-scheme: dark) /* chtml maction */');
 		}


### PR DESCRIPTION
The `switchToBSStyle` method should be called on the `commonStyles` key of the `CHTML` object rather than the object itself (which is actually a function).