### PR TITLE
Fix some layout and validation issues.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1442,13 +1442,13 @@ sub output_custom_edit_message ($c) {
 
 # Output the "Show Past Answers" button
 sub output_past_answer_button ($c) {
-	my $problemID = $c->{problem}->problem_id;
-	my $setRecord = $c->db->getGlobalSet($c->{problem}->set_id);
-	if (defined $setRecord && $setRecord->assignment_type eq 'jitar') {
-		$problemID = join('.', jitar_id_to_seq($problemID));
-	}
-
 	if ($c->authz->hasPermissions($c->param('user'), 'view_answers')) {
+		my $problemID = $c->{problem}->problem_id;
+		my $setRecord = $c->db->getGlobalSet($c->{problem}->set_id);
+		if (defined $setRecord && $setRecord->assignment_type eq 'jitar') {
+			$problemID = join('.', jitar_id_to_seq($problemID));
+		}
+
 		my $hiddenFields = $c->hidden_authen_fields;
 		$hiddenFields =~ s/\"hidden_/\"pastans-hidden_/g;
 		return $c->form_for(

--- a/templates/ContentGenerator/Base/feedback_macro_email.html.ep
+++ b/templates/ContentGenerator/Base/feedback_macro_email.html.ep
@@ -6,8 +6,6 @@
 		% next if $key eq 'pg_object';    # Not used in internal feedback mechanism
 		<%= hidden_field $key => $value =%>
 	% }
-	<div class="mb-3">
-		<%= submit_button maketext($ce->{feedback_button_name}) || maketext('Email instructor'),
-			name => 'feedbackForm', class => 'btn btn-primary' =%>
-	</div>
+	<%= submit_button maketext($ce->{feedback_button_name}) || maketext('Email instructor'),
+		name => 'feedbackForm', class => 'btn btn-primary' =%>
 % end

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -114,10 +114,11 @@
 		<% end =%>
 	</div>
 </div>
-<div id="problemFooter" class="problemFooter">
-	<%= $c->output_past_answer_button =%>
-	<%= $c->output_email_instructor =%>
-</div>
+<%= $c->output_past_answer_button =%>
+% my $emailInstructorButton = $c->output_email_instructor;
+% if ($emailInstructorButton) {
+	<div class="mb-3"><%= $emailInstructorButton =%></div>
+% }
 <%= include 'ContentGenerator/Base/problem_warning_and_debug_output',
 	warnings         => $c->{pg}{warnings},
 	warning_messages => ref $c->{pg}{warning_messages} eq 'ARRAY' ? $c->{pg}{warning_messages} : [],

--- a/templates/ContentGenerator/ProblemSet/auxiliary_tools.html.ep
+++ b/templates/ContentGenerator/ProblemSet/auxiliary_tools.html.ep
@@ -43,7 +43,7 @@
 				<div class="modal-dialog modal-dialog-centered">
 					<div class="modal-content">
 						<div class="modal-header">
-							<h4 class="modal-title"><%= maketext('Achievement Rewards') %></h4>
+							<h1 class="modal-title h4"><%= maketext('Achievement Rewards') %></h1>
 							<button type="button" class="btn-close" data-bs-dismiss="modal"
 								aria-label="<%= maketext('close') %>"></button>
 						</div>


### PR DESCRIPTION
First, remove the `div` with the `mb-3` class that I added to the `Email Instructor` button in #2935.  I added it so that warnings or debug messages are appropriately spaced after the button on the problem page. However, the `feedback_macro_email.html.ep` template is used in other places for which that margin causes issues (for example on the problem set page).  Instead the `div` is added on the problem page, if the button is to be shown.

Note that `problemFooter` div has been removed, since that isn't even doing anything.

Also, the database access in the `output_past_answer_button` is skipped if the button is not to be shown. I just saw this while working on the area and realized that is bad.

Finally, the `h4` for the header of the achievement rewards dialog is changed to an `h1`.  The css `h4` class is used to give the header the same size and style.  Note that structurally a "modal dialog represents its own separate document/context, so the .modal-title should ideally be an `<h1>`." That is quoted from bootstrap's [modal dialog documentation](https://getbootstrap.com/docs/5.3/components/modal/).