### PR TITLE
show desired course ID in messages for when course does not exist

### DIFF
--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -140,10 +140,11 @@ async sub dispatch ($c) {
 		# This route could have the courseID set, but does not need authentication.
 		return 1 if $c->current_route eq 'saml2_metadata';
 
-		return (0, 'This course does not exist.')
+		return (0, "The course $routeCaptures{courseID} does not exist.")
 			unless (-e $ce->{courseDirs}{root}
 				|| -e "$ce->{webwork_courses_dir}/$ce->{admin_course_id}/archives/$routeCaptures{courseID}.tar.gz");
-		return (0, 'This course has been archived and closed.') unless -e $ce->{courseDirs}{root};
+		return (0, "The course $routeCaptures{courseID} has been archived and closed.")
+			unless -e $ce->{courseDirs}{root};
 
 		my $db = WeBWorK::DB->new($ce);
 		debug("(here's the DB handle: $db)\n");


### PR DESCRIPTION
If you try to visit a course that does not exist (including the situation where a course has been archived and closed), you see one of these messages affected here. The change is to display the desired course ID in the message. Of course, you could see the desired course ID in the address bar. But Safari doesn't show the address bar unless you make extra effort.

This is frustrating when someone sends me a screenshot from Safari, and they are in this situation. It's often the case that they are using LTI, and did not update LTI links to a new WeBWorK course when they copied the LMS course. It would be easier to diagnose and convince people this is the issue if the messages here included the desired courseID.