### PR TITLE
Fix a minor issue with the datepicker.

### DIFF
--- a/htdocs/js/DatePicker/datepicker.js
+++ b/htdocs/js/DatePicker/datepicker.js
@@ -119,13 +119,14 @@
 						],
 						onClick: (index, fp) => {
 							if (index === 0) {
-								const today = new Date();
-								// If there isn't a selected date, then use 12:00 am on the current date.
-								const selectedDate = fp.selectedDates[0] ?? new Date(new Date().toDateString());
-								selectedDate.setFullYear(today.getFullYear());
-								selectedDate.setMonth(today.getMonth());
-								selectedDate.setDate(today.getDate());
-								fp.setDate(selectedDate, true);
+								// The initial date represents 12:00 am on the current date.
+								const today = new Date(new Date().toDateString());
+								if (fp.selectedDates[0]) {
+									today.setHours(fp.selectedDates[0].getHours());
+									today.setMinutes(fp.selectedDates[0].getMinutes());
+									today.setSeconds(fp.selectedDates[0].getSeconds());
+								}
+								fp.setDate(today, true);
 							} else if (index === 1) {
 								fp.setDate(new Date(), true);
 							}

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -251,13 +251,14 @@
 					],
 					onClick: (index, fp) => {
 						if (index === 0) {
-							const today = new Date();
-							// If there isn't a selected date, then use 12:00 am on the current date.
-							const selectedDate = fp.selectedDates[0] ?? new Date(new Date().toDateString());
-							selectedDate.setFullYear(today.getFullYear());
-							selectedDate.setMonth(today.getMonth());
-							selectedDate.setDate(today.getDate());
-							fp.setDate(selectedDate);
+							// The initial date represents 12:00 am on the current date.
+							const today = new Date(new Date().toDateString());
+							if (fp.selectedDates[0]) {
+								today.setHours(fp.selectedDates[0].getHours());
+								today.setMinutes(fp.selectedDates[0].getMinutes());
+								today.setSeconds(fp.selectedDates[0].getSeconds());
+							}
+							fp.setDate(today, true);
 						} else if (index === 1) {
 							fp.setDate(new Date());
 						}


### PR DESCRIPTION
With the current code if you are in a month that does not have a day (such as April that does not have the 31st), one of those days is selected in another month that does have that day, and you click the "Today" button, then it doesn't go to today.  Instead it goes to the date of today in the next month.  This is because the code sets the year, month, and day for today on the selected date object and in that order, and uses the modified selected date to set the flatpickr date. So for example, if today is April 7, 2026, and the selected date is July 31, 2026, then the selected date's year is set to 2026, then the month set to April.  So at that point the selected date is April 31, 2026, which really becomes May 1, 2026.  Then the day is set, and so you get May 7, 2026.

This fixes the issue by starting with todays date at 12:00 am, and then setting the time of todays date to the time of the selected date, and then using that to set the flatpickr date.