### PR TITLE
Add horizontal padding to set info icon.

### DIFF
--- a/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
+++ b/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
@@ -20,7 +20,7 @@
 				class => 'fw-bold'
 			=%>
 			% if ($set->description =~ /\S/) {
-				<a class="set-id-tooltip" role="button" tabindex="0" data-bs-placement="right"
+				<a class="set-id-tooltip px-1" role="button" tabindex="0" data-bs-placement="right"
 						data-bs-toggle="tooltip" data-bs-title="<%= $set->description =%>"
 						data-fallback-placements="top bottom">
 					<i class="icon fas fa-circle-info" aria-hidden="true"></i>


### PR DESCRIPTION
This adds some spacing between the set link and the info icon to make it accessible on small touch screens to give enough space to touch the icon without hitting the link instead.