### PR TITLE
Update the PG CodeMirror Editor.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -8,7 +8,7 @@
 			"license": "GPL-2.0+",
 			"dependencies": {
 				"@fortawesome/fontawesome-free": "^7.0.0",
-				"@openwebwork/pg-codemirror-editor": "^0.0.9",
+				"@openwebwork/pg-codemirror-editor": "^0.0.10",
 				"bootstrap": "~5.3.7",
 				"flatpickr": "^4.6.13",
 				"iframe-resizer": "^4.4.2",
@@ -33,9 +33,9 @@
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+			"version": "6.20.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+			"integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -45,13 +45,13 @@
 			}
 		},
 		"node_modules/@codemirror/commands": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
-			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+			"integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.4.0",
+				"@codemirror/state": "^6.6.0",
 				"@codemirror/view": "^6.27.0",
 				"@lezer/common": "^1.1.0"
 			}
@@ -87,9 +87,9 @@
 			}
 		},
 		"node_modules/@codemirror/lang-javascript": {
-			"version": "6.2.4",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
-			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+			"integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/autocomplete": "^6.0.0",
@@ -116,23 +116,23 @@
 			}
 		},
 		"node_modules/@codemirror/language": {
-			"version": "6.11.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
-			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+			"integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
-				"@lezer/common": "^1.1.0",
+				"@lezer/common": "^1.5.0",
 				"@lezer/highlight": "^1.0.0",
 				"@lezer/lr": "^1.0.0",
 				"style-mod": "^4.0.0"
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
-			"integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+			"integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -141,20 +141,20 @@
 			}
 		},
 		"node_modules/@codemirror/search": {
-			"version": "6.5.11",
-			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
-			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+			"integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
+				"@codemirror/view": "^6.37.0",
 				"crelt": "^1.0.5"
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
-			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+			"integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
@@ -173,12 +173,12 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.38.8",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
-			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+			"integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/state": "^6.5.0",
+				"@codemirror/state": "^6.6.0",
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
@@ -244,15 +244,15 @@
 			}
 		},
 		"node_modules/@lezer/common": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
-			"integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg==",
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+			"integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
 			"license": "MIT"
 		},
 		"node_modules/@lezer/css": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
-			"integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+			"integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -270,9 +270,9 @@
 			}
 		},
 		"node_modules/@lezer/html": {
-			"version": "1.3.12",
-			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
-			"integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+			"version": "1.3.13",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+			"integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -292,9 +292,9 @@
 			}
 		},
 		"node_modules/@lezer/lr": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.4.tgz",
-			"integrity": "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.0.0"
@@ -324,26 +324,26 @@
 			"license": "Apache-2.0"
 		},
 		"node_modules/@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.4.tgz",
-			"integrity": "sha512-lNA9PVTRDNWfmL87ux3zbFQfih+6tXKJdz+yA1CPbHWaNuNY+OK9dur+Ul5H6Hi6flGWlcE674/eMmkelLRAng==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.5.tgz",
+			"integrity": "sha512-3zNm9aFc6/IHBG4lJq8QOc2bF2rIFkSPX2hwCexgEcmchVBOsYPSfB0+bRsftfQQ4YdPFP64uDlSZBKu1yRcZQ==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"node_modules/@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.9.tgz",
-			"integrity": "sha512-6uy28r0ejOzJOC9vkgCu6tx9Zyi6ZpYWmqsk4sJlPamOicOiVNL5riu7pb4aIxmbdZWw4pXsGGilzYB38bnYVA==",
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.10.tgz",
+			"integrity": "sha512-kX7aJaWl2UagEX6kVToxuMUpYyh8zlSbg2chUv71e9nIw4jcwpvis8WkCSsYGRJw45hQTN1N42MPJOYqV+8fzQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-html": "^6.4.11",
 				"@codemirror/lang-xml": "^6.1.0",
 				"@codemirror/theme-one-dark": "^6.1.3",
-				"@openwebwork/codemirror-lang-pg": "^0.0.4",
+				"@openwebwork/codemirror-lang-pg": "^0.0.5",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -355,8 +355,8 @@
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
 				"codemirror": "^6.0.2",
-				"codemirror-lang-mt": "^0.0.4",
-				"codemirror-lang-perl": "^0.1.7",
+				"codemirror-lang-mt": "^0.0.5",
+				"codemirror-lang-perl": "^0.1.8",
 				"style-mod": "^4.1.3",
 				"thememirror": "^2.0.1"
 			}
@@ -1042,28 +1042,28 @@
 			}
 		},
 		"node_modules/codemirror-lang-mt": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.4.tgz",
-			"integrity": "sha512-8jKq4H0JG/mZQwz8TaV1KP1PBL14UKj9icpIB2ZwQ05e+MlvvJbt4Q6DoSXHghbP++4frzDkgRgIDZjMJ3I0+Q==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.5.tgz",
+			"integrity": "sha512-Gb7Di+IDN5zruiKhcbqCA95b+DzGagC1YJas4o9gQvGSHt3u3iaktLG19TO2F4miKLYhrV+3UOMGsOb+4iKZLQ==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/lang-css": "^6.3.1",
 				"@codemirror/lang-html": "^6.4.11",
-				"@codemirror/lang-javascript": "^6.2.4",
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/lang-javascript": "^6.2.5",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"node_modules/codemirror-lang-perl": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.7.tgz",
-			"integrity": "sha512-GxGVpHIUVzVnsJDd7zpkm5S+t+mgFI+XAY4jOmocaUMRuCsPzLLbYX9VJ6LkFY00bJDwrtKSS503lSsocX46xQ==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.8.tgz",
+			"integrity": "sha512-l3z73XLzFjrkd1LN/9KwR3tsO9oegmCBTgQC4Bg9vJhmv4js0RtnEAN3mUMWtib1Qecb/dQc5mpNqClYGhHuYA==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"node_modules/colord": {
@@ -2525,9 +2525,9 @@
 	},
 	"dependencies": {
 		"@codemirror/autocomplete": {
-			"version": "6.20.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.0.tgz",
-			"integrity": "sha512-bOwvTOIJcG5FVo5gUUupiwYh8MioPLQ4UcqbcRf7UQ98X90tCa9E1kZ3Z7tqwpZxYyOvh1YTYbmZE9RTfTp5hg==",
+			"version": "6.20.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.1.tgz",
+			"integrity": "sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==",
 			"requires": {
 				"@codemirror/language": "^6.0.0",
 				"@codemirror/state": "^6.0.0",
@@ -2536,12 +2536,12 @@
 			}
 		},
 		"@codemirror/commands": {
-			"version": "6.10.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.0.tgz",
-			"integrity": "sha512-2xUIc5mHXQzT16JnyOFkh8PvfeXuIut3pslWGfsGOhxP/lpgRm9HOl/mpzLErgt5mXDovqA0d11P21gofRLb9w==",
+			"version": "6.10.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
+			"integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
 			"requires": {
 				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.4.0",
+				"@codemirror/state": "^6.6.0",
 				"@codemirror/view": "^6.27.0",
 				"@lezer/common": "^1.1.0"
 			}
@@ -2575,9 +2575,9 @@
 			}
 		},
 		"@codemirror/lang-javascript": {
-			"version": "6.2.4",
-			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.4.tgz",
-			"integrity": "sha512-0WVmhp1QOqZ4Rt6GlVGwKJN3KW7Xh4H2q8ZZNGZaP6lRdxXJzmjm4FqvmOojVj6khWJHIb9sp7U/72W7xQgqAA==",
+			"version": "6.2.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.2.5.tgz",
+			"integrity": "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A==",
 			"requires": {
 				"@codemirror/autocomplete": "^6.0.0",
 				"@codemirror/language": "^6.6.0",
@@ -2602,22 +2602,22 @@
 			}
 		},
 		"@codemirror/language": {
-			"version": "6.11.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.11.3.tgz",
-			"integrity": "sha512-9HBM2XnwDj7fnu0551HkGdrUrrqmYq/WC5iv6nbY2WdicXdGbhR/gfbZOH73Aqj4351alY1+aoG9rCNfiwS1RA==",
+			"version": "6.12.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
+			"integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.23.0",
-				"@lezer/common": "^1.1.0",
+				"@lezer/common": "^1.5.0",
 				"@lezer/highlight": "^1.0.0",
 				"@lezer/lr": "^1.0.0",
 				"style-mod": "^4.0.0"
 			}
 		},
 		"@codemirror/lint": {
-			"version": "6.9.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.2.tgz",
-			"integrity": "sha512-sv3DylBiIyi+xKwRCJAAsBZZZWo82shJ/RTMymLabAdtbkV5cSKwWDeCgtUq3v8flTaXS2y1kKkICuRYtUswyQ==",
+			"version": "6.9.5",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.5.tgz",
+			"integrity": "sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
 				"@codemirror/view": "^6.35.0",
@@ -2625,19 +2625,19 @@
 			}
 		},
 		"@codemirror/search": {
-			"version": "6.5.11",
-			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.5.11.tgz",
-			"integrity": "sha512-KmWepDE6jUdL6n8cAAqIpRmLPBZ5ZKnicE8oGU/s3QrAVID+0VhLFrzUucVKHG5035/BSykhExDL/Xm7dHthiA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.6.0.tgz",
+			"integrity": "sha512-koFuNXcDvyyotWcgOnZGmY7LZqEOXZaaxD/j6n18TCLx2/9HieZJ5H6hs1g8FiRxBD0DNfs0nXn17g872RmYdw==",
 			"requires": {
 				"@codemirror/state": "^6.0.0",
-				"@codemirror/view": "^6.0.0",
+				"@codemirror/view": "^6.37.0",
 				"crelt": "^1.0.5"
 			}
 		},
 		"@codemirror/state": {
-			"version": "6.5.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.5.2.tgz",
-			"integrity": "sha512-FVqsPqtPWKVVL3dPSxy8wEF/ymIEuVzF1PK3VbUgrxXpJUSHQWWZz4JMToquRxnkw+36LTamCZG2iua2Ptq0fA==",
+			"version": "6.6.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
+			"integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
 			"requires": {
 				"@marijn/find-cluster-break": "^1.0.0"
 			}
@@ -2654,11 +2654,11 @@
 			}
 		},
 		"@codemirror/view": {
-			"version": "6.38.8",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.38.8.tgz",
-			"integrity": "sha512-XcE9fcnkHCbWkjeKyi0lllwXmBLtyYb5dt89dJyx23I9+LSh5vZDIuk7OLG4VM1lgrXZQcY6cxyZyk5WVPRv/A==",
+			"version": "6.41.0",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.41.0.tgz",
+			"integrity": "sha512-6H/qadXsVuDY219Yljhohglve8xf4B8xJkVOEWfA5uiYKiTFppjqsvsfR5iPA0RbvRBoOyTZpbLIxe9+0UR8xA==",
 			"requires": {
-				"@codemirror/state": "^6.5.0",
+				"@codemirror/state": "^6.6.0",
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
@@ -2712,14 +2712,14 @@
 			}
 		},
 		"@lezer/common": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.4.0.tgz",
-			"integrity": "sha512-DVeMRoGrgn/k45oQNu189BoW4SZwgZFzJ1+1TV5j2NJ/KFC83oa/enRqZSGshyeMk5cPWMhsKs9nx+8o0unwGg=="
+			"version": "1.5.2",
+			"resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+			"integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="
 		},
 		"@lezer/css": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.0.tgz",
-			"integrity": "sha512-pBL7hup88KbI7hXnZV3PQsn43DHy6TWyzuyk2AO9UyoXcDltvIdqWKE1dLL/45JVZ+YZkHe1WVHqO6wugZZWcw==",
+			"version": "1.3.3",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
+			"integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
@@ -2735,9 +2735,9 @@
 			}
 		},
 		"@lezer/html": {
-			"version": "1.3.12",
-			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.12.tgz",
-			"integrity": "sha512-RJ7eRWdaJe3bsiiLLHjCFT1JMk8m1YP9kaUbvu2rMLEoOnke9mcTVDyfOslsln0LtujdWespjJ39w6zo+RsQYw==",
+			"version": "1.3.13",
+			"resolved": "https://registry.npmjs.org/@lezer/html/-/html-1.3.13.tgz",
+			"integrity": "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg==",
 			"requires": {
 				"@lezer/common": "^1.2.0",
 				"@lezer/highlight": "^1.0.0",
@@ -2755,9 +2755,9 @@
 			}
 		},
 		"@lezer/lr": {
-			"version": "1.4.4",
-			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.4.tgz",
-			"integrity": "sha512-LHL17Mq0OcFXm1pGQssuGTQFPPdxARjKM8f7GA5+sGtHi0K3R84YaSbmche0+RKWHnCsx9asEe5OWOI4FHfe4A==",
+			"version": "1.4.8",
+			"resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.8.tgz",
+			"integrity": "sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==",
 			"requires": {
 				"@lezer/common": "^1.0.0"
 			}
@@ -2783,24 +2783,24 @@
 			"integrity": "sha512-LeV5AWzoR7k/k2tg5mW0Ad3Jr9oK9guW/zBUIP8aoiIZcZIhvAV9dlbtUSqSe1wgEBUP1KOcJXcrE/NxOqkxlQ=="
 		},
 		"@openwebwork/codemirror-lang-pg": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.4.tgz",
-			"integrity": "sha512-lNA9PVTRDNWfmL87ux3zbFQfih+6tXKJdz+yA1CPbHWaNuNY+OK9dur+Ul5H6Hi6flGWlcE674/eMmkelLRAng==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/@openwebwork/codemirror-lang-pg/-/codemirror-lang-pg-0.0.5.tgz",
+			"integrity": "sha512-3zNm9aFc6/IHBG4lJq8QOc2bF2rIFkSPX2hwCexgEcmchVBOsYPSfB0+bRsftfQQ4YdPFP64uDlSZBKu1yRcZQ==",
 			"requires": {
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"@openwebwork/pg-codemirror-editor": {
-			"version": "0.0.9",
-			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.9.tgz",
-			"integrity": "sha512-6uy28r0ejOzJOC9vkgCu6tx9Zyi6ZpYWmqsk4sJlPamOicOiVNL5riu7pb4aIxmbdZWw4pXsGGilzYB38bnYVA==",
+			"version": "0.0.10",
+			"resolved": "https://registry.npmjs.org/@openwebwork/pg-codemirror-editor/-/pg-codemirror-editor-0.0.10.tgz",
+			"integrity": "sha512-kX7aJaWl2UagEX6kVToxuMUpYyh8zlSbg2chUv71e9nIw4jcwpvis8WkCSsYGRJw45hQTN1N42MPJOYqV+8fzQ==",
 			"requires": {
 				"@codemirror/lang-html": "^6.4.11",
 				"@codemirror/lang-xml": "^6.1.0",
 				"@codemirror/theme-one-dark": "^6.1.3",
-				"@openwebwork/codemirror-lang-pg": "^0.0.4",
+				"@openwebwork/codemirror-lang-pg": "^0.0.5",
 				"@replit/codemirror-emacs": "^6.1.0",
 				"@replit/codemirror-vim": "^6.3.0",
 				"cm6-theme-basic-dark": "^0.2.0",
@@ -2812,8 +2812,8 @@
 				"cm6-theme-solarized-dark": "^0.2.0",
 				"cm6-theme-solarized-light": "^0.2.0",
 				"codemirror": "^6.0.2",
-				"codemirror-lang-mt": "^0.0.4",
-				"codemirror-lang-perl": "^0.1.7",
+				"codemirror-lang-mt": "^0.0.5",
+				"codemirror-lang-perl": "^0.1.8",
 				"style-mod": "^4.1.3",
 				"thememirror": "^2.0.1"
 			}
@@ -3126,26 +3126,26 @@
 			}
 		},
 		"codemirror-lang-mt": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.4.tgz",
-			"integrity": "sha512-8jKq4H0JG/mZQwz8TaV1KP1PBL14UKj9icpIB2ZwQ05e+MlvvJbt4Q6DoSXHghbP++4frzDkgRgIDZjMJ3I0+Q==",
+			"version": "0.0.5",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-mt/-/codemirror-lang-mt-0.0.5.tgz",
+			"integrity": "sha512-Gb7Di+IDN5zruiKhcbqCA95b+DzGagC1YJas4o9gQvGSHt3u3iaktLG19TO2F4miKLYhrV+3UOMGsOb+4iKZLQ==",
 			"requires": {
 				"@codemirror/lang-css": "^6.3.1",
 				"@codemirror/lang-html": "^6.4.11",
-				"@codemirror/lang-javascript": "^6.2.4",
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/lang-javascript": "^6.2.5",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"codemirror-lang-perl": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.7.tgz",
-			"integrity": "sha512-GxGVpHIUVzVnsJDd7zpkm5S+t+mgFI+XAY4jOmocaUMRuCsPzLLbYX9VJ6LkFY00bJDwrtKSS503lSsocX46xQ==",
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/codemirror-lang-perl/-/codemirror-lang-perl-0.1.8.tgz",
+			"integrity": "sha512-l3z73XLzFjrkd1LN/9KwR3tsO9oegmCBTgQC4Bg9vJhmv4js0RtnEAN3mUMWtib1Qecb/dQc5mpNqClYGhHuYA==",
 			"requires": {
-				"@codemirror/language": "^6.11.3",
+				"@codemirror/language": "^6.12.3",
 				"@lezer/highlight": "^1.2.3",
-				"@lezer/lr": "^1.4.4"
+				"@lezer/lr": "^1.4.8"
 			}
 		},
 		"colord": {

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -14,7 +14,7 @@
 	},
 	"dependencies": {
 		"@fortawesome/fontawesome-free": "^7.0.0",
-		"@openwebwork/pg-codemirror-editor": "^0.0.9",
+		"@openwebwork/pg-codemirror-editor": "^0.0.10",
 		"bootstrap": "~5.3.7",
 		"flatpickr": "^4.6.13",
 		"iframe-resizer": "^4.4.2",


### PR DESCRIPTION
Updated packages have been published, and this just updates the package.json file to point to the latest version.

The dependencies of the `pg-codemirror-editor` and `codemirror-lang-pg` packages were updated (largely to deal with security vulnerabilities in the dependencies).

There is also a bug fixed with builtin operator names occuring as the key of a hash. For example, the keys of the following hash are builtin operators, but should not be interpreted as such in this context.

```perl
%hash = (
    step    => 1,
    defined => 1,
    split   => 1
);
```

Since they were the hask key value pair was not parsing, and so all syntax highlighting after it is messed up.

The first key `step` is a PG operator, the second `defined` is a Perl named unary operator, the third `split` is a Perl list operator.  Of course any of the other PG operators, Perl named unary operators, or Perl list operators had the same problem since they are all handled in the code by the same external tokenizer.