### PR TITLE
Fix a minor issue resulting from #2935.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1512,7 +1512,7 @@ async sub getProblemHTML ($c, $effectiveUser, $set, $formFields, $mergedProblem)
 		if $c->{can}{checkAnswers}
 		&& (!$c->{submitAnswers} || defined $c->param('problem_data_' . $mergedProblem->problem_id));
 
-	$c->stash->{haveProblemWarnings} = 1 if $pg->{warnings} || @{ $pg->{pgwarning} // [] };
+	$c->stash->{haveProblemWarnings} = 1 if $pg->{warnings} || @{ $pg->{warning_messages} // [] };
 
 	return $pg;
 }

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -65,7 +65,7 @@
 % stash->{footerWidthClass} = 'col-lg-10';
 %
 <%== $c->post_header_text =%>
-% if ($c->{pg}{warnings} || @{ $c->{pgwarning} // [] }) {
+% if ($c->{pg}{warnings} || @{ $c->{pg}{warning_messages} // [] }) {
 	<div class="row g-0 mb-2">
 		<div class="col-12 alert alert-danger m-0">
 			<%== maketext('<strong>Warning</strong>: There may be something wrong with this question. '


### PR DESCRIPTION
There is no longer a `pgwarning` key set on the controller object for the `lib/WeBWorK/ContentGenerator/Problem.pm` module and never was a `pgwarning` key for the returned pg object in the
`lib/ContentGenerator/GatewayQuiz.pm` module.  So use the correct key on the returned pg object in both cases.  That is the `warning_messages` key.

The warning messages were still being shown at the bottom, but not the message at the top of the page notifying of the existence of those warnings.  Since the warnings at the bottom might not be visible, the warnings may be missed.