### PR TITLE
Add a custom sagecell server URL option.

### DIFF
--- a/conf/localOverrides.conf.dist
+++ b/conf/localOverrides.conf.dist
@@ -435,6 +435,21 @@ $mail{feedbackRecipients}    = [
 #$pg{specialPGEnvironmentVars}{Rserve} = {host => "r"};
 
 ################################################################################
+# Usa a custom Sage cell server.
+################################################################################
+
+# By default the AskSage method of PG uses the public sagecell service located
+# at https://sagecell.sagemath.org/service. However, the server at that address
+# is no longer accepting public requests. So in order for problems that use the
+# AskSage method to work a different sagecell server must be used.  Uncomment
+# the line below and set the value to a custom sagecell server address to use
+# with the AskSage method. If using the docker container built with the
+# instructions and files in the sagecell-docker directory the PG repository, the
+# use the line below as is.
+
+#$pg{URLs}{sagecellService} = 'http://localhost:3500/service';
+
+################################################################################
 # Authentication
 ################################################################################
 


### PR DESCRIPTION
This just adds the commented out setting for using the new custom SageCell server URL from https://github.com/openwebwork/pg/pull/1399.