### PR TITLE
Remove PRINT_FILE_NAMES_FOR and PRINT_FILE_NAMES_PERMISSION_LEVEL

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -797,7 +797,7 @@ $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 	can_check_and_submit_answers                    => "ta",
 	can_use_show_me_another_early                   => "ta",
 	create_new_set_version_when_acting_as_student   => undef,
-	print_path_to_problem                           => "professor", # see "Special" PG environment variables
+	print_path_to_problem                           => "professor",
 	always_show_hint                                => "professor",
 	always_show_solution                            => "professor",
 	record_set_version_answers_when_acting_as_student => undef,
@@ -1174,13 +1174,6 @@ $pg{directories}{imagesPath} = [
 $pg{URLs}{localHelpURL} = "$pg_htdocs_url/helpFiles";
 
 ##### "Special" PG environment variables. (Stuff that doesn't fit in anywhere else.)
-
-# Users for whom to print the file name of the PG file being processed.
-$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [ "professor", ];
-
-# File names are also printed for anyone with this permission or higher
-$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL} =
-	$userRoles{ $permissionLevels{print_path_to_problem} };
 
 # whether to use javascript for rendering Live3D graphs
 $pg{specialPGEnvironmentVars}{use_javascript_for_live3d} = 1;

--- a/courses.dist/modelCourse/course.conf
+++ b/courses.dist/modelCourse/course.conf
@@ -2,12 +2,6 @@
 
 # This file is used to override the global WeBWorK course environment for this course.
 
-# Users for whom to label problems with the PG file name (global value typically "professor")
-# For users in this list, PG will display the source file name when rendering a problem.
-# defaults.config values:
-# 	$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = ['professor'];
-$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = ['admin'];
-
 # The following hashes control which users are allowed to see students from which
 # sections.  This is typically used for large multi-section classes with many students, ta's and
 # professors.  When set users will only be allowed to see students from the appropriate section in the following:

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -294,8 +294,6 @@ sub do_add_course ($c) {
 
 	my $ce2 = WeBWorK::CourseEnvironment->new({ courseName => $add_courseID });
 
-	my %courseOptions;
-
 	my @users;
 
 	# copy users from current (admin) course if desired
@@ -392,15 +390,7 @@ sub do_add_course ($c) {
 
 	my $output = $c->c;
 
-	eval {
-		addCourse(
-			courseID      => $add_courseID,
-			ce            => $ce2,
-			courseOptions => \%courseOptions,
-			users         => \@users,
-			%optional_arguments,
-		);
-	};
+	eval { addCourse(courseID => $add_courseID, ce => $ce2, users => \@users, %optional_arguments,); };
 	if ($@) {
 		my $error = $@;
 		push(

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -376,9 +376,6 @@ sub do_add_course ($c) {
 		}
 	}
 
-	push @{ $courseOptions{PRINT_FILE_NAMES_FOR} },
-		map { $_->[0]->user_id } grep { $_->[2]->permission >= $ce->{userRoles}{professor} } @users;
-
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
 	if ($copy_from_course ne '') {

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -993,8 +993,7 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
 			. ($c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) =~
-				s/\x{202f}/ /gr)
-			. "}%\n";
+				s/\x{202f}/ /gr) . "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)
@@ -1167,10 +1166,10 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 				problemID => $MergedProblem->problem_id,
 			),
 			$MergedProblem->problem_id == 0
-				# link for a fake problem (like a header file)
+			# link for a fake problem (like a header file)
 			? (params =>
 					{ sourceFilePath => $MergedProblem->source_file, problemSeed => $MergedProblem->problem_seed })
-				# link for a real problem
+			# link for a real problem
 			: (),
 		);
 

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -118,10 +118,7 @@ async sub pre_header_initialize ($c) {
 	die 'Parameter "user" not defined -- this should never happen' unless defined $userID;
 
 	# Check to see if the user is authorized to view source file paths.
-	$c->{can_show_source_file} =
-		($db->getPermissionLevel($userID)->permission >=
-			$ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL})
-		|| (grep { $_ eq $userID } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} });
+	$c->{can_show_source_file} = $authz->hasPermissions($userID, 'print_path_to_problem');
 
 	if ($generate_hardcopy) {
 		my $validation_failed = 0;
@@ -996,7 +993,8 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 	{
 		print $FH '\\def\\webworkReducedScoringDate{'
 			. ($c->formatDateTime($MergedSet->{reduced_scoring_date}, $ce->{studentDateDisplayFormat}) =~
-				s/\x{202f}/ /gr) . "}%\n";
+				s/\x{202f}/ /gr)
+			. "}%\n";
 	}
 
 	# write set header (theme presetheader, then PG header, then theme postsetheader)
@@ -1169,10 +1167,10 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 				problemID => $MergedProblem->problem_id,
 			),
 			$MergedProblem->problem_id == 0
-			# link for a fake problem (like a header file)
+				# link for a fake problem (like a header file)
 			? (params =>
 					{ sourceFilePath => $MergedProblem->source_file, problemSeed => $MergedProblem->problem_seed })
-			# link for a real problem
+				# link for a real problem
 			: (),
 		);
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -906,10 +906,7 @@ sub page_title ($c) {
 
 	# This uses the permission level and user id of the user assigned to the problem.
 	my $problemUser = $problem->user_id;
-	my $inList      = grep { $_ eq $problemUser } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} };
-	if ($db->getPermissionLevel($problemUser)->permission >=
-		$ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL} || $inList)
-	{
+	if ($c->authz->hasPermissions($problemUser, 'print_path_to_problem')) {
 		$subheader .= ' ' . $problem->source_file;
 	}
 

--- a/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
+++ b/lib/WeBWorK/ContentGenerator/ShowMeAnother.pm
@@ -252,10 +252,7 @@ sub page_title ($c) {
 
 	# This uses the permission level and user id of the user assigned to the problem.
 	my $problemUser = $problem->user_id;
-	if ($c->db->getPermissionLevel($problemUser)->permission >=
-		$ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL}
-		|| grep { $_ eq $problemUser } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} })
-	{
+	if ($c->authz->hasPermissions($problemUser, 'print_path_to_problem')) {
 		$subheader .= ' ' . $problem->source_file;
 	}
 

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -126,10 +126,9 @@ sub listArchivedCourses {
 
 %options must contain:
 
- courseID      => course ID for the new course,
- ce            => a course environment for the new course,
- courseOptions => hash ref explained below
- users         => array ref explained below
+ courseID => course ID for the new course,
+ ce       => a course environment for the new course,
+ users    => array ref explained below
 
 %options may contain:
 
@@ -149,8 +148,6 @@ Create a new course with ID $courseID.
 
 $ce is a WeBWorK::CourseEnvironment object that describes the new course's
 environment.
-
-$courseOptions is a reference to a hash containing the following options:
 
 $users is a list of arrayrefs, each containing a User, Password, and
 PermissionLevel record for a single user:
@@ -183,11 +180,10 @@ sub addCourse {
 		debug("$key  : $value");
 	}
 
-	my $courseID      = $options{courseID};
-	my $sourceCourse  = $options{copyFrom} // '';
-	my $ce            = $options{ce};
-	my %courseOptions = %{ $options{courseOptions} // {} };
-	my @users         = exists $options{users} ? @{ $options{users} } : ();
+	my $courseID     = $options{courseID};
+	my $sourceCourse = $options{copyFrom} // '';
+	my $ce           = $options{ce};
+	my @users        = exists $options{users} ? @{ $options{users} } : ();
 
 	debug \@users;
 
@@ -428,7 +424,7 @@ sub addCourse {
 		my $courseEnvFile = $ce->{courseFiles}{environment};
 		open my $fh, ">:utf8", $courseEnvFile
 			or die "failed to open $courseEnvFile for writing.\n";
-		writeCourseConf($fh, $ce, %courseOptions);
+		writeCourseConf($fh);
 		close $fh;
 	}
 
@@ -1176,18 +1172,17 @@ sub protectQString {
 	return $string;
 }
 
-=item writeCourseConf($fh, $ce, %options)
+=item writeCourseConf($fh)
 
-Writes a course.conf file to $fh, a file handle, using defaults from the course
-environment object $ce and overrides from %options. %options can contain any of
-the pairs accepted in %courseOptions by addCourse(), above.
+Writes an essentially empty course.conf file to $fh, a file handle. System
+administrators can use this file to override global settings for a course.
 
 =back
 
 =cut
 
 sub writeCourseConf {
-	my ($fh, $ce, %options) = @_;
+	my ($fh) = @_;
 
 	print $fh <<'EOF';
 #!perl

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -152,10 +152,6 @@ environment.
 
 $courseOptions is a reference to a hash containing the following options:
 
-    PRINT_FILE_NAMES_FOR => $pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR}
-
-C<PRINT_FILE_NAMES_FOR> is a reference to an array.
-
 $users is a list of arrayrefs, each containing a User, Password, and
 PermissionLevel record for a single user:
 
@@ -1199,26 +1195,6 @@ sub writeCourseConf {
 # This file is used to override the global WeBWorK course environment for this course.
 
 EOF
-
-	print $fh <<'EOF';
-# Users for whom to label problems with the PG file name (global value typically "professor")
-# For users in this list, PG will display the source file name when rendering a problem.
-# defaults.config values:
-EOF
-
-	if (defined $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR}) {
-		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [',
-			join(", ",
-			map { "'" . protectQString($_) . "'" } @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} }),
-			'];', "\n";
-	} else {
-		print $fh "# \t", '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [ ];', "\n";
-	}
-
-	if (defined $options{PRINT_FILE_NAMES_FOR}) {
-		print $fh '$pg{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} = [',
-			join(", ", map { "'" . protectQString($_) . "'" } @{ $options{PRINT_FILE_NAMES_FOR} }), '];', "\n";
-	}
 }
 
 sub get_SeedCE

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -574,14 +574,7 @@
 						% }
 						%
 						% # This uses the permission level and user id of the user assigned to the set.
-						% if (
-							% $db->getPermissionLevel($effectiveUserID)->permission >=
-								% $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_PERMISSION_LEVEL}
-							% || (
-								% grep { $_ eq $effectiveUserID }
-									% @{ $ce->{pg}{specialPGEnvironmentVars}{PRINT_FILE_NAMES_FOR} }
-							% )
-						% )
+						% if ( $authz->hasPermissions($effectiveUserID, 'print_path_to_problem') )
 						% {
 							<%= $problems->[ $probOrder->[$i] ]->source_file %>
 						% }


### PR DESCRIPTION
This removes the special PG environment variables `PRINT_FILE_NAMES_FOR` and `PRINT_FILE_NAMES_PERMISSION_LEVEL`.

In defaults.config the value of `PRINT_FILE_NAMES_PERMISSION_LEVEL` is set to the value of the `print_path_to_problem` permission, so now that permission is just checked directly.

I don't see the use of `PRINT_FILE_NAMES_FOR`.  When a new course is created it is hardcoded to add all users with permission level of 'professor' or higher to the array, but those users will already be able to view file names via the `print_path_to_problem` permission.

The motivation behind this was to remove the one remaining setting that is added to course.conf when a new course is created.  Now that file contains no settings by default.