### PR TITLE
Fix an issue with the `addcourse` script.

### DIFF
--- a/bin/addcourse
+++ b/bin/addcourse
@@ -49,7 +49,7 @@ use Getopt::Long;
 
 BEGIN {
 	use Mojo::File qw(curfile);
-	use Env qw(WEBWORK_ROOT);
+	use Env        qw(WEBWORK_ROOT);
 
 	$WEBWORK_ROOT = curfile->dirname->dirname;
 }
@@ -59,9 +59,9 @@ use lib "$ENV{WEBWORK_ROOT}/lib";
 
 use WeBWorK::CourseEnvironment;
 use WeBWorK::File::Classlist;
-use WeBWorK::Utils qw(runtime_use cryptPassword);
+use WeBWorK::Utils                   qw(runtime_use cryptPassword);
 use WeBWorK::Utils::CourseManagement qw(addCourse);
-use WeBWorK::File::Classlist qw(parse_classlist);
+use WeBWorK::File::Classlist         qw(parse_classlist);
 use WeBWorK::DB::Record::User;
 use WeBWorK::DB::Record::Password;
 use WeBWorK::DB::Record::PermissionLevel;
@@ -123,6 +123,8 @@ if ($users) {
 		if (!$record{status} && defined $professors{$user_id}) {
 			$record{permission} = $ce->{userRoles}{professor};
 		}
+
+		$record{accommodation_time_factor} = 1;
 
 		delete $professors{$user_id};
 


### PR DESCRIPTION
The `addcourse` script does not use a database object to create a user record.  Instead it directly calls `WeBWorK::DB::Record::User->new(%record)`. So if the `%record` hash does not have the `accommodation_time_factor` key set, then the script errors out when it attempts to create a user. So make sure that is set.

It seems that `perltidy` was also run on the file.  I just noticed that now when I review this in preparation to create the pull request.