### PR TITLE
Update the docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ RUN apt-get update \
 	libpandoc-wrapper-perl \
 	libpath-class-perl \
 	libpath-tiny-perl \
+	libperl-critic-perl \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
@@ -174,7 +175,7 @@ RUN apt-get update \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
-	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
 	&& apt-get clean \
 	&& rm -fr /var/lib/apt/lists/* /tmp/*
@@ -182,10 +183,9 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n \
-	Statistics::R::IO \
+RUN cpanm -n \
 	DBD::MariaDB \
-	Perl::Tidy@20220613 \
+	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -88,6 +88,7 @@ RUN apt-get update \
 	libpandoc-wrapper-perl \
 	libpath-class-perl \
 	libpath-tiny-perl \
+	libperl-critic-perl \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
@@ -136,7 +137,7 @@ RUN apt-get update \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
-	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
 	&& apt-get clean \
 	&& rm -fr /var/lib/apt/lists/* /tmp/*
@@ -144,10 +145,9 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n \
-	Statistics::R::IO \
+RUN cpanm -n \
 	DBD::MariaDB \
-	Perl::Tidy@20220613 \
+	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:10.4
+    image: mariadb:10.11
 
     # Set a fixed container name, so it does not depend on the directory name
     container_name: webwork2_db_1

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ ! -d "$APP_ROOT/courses/admin" ]; then
 	umask 2
 	cd $APP_ROOT/courses
 	wait_for_db
-	$WEBWORK_ROOT/bin/addcourse admin --db-layout=sql_single --users=$WEBWORK_ROOT/courses.dist/adminClasslist.lst --professors=admin
+	$WEBWORK_ROOT/bin/addcourse admin --users=$WEBWORK_ROOT/courses.dist/adminClasslist.lst --professors=admin
 	chown www-data:www-data -R $APP_ROOT/courses
 	echo "Admin course is created."
 	echo "user: admin password: admin added to course admin and tables upgraded"


### PR DESCRIPTION
Update to node 24 in the build instead of node 20.
    
Update the Perl::Tidy version to the version currently used in development.

Don't install the `Statistics::R::IO` module.  That is not used anymore.

Update to the mariadb 10.11 docker image for the database volume. That should have been done before when I updated the docker build to Ubuntu 24.  That matches the version of mariadb in Ubuntu 24.

Remove the `--db-layout` option that was passed to the `addcourse` script.  That is not valid for the script anymore.

<s>Note that this depends on #2957, since the docker build will fail without the bug in the `addcourse` script fixed.</s>