### PR TITLE
Add extension time factor setting.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -141,6 +141,7 @@ $achievementPointsPerProblem = 5;
 $achievementPointsPerProblemReduced = 3;
 $achievementPreambleFile = "preamble.at";
 $achievementExcludeSet = [];
+$achievementExtensionFactor = 1;
 $mail{achievementEmailFrom} = '';
 $showCourseHomeworkTotals = 1;
 

--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -72,7 +72,7 @@ sub UserItems ($c, $userName, $set, $records) {
 
 	for my $item (@{ +ITEMS }) {
 		next unless $globalData->{$item};
-		my $achievementItem = "WeBWorK::AchievementItems::$item"->new;
+		my $achievementItem = "WeBWorK::AchievementItems::$item"->new($c);
 		$achievementItem->{count} = $globalData->{$item};
 
 		# Return list of achievements items if $set is not defined.

--- a/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
+++ b/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
@@ -6,14 +6,16 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(between);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'AddNewTestGW',
 		name        => x('Oil of Cleansing'),
-		description => x(
-			'Unlock an additional version of a test.  If used before the close date of '
-				. 'the test this will allow you to generate a new version of the test.'
-		)
+		description => [
+			x(
+				'Unlock an additional version of a test.  If used before the close date of '
+					. 'the test this will allow you to generate a new version of the test.'
+			)
+		]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/DoubleProb.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleProb.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'DoubleProb',
 		name        => x('Cupcake of Enlargement'),
-		description => x('Causes a single homework problem to be worth twice as much.')
+		description => [ x('Causes a single homework problem to be worth twice as much.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/DoubleSet.pm
+++ b/lib/WeBWorK/AchievementItems/DoubleSet.pm
@@ -6,11 +6,12 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'DoubleSet',
 		name        => x('Cake of Enlargement'),
-		description => x('Cause the selected homework set to count for twice as many points as it normally would.')
+		description =>
+			[ x('Cause the selected homework set to count for twice as many points as it normally would.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/DuplicateProb.pm
+++ b/lib/WeBWorK/AchievementItems/DuplicateProb.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(between);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'DuplicateProb',
 		name        => x('Box of Transmogrification'),
-		description => x('Causes a homework problem to become a clone of another problem from the same set.')
+		description => [ x('Causes a homework problem to become a clone of another problem from the same set.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDate.pm
@@ -1,34 +1,42 @@
 package WeBWorK::AchievementItems::ExtendDueDate;
 use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
-# Item to extend a close date by 24 hours.
+# Item to extend a close date by 24 * $achievementExtensionFactor hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(before after between);
+use WeBWorK::Utils::DateTime qw(before after between getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDate',
 		name        => x('Tunic of Extension'),
-		description => x(
-			'Adds 24 hours to the close date of a homework. '
-				. 'This will randomize problem details if used after the original close date.'
-		)
+		description => [
+			x(
+				'Adds [_1] to the close date of a homework. '
+					. 'This will randomize problem details if used after the original close date.',
+				$timeText
+			)
+		],
+		time     => $time,
+		timeText => $timeText
 	}, $class;
 }
 
 sub can_use ($self, $set, $records, $c) {
-	return $set->assignment_type eq 'default' && between($set->open_date, $set->due_date + ONE_DAY);
+	return $set->assignment_type eq 'default' && between($set->open_date, $set->due_date + $self->{time});
 }
 
 sub print_form ($self, $set, $records, $c) {
 	my $randomization_statement = after($set->due_date) ? $c->maketext('All problems will be rerandomized.') : '';
 	if ($set->enable_reduced_scoring) {
-		if (before($set->reduced_scoring_date + ONE_DAY)) {
+		if (before($set->reduced_scoring_date + $self->{time})) {
 			return $c->c(
-				$c->tag('p', $c->maketext('Extend the deadline by 24 hours. [_1]', $randomization_statement)),
+				$c->tag(
+					'p',
+					$c->maketext('Extend the deadline by [_1]. [_2]', $self->{timeText}, $randomization_statement)
+				),
 				$c->tag(
 					'ul',
 					$c->c(
@@ -37,7 +45,7 @@ sub print_form ($self, $set, $records, $c) {
 							$c->maketext(
 								'You will be able to receive full credit until [_1].',
 								$c->formatDateTime(
-									$set->reduced_scoring_date + ONE_DAY,
+									$set->reduced_scoring_date + $self->{time},
 									$c->ce->{studentDateDisplayFormat}
 								)
 							)
@@ -46,7 +54,10 @@ sub print_form ($self, $set, $records, $c) {
 							'li',
 							$c->maketext(
 								'You will be able to receive reduced credit until [_1].',
-								$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+								$c->formatDateTime(
+									$set->due_date + $self->{time},
+									$c->ce->{studentDateDisplayFormat}
+								)
 							)
 						)
 					)->join('')
@@ -57,8 +68,9 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Extend the reduced credit deadline of this assignment to [_1] (an additional 24 hours). [_2]',
-						$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat}),
+						'Extend the reduced credit deadline of this assignment to [_1] (an additional [_2]). [_3]',
+						$c->formatDateTime($set->due_date + $self->{time}, $c->ce->{studentDateDisplayFormat}),
+						$self->{timeText},
 						$randomization_statement
 					)
 				),
@@ -76,8 +88,9 @@ sub print_form ($self, $set, $records, $c) {
 		return $c->tag(
 			'p',
 			$c->maketext(
-				'Extend the close date of this assignment to [_1] (an additional 24 hours). [_2]',
-				$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat}),
+				'Extend the close date of this assignment to [_1] (an additional [_2]). [_3]',
+				$c->formatDateTime($set->due_date + $self->{time}, $c->ce->{studentDateDisplayFormat}),
+				$self->{timeText},
 				$randomization_statement
 			)
 		);
@@ -104,11 +117,11 @@ sub use_item ($self, $set, $records, $c) {
 
 	# Add time to the reduced scoring date if it was defined in the first place
 	if ($set->reduced_scoring_date) {
-		$set->reduced_scoring_date($set->reduced_scoring_date + ONE_DAY);
+		$set->reduced_scoring_date($set->reduced_scoring_date + $self->{time});
 		$userSet->reduced_scoring_date($set->reduced_scoring_date);
 	}
 	# Add time to the close date
-	$set->due_date($set->due_date + ONE_DAY);
+	$set->due_date($set->due_date + $self->{time});
 	$userSet->due_date($set->due_date);
 	# This may require also extending the answer date.
 	if ($set->due_date > $set->answer_date) {
@@ -117,10 +130,8 @@ sub use_item ($self, $set, $records, $c) {
 	}
 	$db->putUserSet($userSet);
 
-	return $c->maketext(
-		'Close date of this assignment extended by 24 hours to [_1].',
-		$c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat})
-	);
+	return $c->maketext('Close date of this assignment extended by [_1] to [_2].',
+		$self->{timeText}, $c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat}));
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -4,15 +4,17 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend the close date on a test
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(before between);
+use WeBWorK::Utils::DateTime qw(before between getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ExtendDueDateGW',
 		name        => x('Amulet of Extension'),
-		description => x('Extends the close date of a test by 24 hours.')
+		description => [ x('Extends the close date of a test by [_1].', $timeText) ],
+		time        => $time,
+		timeText    => $timeText,
 	}, $class;
 }
 
@@ -20,14 +22,14 @@ sub can_use ($self, $set, $records, $c) {
 	return
 		$set->assignment_type =~ /gateway/
 		&& $set->set_id !~ /,v\d+$/
-		&& between($set->open_date, $set->due_date + ONE_DAY);
+		&& between($set->open_date, $set->due_date + $self->{time});
 }
 
 sub print_form ($self, $set, $records, $c) {
 	if ($set->enable_reduced_scoring) {
-		if (before($set->reduced_scoring_date + ONE_DAY)) {
+		if (before($set->reduced_scoring_date + $self->{time})) {
 			return $c->c(
-				$c->tag('p', $c->maketext('Extend the deadline by 24 hours.')),
+				$c->tag('p', $c->maketext('Extend the deadline by [_1].', $self->{timeText})),
 				$c->tag(
 					'ul',
 					$c->c(
@@ -36,7 +38,7 @@ sub print_form ($self, $set, $records, $c) {
 							$c->maketext(
 								'You will be able to receive full credit until [_1].',
 								$c->formatDateTime(
-									$set->reduced_scoring_date + ONE_DAY,
+									$set->reduced_scoring_date + $self->{time},
 									$c->ce->{studentDateDisplayFormat}
 								)
 							)
@@ -45,7 +47,10 @@ sub print_form ($self, $set, $records, $c) {
 							'li',
 							$c->maketext(
 								'You will be able to receive reduced credit until [_1].',
-								$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+								$c->formatDateTime(
+									$set->due_date + $self->{time},
+									$c->ce->{studentDateDisplayFormat}
+								)
 							)
 						)
 					)->join('')
@@ -56,8 +61,9 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Extend the reduced credit deadline of this assignment to [_1] (an additional 24 hours).',
-						$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+						'Extend the reduced credit deadline of this assignment to [_1] (an additional [_2]).',
+						$c->formatDateTime($set->due_date + $self->{time}, $c->ce->{studentDateDisplayFormat}),
+						$self->{timeText}
 					)
 				),
 				$c->tag(
@@ -74,8 +80,9 @@ sub print_form ($self, $set, $records, $c) {
 		return $c->tag(
 			'p',
 			$c->maketext(
-				'Extend the close date of this assignment to [_1] (an additional 24 hours).',
-				$c->formatDateTime($set->due_date + ONE_DAY, $c->ce->{studentDateDisplayFormat})
+				'Extend the close date of this assignment to [_1] (an additional [_2]).',
+				$c->formatDateTime($set->due_date + $self->{time}, $c->ce->{studentDateDisplayFormat}),
+				$self->{timeText}
 			)
 		);
 	}
@@ -87,12 +94,12 @@ sub use_item ($self, $set, $records, $c) {
 
 	# Add time to the reduced scoring date, due date, and answer date.
 	if ($set->reduced_scoring_date) {
-		$set->reduced_scoring_date($set->reduced_scoring_date + ONE_DAY);
+		$set->reduced_scoring_date($set->reduced_scoring_date + $self->{time});
 		$userSet->reduced_scoring_date($set->reduced_scoring_date);
 	}
-	$set->due_date($set->due_date + ONE_DAY);
+	$set->due_date($set->due_date + $self->{time});
 	$userSet->due_date($set->due_date);
-	$set->answer_date($set->answer_date + ONE_DAY);
+	$set->answer_date($set->answer_date + $self->{time});
 	$userSet->answer_date($set->answer_date);
 	$db->putUserSet($userSet);
 
@@ -102,15 +109,15 @@ sub use_item ($self, $set, $records, $c) {
 	#my @versions = $db->listSetVersions($userName, $setID);
 	#for my $version (@versions) {
 	#	$set = $db->getSetVersion($userName, $setID, $version);
-	#	$set->reduced_scoring_date($set->reduced_scoring_date() + ONE_DAY)
+	#	$set->reduced_scoring_date($set->reduced_scoring_date() + $self->{time})
 	#		if defined($set->reduced_scoring_date()) && $set->reduced_scoring_date();
-	#	$set->due_date($set->due_date() + ONE_DAY);
-	#	$set->answer_date($set->answer_date() + ONE_DAY);
+	#	$set->due_date($set->due_date() + $self->{time});
+	#	$set->answer_date($set->answer_date() + $self->{time});
 	#	$db->putSetVersion($set);
 	#}
 
-	return $c->maketext('Close date of this test extended by 24 hours to [_1].',
-		$c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat}));
+	return $c->maketext('Close date of this test extended by [_1] to [_2].',
+		$self->{timeText}, $c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat}));
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/ExtendReducedDate.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendReducedDate.pm
@@ -1,22 +1,27 @@
 package WeBWorK::AchievementItems::ExtendReducedDate;
 use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
-# Item to extend a close date by 24 hours.
+# Item to extend a close date by 24 * $achievementExtensionFactor hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(between getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ExtendReducedDate',
 		name        => x('Scroll of Extension'),
-		description => x(
-			'Adds 24 hours to the reduced scoring date of an assignment.  You will have to resubmit '
-				. 'any problems that have already been penalized to earn full credit.  You cannot '
-				. 'extend the reduced scoring date beyond the due date of an assignment.'
-		)
+		description => [
+			x(
+				'Adds [_1] to the reduced scoring date of an assignment.  You will have to resubmit '
+					. 'any problems that have already been penalized to earn full credit.  You cannot '
+					. 'extend the reduced scoring date beyond the due date of an assignment.',
+				$timeText
+			)
+		],
+		time     => $time,
+		timeText => $timeText
 	}, $class;
 }
 
@@ -28,7 +33,7 @@ sub can_use ($self, $set, $records, $c) {
 		&& $set->reduced_scoring_date
 		&& $set->reduced_scoring_date < $set->due_date;
 
-	$self->{new_date} = $set->reduced_scoring_date + ONE_DAY;
+	$self->{new_date} = $set->reduced_scoring_date + $self->{time};
 	$self->{new_date} = $set->due_date if $set->due_date < $self->{new_date};
 	return between($set->open_date, $self->{new_date});
 }
@@ -45,8 +50,9 @@ sub print_form ($self, $set, $records, $c) {
 	return $c->tag(
 		'p',
 		$c->maketext(
-			'Extend the reduced scoring date to [_1] (an additional 24 hours).',
-			$c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat})
+			'Extend the reduced scoring date to [_1] (an additional [_2]).',
+			$c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat}),
+			$self->{timeText}
 		)
 	);
 }
@@ -61,10 +67,8 @@ sub use_item ($self, $set, $records, $c) {
 	$userSet->reduced_scoring_date($set->reduced_scoring_date);
 	$db->putUserSet($userSet);
 
-	return $c->maketext(
-		'Reduced scoring date of this assignment extended by 24 hours to [_1].',
-		$c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat})
-	);
+	return $c->maketext('Reduced scoring date of this assignment extended by [_1] to [_2].',
+		$self->{timeText}, $c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat}));
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/FullCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditProb.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x wwRound);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'FullCreditProb',
 		name        => x('Greater Rod of Revelation'),
-		description => x('Gives full credit on a single homework problem.')
+		description => [ x('Gives full credit on a single homework problem.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x wwRound);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'FullCreditSet',
 		name        => x('Greater Tome of Enlightenment'),
-		description => x('Gives full credit on every problem in a set.')
+		description => [ x('Gives full credit on every problem in a set.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditProb.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x wwRound);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'HalfCreditProb',
 		name        => x('Lesser Rod of Revelation'),
-		description => x('Increases the grade of a single problem by 50%, to a maximum of 100%.')
+		description => [ x('Increases the grade of a single problem by 50%, to a maximum of 100%.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x wwRound);
 use WeBWorK::Utils::DateTime qw(after);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'HalfCreditSet',
 		name        => x('Lesser Tome of Enlightenment'),
-		description => x('Increases the score of every problem in an assignment by 50%, to a maximum of 100%.')
+		description => [ x('Increases the score of every problem in an assignment by 50%, to a maximum of 100%.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/NoReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/NoReducedCred.pm
@@ -7,14 +7,16 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(between);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'NoReducedCred',
 		name        => x('Potion of Power'),
-		description => x(
-			'Remove reduced scoring penalties from an open assignment.  You will have to resubmit '
-				. 'any problems that have already been penalized to earn full credit on them.'
-		)
+		description => [
+			x(
+				'Remove reduced scoring penalties from an open assignment.  You will have to resubmit '
+					. 'any problems that have already been penalized to earn full credit on them.'
+			)
+		]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/ReducedCred.pm
+++ b/lib/WeBWorK/AchievementItems/ReducedCred.pm
@@ -1,28 +1,33 @@
 package WeBWorK::AchievementItems::ReducedCred;
 use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
-# Item to extend a close date by 24 hours for reduced credit
+# Item to extend a close date by 24 * $achievementExtensionFactor hours for reduced credit
 # Reduced scoring needs to be enabled for this item to work.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(after between);
+use WeBWorK::Utils::DateTime qw(after between getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ReducedCred',
 		name        => x('Ring of Reduction'),
-		description => x(
-			'Enable reduced scoring for a homework set.  This will allow you to submit answers '
-				. 'for partial credit for 24 hours after the close date. '
-				. 'This will randomize problem details if used after the original close date.'
-		)
+		description => [
+			x(
+				'Enable reduced scoring for a homework set.  This will allow you to submit answers '
+					. 'for partial credit for [_1] after the close date. '
+					. 'This will randomize problem details if used after the original close date.',
+				$timeText
+			)
+		],
+		time     => $time,
+		timeText => $timeText
 	}, $class;
 }
 
 sub can_use ($self, $set, $records, $c) {
-	return $set->assignment_type eq 'default' && between($set->open_date, $set->due_date + ONE_DAY);
+	return $set->assignment_type eq 'default' && between($set->open_date, $set->due_date + $self->{time});
 }
 
 sub print_form ($self, $set, $records, $c) {
@@ -40,9 +45,10 @@ sub print_form ($self, $set, $records, $c) {
 	return $c->tag(
 		'p',
 		$c->maketext(
-			'Extend the close date of this assignment to [_1] (an additional 24 hours).  Any submissions during '
-				. 'this additional time will be reduced and are worth [_2]% of their full value. [_3]',
-			$c->formatDateTime($set->due_date + ONE_DAY, $ce->{studentDateDisplayFormat}),
+			'Extend the close date of this assignment to [_1] (an additional [_2]).  Any submissions during '
+				. 'this additional time will be reduced and are worth [_3]% of their full value. [_4]',
+			$c->formatDateTime($set->due_date + $self->{time}, $ce->{studentDateDisplayFormat}),
+			$self->{timeText},
 			100 * $ce->{pg}{ansEvalDefaults}{reducedScoringValue},
 			$randomization_statement
 		)
@@ -79,7 +85,7 @@ sub use_item ($self, $set, $records, $c) {
 	$set->enable_reduced_scoring(1);
 	$userSet->enable_reduced_scoring(1);
 	# Add time to the close date
-	$set->due_date($set->due_date + ONE_DAY);
+	$set->due_date($set->due_date + $self->{time});
 	$userSet->due_date($set->due_date);
 	# This may require also extending the answer date.
 	if ($set->due_date > $set->answer_date) {
@@ -88,10 +94,8 @@ sub use_item ($self, $set, $records, $c) {
 	}
 	$db->putUserSet($userSet);
 
-	return $c->maketext(
-		'Close date of this assignment extended by 24 hours to [_1].',
-		$c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat})
-	);
+	return $c->maketext('Close date of this assignment extended by [_1] to [_2].',
+		$self->{timeText}, $c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat}));
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
+++ b/lib/WeBWorK/AchievementItems/ResetIncorrectAttempts.pm
@@ -6,11 +6,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 use WeBWorK::Utils           qw(x);
 use WeBWorK::Utils::DateTime qw(between);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'ResetIncorrectAttempts',
 		name        => x('Potion of Forgetfulness'),
-		description => x('Resets the number of incorrect attempts on a single homework problem.')
+		description => [ x('Resets the number of incorrect attempts on a single homework problem.') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/AchievementItems/ResurrectGW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectGW.pm
@@ -4,21 +4,26 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 # Item to extend the due date on a gateway
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(after);
+use WeBWorK::Utils::DateTime qw(after getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ResurrectGW',
 		name        => x('Necromancers Charm'),
-		description => x(
-			'Reopens any test for an additional 24 hours. If you are allowed to start new versions of the test, '
-				. 'then this allows you to start a new test even if the close date has past. '
-				. 'If you were not allowed to start a new version of the test, '
-				. 'then this item will not allow you to take additional versions of the test. '
-				. 'This item will not extend the time limit for any tests that you have already started.'
-		)
+		description => [
+			x(
+				'Reopens any test for an additional [_1]. If you are allowed to start new versions of the test, '
+					. 'then this allows you to start a new test even if the close date has past. '
+					. 'If you were not allowed to start a new version of the test, '
+					. 'then this item will not allow you to take additional versions of the test. '
+					. 'This item will not extend the time limit for any tests that you have already started.',
+				$timeText
+			)
+		],
+		time     => $time,
+		timeText => $timeText
 	}, $class;
 }
 
@@ -38,23 +43,25 @@ sub print_form ($self, $set, $records, $c) {
 		return $c->tag(
 			'p',
 			$c->maketext(
-				'Reopen this test for the next 24 hours. If you were allowed to start new versions of the test, '
+				'Reopen this test for the next [_1]. If you were allowed to start new versions of the test, '
 					. 'then this will allow you to start a new test. '
 					. 'If you have already started all of the versions of the test that you are allowed to start, '
 					. 'then you should not use this item. '
-					. 'This item will not extend the time limit for any tests that you have already started.'
+					. 'This item will not extend the time limit for any tests that you have already started.',
+				$self->{timeText}
 			)
 		);
 	} else {
-		if (after($set->due_date - ONE_DAY)) {
+		if (after($set->due_date - $self->{time})) {
 			return $c->tag(
 				'p',
 				$c->maketext(
-					'Reopen this test for full credit for the next 24 hours. If you are allowed to start new versions '
+					'Reopen this test for full credit for the next [_1]. If you are allowed to start new versions '
 						. 'of the test, then this will allow you to start a new test. '
 						. 'If you have already started all of the versions of the test that you are allowed to start, '
 						. 'then you should not use this item. '
-						. 'This item will not extend the time limit for any tests that you have already started.'
+						. 'This item will not extend the time limit for any tests that you have already started.',
+					$self->{timeText}
 				)
 			);
 		} else {
@@ -62,8 +69,9 @@ sub print_form ($self, $set, $records, $c) {
 				$c->tag(
 					'p',
 					$c->maketext(
-						'Reopen this test for full credit for the next 24 hours.  After 24 hours any tests will revert '
-							. 'to counting for [_1]% of their value until [_2].',
+						'Reopen this test for full credit for the next [_1].  After [_1] any tests will revert '
+							. 'to counting for [_2]% of their value until [_3].',
+						$c->{timeText},
 						$c->ce->{pg}{ansEvalDefaults}{reducedScoringValue} * 100,
 						$c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat})
 					)
@@ -89,11 +97,11 @@ sub use_item ($self, $set, $records, $c) {
 
 	# Add time to the reduced scoring date, due date, and answer date.
 	if ($set->reduced_scoring_date) {
-		$set->reduced_scoring_date(time + ONE_DAY);
+		$set->reduced_scoring_date(time + $self->{time});
 		$userSet->reduced_scoring_date($set->reduced_scoring_date);
 	}
-	if (after($set->due_date - ONE_DAY)) {
-		$set->due_date(time + ONE_DAY);
+	if (after($set->due_date - $self->{time})) {
+		$set->due_date(time + $self->{time});
 		$userSet->due_date($set->due_date);
 		if ($set->due_date > $set->answer_date) {
 			$set->answer_date($set->due_date);

--- a/lib/WeBWorK/AchievementItems/ResurrectHW.pm
+++ b/lib/WeBWorK/AchievementItems/ResurrectHW.pm
@@ -1,18 +1,20 @@
 package WeBWorK::AchievementItems::ResurrectHW;
 use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
-# Item to resurrect a homework for 24 hours
+# Item to resurrect a homework for 24 * $achievementExtensionFactor hours
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(after);
+use WeBWorK::Utils::DateTime qw(after getExtensionTime);
 
-use constant ONE_DAY => 86400;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 1);
 
-sub new ($class) {
 	return bless {
 		id          => 'ResurrectHW',
 		name        => x('Scroll of Resurrection'),
-		description => x("Reopens one closed homework set for 24 hours and rerandomizes all problems."),
+		description => [ x('Reopens one closed homework set for [_1] and rerandomizes all problems.', $timeText) ],
+		time        => $time,
+		timeText    => $timeText
 	}, $class;
 }
 
@@ -31,18 +33,26 @@ sub print_form ($self, $set, $records, $c) {
 		return $c->tag(
 			'p',
 			$c->maketext(
-				'Reopen this homework assignment for the next 24 hours. All problems will be rerandomized.')
+				'Reopen this homework assignment for the next [_1]. All problems will be rerandomized.',
+				$self->{timeText}
+			)
 		);
 	} else {
-		if (after($set->due_date - ONE_DAY)) {
-			return $c->tag('p',
-				$c->maketext('Reopen this homework assignment for full credit for the next 24 hours. '));
+		if (after($set->due_date - $self->{time})) {
+			return $c->tag(
+				'p',
+				$c->maketext(
+					'Reopen this homework assignment for full credit for the next [_1]. ',
+					$self->{timeText}
+				)
+			);
 		} else {
 			return $c->tag(
 				'p',
 				$c->maketext(
-					'Reopen this homework assignment for full credit for the next 24 hours. After 24 hours '
-						. 'any progress will revert to counting for [_1]% of the value until [_2].',
+					'Reopen this homework assignment for full credit for the next [_1]. After [_1] '
+						. 'any progress will revert to counting for [_2]% of the value until [_3].',
+					$self->{timeText},
 					$c->ce->{pg}{ansEvalDefaults}{reducedScoringValue} * 100,
 					$c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat})
 				)
@@ -72,12 +82,12 @@ sub use_item ($self, $set, $records, $c) {
 
 	# Add time to the reduced scoring date if it was defined in the first place
 	if ($set->reduced_scoring_date) {
-		$set->reduced_scoring_date(time + ONE_DAY);
+		$set->reduced_scoring_date(time + $self->{time});
 		$userSet->reduced_scoring_date($set->reduced_scoring_date);
 	}
 	# Add time to the close date if necessary
-	if (after($set->due_date - ONE_DAY)) {
-		$set->due_date(time + ONE_DAY);
+	if (after($set->due_date - $self->{time})) {
+		$set->due_date(time + $self->{time});
 		$userSet->due_date($set->due_date);
 		# This may require also extending the answer date.
 		if ($set->due_date > $set->answer_date) {

--- a/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendDueDate.pm
@@ -1,125 +1,27 @@
 package WeBWorK::AchievementItems::SuperExtendDueDate;
-use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
+use Mojo::Base 'WeBWorK::AchievementItems::ExtendDueDate', -signatures;
 
-# Item to extend a close date by 48 hours.
+# Item to extend a close date by 48 * $achievementExtensionFactor hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(before after between);
+use WeBWorK::Utils::DateTime qw(getExtensionTime);
 
-use constant TWO_DAYS => 172800;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 2);
 
-sub new ($class) {
 	return bless {
 		id          => 'SuperExtendDueDate',
 		name        => x('Robe of Longevity'),
-		description => x(
-			'Adds 48 hours to the close date of a homework. '
-				. 'This will randomize problem details if used after the original close date.'
-		)
-	}, $class;
-}
-
-sub can_use ($self, $set, $records, $c) {
-	return $set->assignment_type eq 'default' && between($set->open_date, $set->due_date + TWO_DAYS);
-}
-
-sub print_form ($self, $set, $records, $c) {
-	my $randomization_statement = after($set->due_date) ? $c->maketext('All problems will be rerandomized.') : '';
-	if ($set->enable_reduced_scoring) {
-		if (before($set->reduced_scoring_date + TWO_DAYS)) {
-			return $c->c(
-				$c->tag('p', $c->maketext('Extend the deadline by 48hours. [_1]', $randomization_statement)),
-				$c->tag(
-					'ul',
-					$c->c(
-						$c->tag(
-							'li',
-							$c->maketext(
-								'You will be able to receive full credit until [_1].',
-								$c->formatDateTime(
-									$set->reduced_scoring_date + TWO_DAYS,
-									$c->ce->{studentDateDisplayFormat}
-								)
-							)
-						),
-						$c->tag(
-							'li',
-							$c->maketext(
-								'You will be able to receive reduced credit until [_1].',
-								$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat})
-							)
-						)
-					)->join('')
-				),
-			)->join('');
-		} else {
-			return $c->c(
-				$c->tag(
-					'p',
-					$c->maketext(
-						'Extend the reduced credit deadline of this assignment to [_1] (an additional 48 hours). [_2]',
-						$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat}),
-						$randomization_statement
-					)
-				),
-				$c->tag(
-					'p',
-					$c->maketext(
-						'Because the deadline has already passed you will only '
-							. 'receive reduced credit during this extension.'
-					)
-				)
-			)->join('');
-		}
-
-	} else {
-		return $c->tag(
-			'p',
-			$c->maketext(
-				'Extend the close date of this assignment to [_1] (an additional 48 hours). [_2]',
-				$c->formatDateTime($set->due_date + TWO_DAYS, $c->ce->{studentDateDisplayFormat}),
-				$randomization_statement
+		description => [
+			x(
+				'Adds [_1] to the close date of a homework. '
+					. 'This will randomize problem details if used after the original close date.',
+				$timeText
 			)
-		);
-	}
-}
-
-sub use_item ($self, $set, $records, $c) {
-	my $db      = $c->db;
-	my $userSet = $db->getUserSet($set->user_id, $set->set_id);
-
-	# Change the seed for all of the problems if the set is currently closed.
-	if (after($set->due_date)) {
-		my %userProblems =
-			map { $_->problem_id => $_ }
-			$db->getUserProblemsWhere({ user_id => $set->user_id, set_id => $set->set_id });
-		for my $problem (@$records) {
-			my $userProblem = $userProblems{ $problem->problem_id };
-			$userProblem->problem_seed($userProblem->problem_seed % 2**31 + 1);
-			$problem->problem_seed($userProblem->problem_seed);
-			$db->putUserProblem($userProblem);
-		}
-	}
-
-	# Add time to the reduced scoring date if it was defined in the first place
-	if ($set->reduced_scoring_date) {
-		$set->reduced_scoring_date($set->reduced_scoring_date + TWO_DAYS);
-		$userSet->reduced_scoring_date($set->reduced_scoring_date);
-	}
-	# Add time to the close date
-	$set->due_date($set->due_date + TWO_DAYS);
-	$userSet->due_date($set->due_date);
-	# This may require also extending the answer date.
-	if ($set->due_date > $set->answer_date) {
-		$set->answer_date($set->due_date);
-		$userSet->answer_date($set->answer_date);
-	}
-	$db->putUserSet($userSet);
-
-	return $c->maketext(
-		'Close date of this assignment extended by 48 hours to [_1].',
-		$c->formatDateTime($set->due_date, $c->ce->{studentDateDisplayFormat})
-	);
+		],
+		time     => $time,
+		timeText => $timeText
+	}, $class;
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/SuperExtendReducedDate.pm
+++ b/lib/WeBWorK/AchievementItems/SuperExtendReducedDate.pm
@@ -1,69 +1,28 @@
 package WeBWorK::AchievementItems::SuperExtendReducedDate;
-use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
+use Mojo::Base 'WeBWorK::AchievementItems::ExtendReducedDate', -signatures;
 
-# Item to extend a close date by 48 hours.
+# Item to extend a close date by 48 * $achievementExtensionFactor hours.
 
 use WeBWorK::Utils           qw(x);
-use WeBWorK::Utils::DateTime qw(between);
+use WeBWorK::Utils::DateTime qw(getExtensionTime);
 
-use constant TWO_DAYS => 172800;
+sub new ($class, $c) {
+	my ($time, $timeText) = getExtensionTime($c, 2);
 
-sub new ($class) {
 	return bless {
 		id          => 'SuperExtendReducedDate',
 		name        => x('Scroll of Longevity'),
-		description => x(
-			'Adds 48 hours to the reduced scoring date of an assignment.  You will have to resubmit '
-				. 'any problems that have already been penalized to earn full credit.  You cannot '
-				. 'extend the reduced scoring date beyond the due date of an assignment.'
-		)
+		description => [
+			x(
+				'Adds [_1] to the reduced scoring date of an assignment.  You will have to resubmit '
+					. 'any problems that have already been penalized to earn full credit.  You cannot '
+					. 'extend the reduced scoring date beyond the due date of an assignment.',
+				$timeText
+			)
+		],
+		time     => $time,
+		timeText => $timeText
 	}, $class;
-}
-
-sub can_use ($self, $set, $records, $c) {
-	return 0
-		unless $set->assignment_type eq 'default'
-		&& $set->enable_reduced_scoring
-		&& $set->reduced_scoring_date
-		&& $set->reduced_scoring_date < $set->due_date;
-
-	$self->{new_date} = $set->reduced_scoring_date + TWO_DAYS;
-	$self->{new_date} = $set->due_date if $set->due_date < $self->{new_date};
-	return between($set->open_date, $self->{new_date});
-}
-
-sub print_form ($self, $set, $records, $c) {
-	return $c->tag(
-		'p',
-		$c->maketext(
-			q{This item won't work unless your instructor enables the reduced scoring feature.  }
-				. 'Let your instructor know that you received this message.'
-		)
-	) unless $c->{ce}->{pg}{ansEvalDefaults}{enableReducedScoring};
-
-	return $c->tag(
-		'p',
-		$c->maketext(
-			'Extend the reduced scoring date to [_1] (an additional 48 hours).',
-			$c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat})
-		)
-	);
-}
-
-sub use_item ($self, $set, $records, $c) {
-	return '' unless $c->{ce}->{pg}{ansEvalDefaults}{enableReducedScoring};
-
-	my $db      = $c->db;
-	my $userSet = $db->getUserSet($set->user_id, $set->set_id);
-
-	$set->reduced_scoring_date($self->{new_date});
-	$userSet->reduced_scoring_date($set->reduced_scoring_date);
-	$db->putUserSet($userSet);
-
-	return $c->maketext(
-		'Reduced scoring date of this assignment extended by 48 hours to [_1].',
-		$c->formatDateTime($self->{new_date}, $c->ce->{studentDateDisplayFormat})
-	);
 }
 
 1;

--- a/lib/WeBWorK/AchievementItems/Surprise.pm
+++ b/lib/WeBWorK/AchievementItems/Surprise.pm
@@ -5,11 +5,11 @@ use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
 use WeBWorK::Utils qw(x);
 
-sub new ($class) {
+sub new ($class, $c) {
 	return bless {
 		id          => 'Surprise',
 		name        => x('Mysterious Package (with Ribbons)'),
-		description => x('What could be inside?')
+		description => [ x('What could be inside?') ]
 	}, $class;
 }
 

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -322,6 +322,21 @@ sub getConfigValues ($ce) {
 				type => 'boolean'
 			},
 			{
+				var  => 'achievementExtensionFactor',
+				doc  => x('Multiplicative time factor for extension achievement items'),
+				doc2 => x(
+					'This sets the time factor which affects the extension time for the extension achievement items. '
+						. 'This factor is multiplied by the base extension time of 24 hours to determine the '
+						. 'extension time. In effect, this is the number of days of the extension. If this factor is '
+						. 'not a whole number, then the resulting time is rounded to the nearest full hour, and '
+						. 'cannot be less than 1 hour. This affects the extension achievement items "ExtendDueDate", '
+						. '"ExtendDueDateGW", "ExtendReducedDate", "ReducedCred", "ResurrectGW", and "ResurrectHW". '
+						. 'The two super extensions, "SuperExtendDueDate" and "SuperExtendedReducedDate", will have '
+						. 'double the time.'
+				),
+				type => 'number'
+			},
+			{
 				var  => 'achievementExcludeSet',
 				doc  => x('List of sets excluded from achievements'),
 				doc2 => x(

--- a/lib/WeBWorK/Utils/DateTime.pm
+++ b/lib/WeBWorK/Utils/DateTime.pm
@@ -3,7 +3,8 @@ use Mojo::Base 'Exporter', -signatures;
 
 use DateTime;
 use DateTime::TimeZone;
-use Time::Zone qw(tz_offset);
+use Time::Zone     qw(tz_offset);
+use WeBWorK::Utils qw(max);
 
 our @EXPORT_OK = qw(
 	before
@@ -13,6 +14,7 @@ our @EXPORT_OK = qw(
 	getDefaultSetDueDate
 	parseDateTime
 	timeToSec
+	getExtensionTime
 );
 
 sub before ($time, $now = time) { return $now < $time }
@@ -226,6 +228,26 @@ sub verify_timezone ($display_tz) {
 	return 'America/New_York';
 }
 
+sub getExtensionTime ($c, $base) {
+	my $hours    = $base * max(int($c->ce->{achievementExtensionFactor} * 24 + 0.5), 1);
+	my $time     = 3600 * $hours;
+	my $days     = int($hours / 24);
+	my $timeText = '';
+
+	if ($days > 2) {
+		$hours -= 24 * $days;
+		if ($hours) {
+			$timeText = $c->maketext('[_1] days and [quant,_2,hour,hours]', $days, $hours);
+		} else {
+			$timeText = $c->maketext('[_1] days', $days);
+		}
+	} else {
+		$timeText = $c->maketext('[quant,_1,hour,hours]', $hours);
+	}
+
+	return ($time, $timeText);
+}
+
 1;
 
 =head1 NAME
@@ -310,5 +332,19 @@ and issue warning.
 
 Note that this method is not exported, and can only be used internally by this
 package.
+
+=head2 getExtensionTime
+
+Usage: C<getExtensionTime($c, $base)>
+
+Determines the length of an extension based on the course environment extension
+time factor setting and C<$base> time. The C<$base> time is the number of days
+for the base extension. The extension time is rounded to the nearest full hour
+and cannot be less than C<$base> hours.
+
+Returns an array consisting of the extension time in seconds and a translated
+string stating the length of the extension. The translated string will state
+the number of days and hours if greater than or equal to 3 days, otherwise
+state only the number of hours.
 
 =cut

--- a/templates/ContentGenerator/Achievements/achievement_items.html.ep
+++ b/templates/ContentGenerator/Achievements/achievement_items.html.ep
@@ -15,7 +15,7 @@
 		<dt>
 			<%= $item->remaining_title($c) %>
 		</dt>
-		<dd class="ms-3 mb-2"><%= maketext($item->description) %></dd>
+		<dd class="ms-3 mb-2"><%= maketext(@{ $item->description }) %></dd>
 	% }
 	</dl>
 % } else {


### PR DESCRIPTION
Add `$achievementExtensionFactor` setting that is used to configure the length of extensions. This works as a multiplicative factor, by multiplying the base time (either 24 or 48 hours) by the factor. The extension time is always rounded to the nearest hour, and cannot be less than a single hour (two hours for the super extensions).

This affects all items that have an extension time.

* ExtendDueDate
* ExtendDueDateGW
* ExtendReducedDate
* ReducedCred
* RessurectGW
* RessurectHW
* SuperExtendDueDate
* SuperExtendReducedDate
