### PR TITLE
Fix division by zero in {Full,Half}CreditSet Items.

### DIFF
--- a/lib/WeBWorK/AchievementItems/FullCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/FullCreditSet.pm
@@ -25,6 +25,8 @@ sub can_use ($self, $set, $records, $c) {
 		$grade += $problem->status * $problem->value;
 		$total += $problem->value;
 	}
+	return 0 unless $total;
+
 	$self->{old_grade} = 100 * wwRound(2, $grade / $total);
 	return $self->{old_grade} == 100 ? 0 : 1;
 }

--- a/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
+++ b/lib/WeBWorK/AchievementItems/HalfCreditSet.pm
@@ -27,6 +27,8 @@ sub can_use ($self, $set, $records, $c) {
 		$new_grade += ($problem->status > 0.5 ? 1 : $problem->status + 0.5) * $problem->value;
 		$total     += $problem->value;
 	}
+	return 0 unless $total;
+
 	$self->{old_grade} = 100 * wwRound(2, $old_grade / $total);
 	$self->{new_grade} = 100 * wwRound(2, $new_grade / $total);
 	return $self->{old_grade} == 100 ? 0 : 1;


### PR DESCRIPTION
If the total weight of a set is zero, due to either no problems in a set or weights set to zero, these items cause a division by zero not allowing a user to see the associated ProblemSet page.

This returns 0 in the can_use methods before dividing by zero in this case, fixing the issue.