### PR TITLE
Make sure that a proctored test becomes unproctored when graded by instructor. (hotfix of #2969)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -1248,7 +1248,7 @@ async sub pre_header_initialize ($c) {
 					($userID eq $effectiveUserID && !$can{recordAnswersNextTime})
 					|| (
 						$userID ne $effectiveUserID
-						&& $authz->hasPermissions($userID, 'record_answers_when_acting_as_student')
+						&& $can{recordAnswers}
 						&& $set->attempts_per_version > 0
 						&& ($problem->num_correct + $problem->num_incorrect + ($c->{submitAnswers} ? 1 : 0) >=
 							$set->attempts_per_version)


### PR DESCRIPTION
When an instructor uses the "Grade Test for" button and the test is on its final submission, currently the grading occurs, but the test is still set as a proctored test.

To fix this the condition that determines if the assignment type should be changed needs to check the `$can{recordAnswers}` value in the case that the `$userID` and `$effectiveUserID` are different.  In that case `$can{recordAnswers}` is the result of the `can_recordAnswers` method which will be true if either the user has the
`record_answers_when_acting_as_student` permission or the user can grade an unsubmitted test.

This fixes issue #2962.

The `GatewayQuiz.pm` module is really so convoluted at this point that it is really becoming impossible to do anything with, and is in desperate need of a complete overhaul and rewrite. Any time any new feature is added to the module or change is made to the module it is almost impossible to go through all of the possibilities and ensure you haven't broken something.