### PR TITLE
Fix colors on the proctor login page for dark mode. (Bootstrap alert aproach)

### DIFF
--- a/templates/ContentGenerator/LoginProctor.html.ep
+++ b/templates/ContentGenerator/LoginProctor.html.ep
@@ -16,14 +16,14 @@
 % # Print a message about submission times if we're submitting an answer.
 % if (param('submitAnswers')) {
 	% my $dueTime = $userSet->due_date;
-	% my ($color, $msg) = ('#ddddff', '');
+	% my ($alertClass, $msg) = ('alert-primary', '');
 	% if ($dueTime + $ce->{gatewayGracePeriod} < $submitTime) {
-		% $color = '#ffffaa';
+		% $alertClass = ' alert-warning';
 		% $msg = maketext('The time limit on this assignment was exceeded. The assignment may be checked, '
 			% . 'but the result will not be counted.');
 	% }
 	%
-	<div class="card mb-2" style="background-color:<%= $color %>;">
+	<div class="alert mb-2<%= $alertClass %>" role="alert">
 		<div class="card-body p-2">
 			<div class="card-title"><strong><%= maketext('Grading Assignment') %></strong></div>
 			<div class="card-text">
@@ -52,7 +52,7 @@
 		% || ($userSet->restricted_login_proctor eq '' || $userSet->restricted_login_proctor eq 'No'))
 	% {
 		% # The user info and username field for the proctor.
-		<div class="card p-2 mb-2" style="background-color:#ddddff;">
+		<div class="alert alert-primary card p-2 mb-2" role="alert">
 			<div><%= maketext(q{User's username is:}) %> <strong><%= param('effectiveUser') // '' %></strong></div>
 			<div>
 				<%= maketext(q{User's name is:}) %>
@@ -68,7 +68,7 @@
 		</div>
 	% } else {
 		% # Restricted set login
-		<div class="card p-2 mb-2" style="background-color:#ddddff;">
+		<div class="alert alert-primary card p-2 mb-2" role="alert">
 			<em>
 				<%= maketext(
 					'This set has a set-level proctor password to authorize logins. Enter the password below.') =%>


### PR DESCRIPTION
The colors for this were inline style.  Colors cannot be inline anymore since the server cannot detect if the user will have the browser in dark mode or not.  So this switches to using Bootstrap alerts instead.

This is an alternate approach to #2967.

One minor problem with this approach is that in the `math4-yellow` theme the difference between an `alert-primary` and an `alert-warning` is somewhat subtle.  Here is a screenshot demonstrating the two together with this pull request:
<img width="553" height="271" alt="proctor-login" src="https://github.com/user-attachments/assets/88dbc795-d8aa-4394-890d-2d6f25afa4a1" />
The first alert in that image is an `alert-warning` and the second is an `alert-primary`.