### PR TITLE
Fix an invalid localization string in a maketext call.

### DIFF
--- a/lib/WeBWorK/AchievementItems/Surprise.pm
+++ b/lib/WeBWorK/AchievementItems/Surprise.pm
@@ -26,7 +26,7 @@ sub print_form ($self, $set, $records, $c) {
 	# The form opens the file "surprise_message.txt" in the achievements
 	# folder and prints the contents of the file.
 	open my $MESSAGE, '<', "$c->{ce}{courseDirs}{achievements}/surprise_message.txt"
-		or return $c->tag('p', $c->maketext(q{I couldn't find the file [ACHIEVEMENT_DIR]/surprise_message.txt!}));
+		or return $c->tag('p', $c->maketext(q{I couldn't find the file ~[ACHIEVEMENT_DIR~]/surprise_message.txt!}));
 	local $/ = undef;
 	my $message = <$MESSAGE>;
 	close $MESSAGE;


### PR DESCRIPTION
Brackets in a string that are intended to be literal brackets need to be escaped.

To test this earn the "Mysterious Package (with Ribbons)" achievement reward, make sure the `templates/achievements/surprise_message.txt` file does NOT exist, and then open a problem set page.  With the WeBWorK-2.21 release candidate branch an exception is thrown.

This particular bug apparently has been there since 2015.