### PR TITLE
Remove a symbolic link accidentally added in #2979.

### DIFF
--- a/courses.dist/modelCourse/templates/Demo
+++ b/courses.dist/modelCourse/templates/Demo
@@ -1,1 +1,0 @@
-../../../webwork2/assets/pg/Demo


### PR DESCRIPTION
This was a remnant of my first approach for the Demo set of moving it to `assets/pg` and using a link in the model course, and then rewriting all of the problems using modern techniques. This link should not have made it into #2979.