### PR TITLE
Fix an invalid import that is causing warnings.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -8,7 +8,6 @@ WeBWorK::ContentGenerator::Logout - invalidate key and display logout message.
 =cut
 
 use WeBWorK::Localize;
-use WeBWorK::Authen qw(write_log_entry);
 
 sub pre_header_initialize ($c) {
 	my $ce     = $c->ce;
@@ -20,7 +19,7 @@ sub pre_header_initialize ($c) {
 	$authen->logout_user if $authen->can('logout_user');
 
 	$authen->killSession;
-	$authen->WeBWorK::Authen::write_log_entry('LOGGED OUT');
+	$authen->write_log_entry('LOGGED OUT');
 
 	# Check to see if there is a proctor key associated with this login.  If there is a proctor user, then there must be
 	# a proctored test.  So try and delete the key.


### PR DESCRIPTION
The `write_log_entry` method is imported from the `WeBWorK::Authen` package in `lib/WeBWorK/ContentGenerator/Logout.pm` (via the `use WeBWorK::Authen qw(write_log_entry)` call).  However, the `WeBWorK::Authen` package does not define the `import` method (since it does not derive from the `Exporter` package).  As a result warnings occur when this package is loaded.  These warnings have become more prevalant recently (perhaps the perl 5.40 is more strict on this?).

Also, the `write_log_entry` is incorrectly called later in that package. The `write_log_entry` method is an object method and there is no need for the package name in the call.