### PR TITLE
Add a course selection step in content item selection for LTI 1.3.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -242,6 +242,8 @@ $LTIMassUpdateInterval = 86400;
 	#'LMSManageUserData',
 	#'LTI{v1p1}{round_score_digits}',
 	#'LTI{v1p1}{BasicConsumerSecret}',
+	#'LTI{v1p3}{ignoreMissingSourcedID}',
+	#'LTI{v1p3}{autoSyncSetDatesToLMS}',
 	#'LTI{v1p3}{PlatformID}',
 	#'LTI{v1p3}{ClientID}',
 	#'LTI{v1p3}{DeploymentID}',

--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -261,4 +261,21 @@ $LTI{v1p3}{ignoreMissingSourcedID} = 0;
 
 $LTI{v1p3}{autoSyncSetDatesToLMS} = 0;
 
+# If this is set and an instructor attempts to use content selection from an LMS course that is
+# that is not in the LTI course map, then the instructor will be offered a list of WeBWorK
+# courses to choose from.  The WeBWorK courses that will be listed for the instructor are
+# courses that
+#
+# 1. have LTI 1.3 authentication parameters that match those sent by the LMS,
+# 2. have a user for the instructor, that
+#    - has the email address set that matches the email address sent from the LMS, and
+#    - has access_instructor_tools and modify_problem_sets permissions.
+#
+# Note that if only one course is found that satisfies the above conditions, then it will
+# be used automatically.
+#
+# This is a site wide setting only, and cannot be configured per course
+# (in the course.conf file of a course).
+$LTI{v1p3}{allowCourseSelection} = 0;
+
 1;    # final line of the file to reassure perl that it was read properly.

--- a/conf/authen_LTI_1_3.conf.dist
+++ b/conf/authen_LTI_1_3.conf.dist
@@ -83,6 +83,27 @@ $LTI{v1p3}{strip_domain_from_email} = 0;
 # lowercase.
 $LTI{v1p3}{lowercase_username} = 0;
 
+# When the names/roles service URL is used for roster synchronization the LMS may use a
+# different key in the sent data than is used when a user signs in via LTI authentication. Set
+# the following keys to the correct key for your LMS that provides the same identifier via the
+# names/roles service URL as when LTI authentication is used if the key for the
+# preferred_source_of_username or fallback_source_of_username is different. Note that the
+# 'email' key is the same for all LMSs according to the LTI 1.3 specification. So if
+# preferred_source_of_username or fallback_source_of_username is 'email', then you should not
+# set the respective setting below. Also, the 'sub' key obtained during LTI authentication will
+# always match the 'user_id' key obtained from the names/roles service URL according to the LTI
+# 1.3 specification.  So if preferred_source_of_username or fallback_source_of_username is
+# 'sub', then set the respective setting to 'user_id' below. For any other values of
+# preferred_source_of_username or fallback_source_of_username, set debug_lti_parameters to 1,
+# and compare the results when LTI authentication is performed and when using LMS roster
+# synchronization in the accounts manager to determine what (if anything) will work here.
+# Unfortunately, for values other than 'email' or 'sub', there is no guarantee that there will
+# be any valid key provided from the names/roles service URL, and so if you do not see anything
+# valid to use using debug_lti_parameters, then LTI roster synchronization in the accounts
+# manager is just not going to work for you.
+$LTI{v1p3}{namesroles_service_preferred_source_of_username} = '';
+$LTI{v1p3}{namesroles_service_fallback_source_of_username}  = '';
+
 ################################################################################################
 # LTI 1.3 Preferred source of Student Id
 ################################################################################################
@@ -91,6 +112,11 @@ $LTI{v1p3}{lowercase_username} = 0;
 # string. You should use debug_lti_parameters in order to determine the value to use for your
 # LMS.  There may be no claim value that provides this.
 $LTI{v1p3}{preferred_source_of_student_id} = '';
+
+# This is much the same as the namesroles_service_preferred_source_of_username and
+# namesroles_service_fallback_source_of_username above. See the documentation for those to
+# understand this setting.
+$LTI{v1p3}{namesroles_service_preferred_source_of_student_id} = '';
 
 ################################################################################################
 # LTI 1.3 Basic Authentication Parameters
@@ -212,14 +238,27 @@ $LTI{v1p3}{AllowInstitutionRoles} = 0;
 # Miscellaneous
 ################################################################################################
 
-# When grade passback mode is 'homework', someone must use a set-specific link from the LMS in
-# order for grade passback to begin happening for that set. Use of the set-specific link lets
-# WeBWorK store the set's "sourced_ID". So if there is no sourced_ID, the default behavior is
-# that a user in WeBWorK sees the sets as disabled and there is a message about needing to
-# access the set from the LMS. The following option can be set to allow users to work on the set
-# anyway. There will be no grade passback until some later time when an LMS user clicks the
-# set-specific link. In some LMSs, it is possible for the instructor to activate the link.
+# When grade passback mode is 'homework', webwork2 needs to have the lineitem URL for a set in
+# order for grade passback to occur. For manually created links to a webwork2 set in the LMS,
+# webwork2 obtains that URL the first time that someone uses the link, but for links created via
+# deep linking (content selection in the LMS), webwork2 can obtain that URL anytime it is
+# needed.  If webwork2 does not have the lineitem URL stored in the database, the default
+# behavior is that a user in webwork2 sees the sets as disabled, and there is a message about
+# needing to access the set from the LMS. The following option can be set to allow users to work
+# on the set anyway. For manually created links, there will be no grade passback until some
+# later time when an LMS user uses the set-specific link. Note that in most LMSs, the instructor
+# can activate a link by using it. For links created via deep linking, grade passback will
+# always work, but webwork2 will not store the lineitem URL until the first time that grade
+# passback occurs, someone uses the set-specific link, or set dates are synchronized to the LMS.
+# So if you create all links in the LMS using deep linking (content selection), then you will
+# most likely want to set the following option, because the message about needing to access the
+# set from the LMS that is shown in the LMS is simply not true anyway.
 
 $LTI{v1p3}{ignoreMissingSourcedID} = 0;
+
+# Set the following option if you want webwork2 to automatically synchronize set dates to the
+# LMS anytime that a set's open and close dates are changed.
+
+$LTI{v1p3}{autoSyncSetDatesToLMS} = 0;
 
 1;    # final line of the file to reassure perl that it was read properly.

--- a/htdocs/js/ProblemSetList/problemsetlist.js
+++ b/htdocs/js/ProblemSetList/problemsetlist.js
@@ -49,7 +49,14 @@
 		err_msg?.classList.remove('d-none');
 		if (!('set_table_id' in event_listeners)) {
 			event_listeners.set_table_id = hide_errors(
-				['filter_select', 'edit_select', 'publish_filter_select', 'export_select', 'score_select'],
+				[
+					'filter_select',
+					'edit_select',
+					'publish_filter_select',
+					'export_select',
+					'score_select',
+					'lms_date_sync_select'
+				],
 				[err_msg]
 			);
 			document.getElementById('set_table_id')?.addEventListener('change', event_listeners.set_table_id);
@@ -72,7 +79,7 @@
 				e.stopPropagation();
 				show_errors(['filter_err_msg'], [filter_select, filter_text]);
 			}
-		} else if (['edit', 'publish', 'export', 'score'].includes(action)) {
+		} else if (['edit', 'publish', 'export', 'score', 'lms_date_sync'].includes(action)) {
 			const action_select = document.getElementById(`${action}_select`);
 			if (action_select.value === 'selected' && !is_set_selected()) {
 				e.preventDefault();

--- a/lib/Mojolicious/WeBWorK.pm
+++ b/lib/Mojolicious/WeBWorK.pm
@@ -75,6 +75,7 @@ sub startup ($app) {
 	# WeBWorK::ContentGenerator::Instructor::JobManager.
 	$app->plugin(Minion => { $ce->{job_queue}{backend} => $ce->{job_queue}{database_dsn} });
 	$app->minion->add_task(lti_mass_update        => 'Mojolicious::WeBWorK::Tasks::LTIMassUpdate');
+	$app->minion->add_task(lti_set_date_sync      => 'Mojolicious::WeBWorK::Tasks::LTISetDateSync');
 	$app->minion->add_task(send_instructor_email  => 'Mojolicious::WeBWorK::Tasks::SendInstructorEmail');
 	$app->minion->add_task(send_achievement_email => 'Mojolicious::WeBWorK::Tasks::AchievementNotification');
 

--- a/lib/Mojolicious/WeBWorK/Tasks/LTISetDateSync.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/LTISetDateSync.pm
@@ -1,0 +1,313 @@
+package Mojolicious::WeBWorK::Tasks::LTISetDateSync;
+use Mojo::Base 'Minion::Job', -signatures, -async_await;
+
+use Mojo::UserAgent;
+use Mojo::Date;
+
+use WeBWorK::Authen::LTIAdvantage::SubmitGrade;
+use WeBWorK::CourseEnvironment;
+use WeBWorK::DB;
+use WeBWorK::Utils::DateTime qw(formatDateTime);
+
+# Synchronize requested set dates to the LMS.
+sub run ($job, $setIDs, $syncToLMS = 1) {
+	# Establish a lock guard that only allows 1 job at a time (technically more than one could run at a time if a job
+	# takes more than an hour to complete).  As soon as a job completes (or fails) the lock is released and a new job
+	# can start.  New jobs retry every minute until they can acquire their own lock.
+	return $job->retry({ delay => 60 }) unless my $guard = $job->minion->guard('lti_set_date_sync', 3600);
+
+	# Minion does not support asynchronous jobs with notification of job completion, and so the Mojolicious::Promise
+	# wait method must be used. The synchronizeSetDates method is used so that the async/await syntax can be used
+	# instead of using the wait method on each method that needs to be awaited which would be tedious.  So the wait
+	# method only needs to be used once here.
+	$job->synchronizeSetDates($setIDs, $syncToLMS)->wait();
+
+	return;
+}
+
+async sub synchronizeSetDates ($job, $setIDs, $syncToLMS) {
+	my $courseID = $job->info->{notes}{courseID};
+	return $job->fail('The course id was not passed when this job was enqueued.') unless $courseID;
+
+	my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $courseID }) };
+	return $job->fail('Could not construct course environment.') unless $ce;
+
+	$job->{language_handle} = WeBWorK::Localize::getLoc($ce->{language} || 'en');
+
+	return $job->fail($job->maketext('This course is not configured to synchronize set dates with the LMS via LTI.'))
+		if !$ce->{LTIVersion} || $ce->{LTIVersion} ne 'v1p3' || $ce->{LTIGradeMode} ne 'homework';
+
+	my $db = WeBWorK::DB->new($ce);
+	return $job->fail($job->maketext('Could not obtain database connection.')) unless $db;
+
+	my $lineitemsURL = $db->getSettingValue('LTILineitemsURL');
+	return $job->fail($job->maketext('Could not perform date synchronization. The lineitems URL is not available.'))
+		unless $lineitemsURL;
+
+	my $accessToken =
+		await WeBWorK::Authen::LTIAdvantage::SubmitGrade->new(({ ce => $ce, db => $db, app => $job->app }, 1))
+		->get_access_token;
+	return $job->fail($job->maketext('Could not perform date synchronization. Unable to obtain access token.'))
+		unless $accessToken;
+
+	my $ua = Mojo::UserAgent->new;
+
+	my $lineitemsRequest =
+		await $ua->get_p($lineitemsURL, { Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })
+		->catch(sub ($err) {
+			return $err;
+		});
+
+	return $job->fail(
+		$job->maketext('There was an error communicating with the lineitems URL: [_1]', $lineitemsRequest))
+		unless ref $lineitemsRequest;
+
+	my $lineitemsResult = $lineitemsRequest->result;
+
+	return $job->fail($job->maketext(
+		'There was an error obtaining the current lineitems from the LMS: [_1]',
+		$lineitemsResult->message
+	))
+		unless $lineitemsResult->is_success;
+
+	my %lineitems = map { $_->{resourceId} => $_ } grep { defined $_->{resourceId} } @{ $lineitemsResult->json };
+
+	my @messages;
+
+	for my $set ($db->getGlobalSetsWhere({ set_id => $setIDs })) {
+		unless ($lineitems{ $set->set_id }) {
+			# If a link to a set was not created via deep linking, then the lineitem obtained from the lineitems URL
+			# will not have the resourceId. But if the link was used by someone, then the lineitem URL for the set will
+			# be in the lis_source_did column for the set. So that can be used to get the current lineitem information
+			# from the LMS.
+			if ($set->lis_source_did) {
+				my $lineitemRequest =
+					await $ua->get_p($set->lis_source_did,
+						{ Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })
+					->catch(sub ($err) {
+						return $err;
+					});
+
+				unless (ref $lineitemRequest) {
+					push(
+						@messages,
+						$job->maketext(
+							'Error communicating with the lineitem URL for set [_1]: [_2]', $set->set_id,
+							$lineitemRequest
+						)
+					);
+					next;
+				}
+
+				my $lineitemResult = $lineitemRequest->result;
+
+				if ($lineitemResult->is_success) {
+					$lineitems{ $set->set_id } = $lineitemResult->json;
+
+					# Set the resourceId so that the LMS sends it the next time that date synchronization occurs.
+					$lineitems{ $set->set_id }{resourceId} = $set->set_id;
+
+					# If not synchronizing dates to the LMS, then update the lineitem to the LMS now, so that the
+					# resourceId will be set in the LMS. If synchronizing dates to the LMS this will be included when
+					# the dates are sent, so it isn't needed now.
+					if (!$syncToLMS) {
+						my $updateLineitemRequest = await $ua->put_p(
+							$lineitems{ $set->set_id }{id},
+							{
+								Authorization  => "$accessToken->{token_type} $accessToken->{access_token}",
+								'Content-Type' => 'application/vnd.ims.lis.v2.lineitem+json'
+							},
+							json => $lineitems{ $set->set_id }
+						)->catch(sub ($err) {
+								return $err;
+						});
+
+						# Don't add messages about this to the job. This is an internal implementation detail the
+						# instructor that queued the job doesn't need to know about. Just log them.
+						if (ref $updateLineitemRequest) {
+							$job->app->log->error('Failed to update the resource id for set '
+									. $set->set_id
+									. ' while performing date synchronization: '
+									. $updateLineitemRequest->result->message)
+								if !$updateLineitemRequest->result->is_success;
+						} else {
+							$job->app->log->error('Failed to update the resource id for set '
+									. $set->set_id
+									. " while performing date synchronization: $updateLineitemRequest");
+						}
+					}
+				}
+			}
+			unless ($lineitems{ $set->set_id }) {
+				push(
+					@messages,
+					$job->maketext(
+						'Skipping synchronization of dates for "[_1]" as the lineitem for this set is not available.',
+						$set->set_id
+					)
+				);
+				next;
+			}
+		}
+
+		# Save the lineitem URL for the set if it is not yet in the database.
+		if (!defined $set->lis_source_did || $set->lis_source_did ne $lineitems{ $set->set_id }{id}) {
+			$set->lis_source_did($lineitems{ $set->set_id }{id});
+			$db->putGlobalSet($set);
+		}
+
+		if ($syncToLMS) {
+			$lineitems{ $set->set_id }{startDateTime} = formatDateTime($set->open_date, '%Y-%m-%dT%H:%M:%S%z');
+			$lineitems{ $set->set_id }{endDateTime}   = formatDateTime($set->due_date,  '%Y-%m-%dT%H:%M:%S%z');
+
+			my $updateLineitemRequest = await $ua->put_p(
+				$lineitems{ $set->set_id }{id},
+				{
+					Authorization  => "$accessToken->{token_type} $accessToken->{access_token}",
+					'Content-Type' => 'application/vnd.ims.lis.v2.lineitem+json'
+				},
+				json => $lineitems{ $set->set_id }
+			)->catch(sub ($err) {
+					return $err;
+			});
+
+			unless (ref $updateLineitemRequest) {
+				push(
+					@messages,
+					$job->maketext(
+						'Failed to submitted dates for "[_1]" to the LMS: [_2]', $set->set_id,
+						$updateLineitemRequest
+					)
+				);
+				next;
+			}
+
+			my $updateLineitemResult = $updateLineitemRequest->result;
+
+			if ($updateLineitemResult->is_success) {
+				push(@messages, $job->maketext('Submitted dates for "[_1]" to the LMS.', $set->set_id,));
+			} else {
+				push(
+					@messages,
+					$job->maketext(
+						'Failed to submit dates for "[_1]" to the LMS: [_2]', $set->set_id,
+						$updateLineitemResult->message
+					)
+				);
+			}
+		} else {
+			my ($openDateChanged, $closeDateChanged) = (0, 0);
+			if ($lineitems{ $set->set_id }{startDateTime}) {
+				my $newOpenDate = Mojo::Date->new($lineitems{ $set->set_id }{startDateTime})->epoch;
+				if (defined $newOpenDate) {
+					$openDateChanged = 1 if $newOpenDate != $set->open_date;
+					$set->open_date($newOpenDate);
+				}
+			}
+			if ($lineitems{ $set->set_id }{endDateTime}) {
+				my $newCloseDate = Mojo::Date->new($lineitems{ $set->set_id }{endDateTime})->epoch;
+				if (defined $newCloseDate) {
+					$closeDateChanged = 1 if $newCloseDate != $set->due_date;
+					$set->due_date($newCloseDate);
+				}
+			}
+
+			# Only change dates if at least one date was received from the LMS. Some LMSs do not support dates and will
+			# not send them at all, or the dates may just not be set in the LMS in which case they also will not be
+			# sent.
+			unless ($openDateChanged || $closeDateChanged) {
+				push(@messages, $job->maketext('The dates for "[_1]" were not changed.', $set->set_id));
+				next;
+			}
+
+			# The following assumes that if the instructor is using synchronization of dates from the LMS, then the
+			# instructor wants those dates to be used.  As such, this tries to make the dates work with the other dates
+			# for the set.
+
+			if ($set->open_date > $set->due_date) {
+				if ($lineitems{ $set->set_id }{startDateTime} && $lineitems{ $set->set_id }{endDateTime}) {
+					push(
+						@messages,
+						$job->maketext(
+							'Error setting dates for [_1]: Invalid dates received from the LMS. '
+								. 'The start date was not before the end date.',
+							$set->set_id
+						)
+					);
+					next;
+				}
+				# If one of the dates was received from the LMS, but not the other, and the current date stored for the
+				# other does not work with the received date, then adjust the other date to make it work.
+				if ($openDateChanged && !$closeDateChanged) {
+					$set->due_date($set->open_date + 60 * $ce->{pg}{assignOpenPriorToDue});
+				} elsif (!$openDateChanged && $closeDateChanged) {
+					$set->open_date($set->due_date - 60 * $ce->{pg}{assignOpenPriorToDue});
+				}
+			}
+
+			$set->answer_date($set->due_date + 60 * $ce->{pg}{answersOpenAfterDueDate})
+				if $set->answer_date < $set->due_date;
+
+			if (!$set->reduced_scoring_date
+				|| $set->reduced_scoring_date < $set->open_date
+				|| $set->reduced_scoring_date > $set->due_date)
+			{
+				if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring} && $set->enable_reduced_scoring) {
+					$set->reduced_scoring_date($set->due_date - 60 * $ce->{pg}{ansEvalDefaults}{reducedScoringPeriod});
+
+					# If using the reducedScoringPeriod results in a time before the open date,
+					# then just use the due date.
+					$set->reduced_scoring_date($set->due_date) if $set->reduced_scoring_date < $set->open_date;
+				} else {
+					$set->reduced_scoring_date($set->due_date);
+				}
+			}
+
+			$db->putGlobalSet($set);
+
+			if ($ce->{pg}{ansEvalDefaults}{enableReducedScoring} && $set->enable_reduced_scoring) {
+				push(
+					@messages,
+					$job->maketext(
+						'Changed dates for "[_1]" to: open date: [_2], reduced scoring date: [_3], '
+							. 'close date: [_4], answer date: [_5]',
+						$set->set_id,
+						(
+							map {
+								formatDateTime($set->$_, 'datetime_format_short', $ce->{siteDefaults}{timezone},
+									$ce->{language})
+							} 'open_date',
+							'reduced_scoring_date',
+							'due_date',
+							'answer_date'
+						)
+					)
+				);
+			} else {
+				push(
+					@messages,
+					$job->maketext(
+						'Changed dates for "[_1]" to: open date: [_2], close date: [_3], answer date: [_4]',
+						$set->set_id,
+						(
+							map {
+								formatDateTime($set->$_, 'datetime_format_short', $ce->{siteDefaults}{timezone},
+									$ce->{language})
+							} 'open_date',
+							'due_date',
+							'answer_date'
+						)
+					)
+				);
+			}
+		}
+	}
+
+	return $job->finish(@messages > 1 ? \@messages : $messages[0]);
+}
+
+sub maketext ($job, @args) {
+	return &{ $job->{language_handle} }(@args);
+}
+
+1;

--- a/lib/WeBWorK/Authen/LTIAdvantage.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage.pm
@@ -197,6 +197,10 @@ sub get_credentials ($self) {
 		$c->stash->{lti_lms_user_id} = $claims->{sub};
 		$c->stash->{lti_lms_lineitem} =
 			$extract_claim->('https://purl.imsglobal.org/spec/lti-ags/claim/endpoint#lineitem');
+		$c->stash->{lti_lms_lineitems_url} =
+			$extract_claim->('https://purl.imsglobal.org/spec/lti-ags/claim/endpoint#lineitems');
+		$c->stash->{lti_lms_namesrolesservice_url} =
+			$extract_claim->('https://purl.imsglobal.org/spec/lti-nrps/claim/namesroleservice#context_memberships_url');
 
 		# Extract a possible setID from the target_link_uri.  This may not be an actual setID.
 		# That will be verified later in WeBWorK::Authen::LTIAdvantage::SubmitGrade::update_sourcedid.

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -70,6 +70,10 @@ sub update_passback_data ($self, $userID) {
 		$self->warning('Missing LMS user id (sub) in JWT.');
 	}
 
+	# Save the namesroleservice URL if it was in the request.
+	$db->setSettingValue('LTINamesRolesServiceURL', $c->stash->{lti_lms_namesrolesservice_url})
+		if $c->stash->{lti_lms_namesrolesservice_url};
+
 	return unless $ce->{LTIGradeMode};
 
 	# The lti_lms_lineitem is the url to post grades to.  It was the 'lineitem' key of the
@@ -92,6 +96,9 @@ sub update_passback_data ($self, $userID) {
 			}
 		}
 	}
+
+	# Save the general lineitems URL if it was in the request.
+	$db->setSettingValue('LTILineitemsURL', $c->stash->{lti_lms_lineitems_url}) if $c->stash->{lti_lms_lineitems_url};
 
 	# Update the access token if necessary.  No need to wait for it to finish here since the token is not needed yet.
 	# This just obtains it if needed for later.
@@ -154,7 +161,8 @@ async sub get_access_token ($self) {
 				'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
 				'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
 				'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
-				'https://purl.imsglobal.org/spec/lti-ags/scope/score'),
+				'https://purl.imsglobal.org/spec/lti-ags/scope/score',
+				'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'),
 			client_assertion => $jwt
 		}
 	)->catch(sub ($err) {
@@ -193,8 +201,13 @@ async sub submit_course_grade ($self, $userID, $submittedSet = undef) {
 
 	my $lineitem = $db->getSettingValue('LTIAdvantageCourseLineitem');
 	unless ($lineitem) {
-		$self->warning('LMS lineitem is not available for the course.');
-		return 0;
+		my $updatedLineitems = await $self->get_lineitems;
+		if (defined $updatedLineitems->{course}) {
+			$lineitem = $updatedLineitems->{course};
+		} else {
+			$self->warning('LMS lineitem is not available for the course.');
+			return 0;
+		}
 	}
 
 	unless ($user->lis_source_did) {
@@ -237,8 +250,13 @@ async sub submit_set_grade ($self, $userID, $setID, $submittedSet = undef) {
 
 	my $userSet = $submittedSet // $db->getMergedSet($userID, $setID);
 	unless ($userSet->lis_source_did) {
-		$self->warning('LMS lineitem is not available for this set.');
-		return 0;
+		my $updatedLineitems = await $self->get_lineitems;
+		if (defined $updatedLineitems->{ $userSet->set_id }) {
+			$userSet->lis_source_did($updatedLineitems->{ $userSet->set_id });
+		} else {
+			$self->warning('LMS lineitem is not available for this set.');
+			return 0;
+		}
 	}
 
 	my $score = getSetPassbackScore($db, $ce, $userID, $userSet, !$self->{post_processing_mode});
@@ -347,6 +365,57 @@ async sub submit_grade ($self, $LMSuserID, $lineitem, $scoreGiven, $scoreMaximum
 
 	$self->warning(join("\n", 'Failed to send grade:', $response->message));
 	return 0;
+}
+
+# If $LTIGradeMode is 'homework', then this gets all lineitem URLs for links to sets created via deep linking from the
+# LMS and updates them in the database,  or if $LTIGradeMode is 'course' and a link for the course grade was created via
+# deep linking, then this gets the lineitem URL for the course grade and updates it in the course settings.  A hash of
+# set_id and lineitem URLs is returned if $LTIGradeMode is 'homework, and a hash with 'course' and the grade lineitem
+# URL is returned if $LTIGradeMode is 'course'. If no lineitem URLs can be identified, then an empty hash is returned.
+async sub get_lineitems ($self) {
+	return $self->{lineitemURLs} if $self->{lineitemURLs};
+	$self->{lineitemURLs} = {};
+
+	my $db = $self->{c}{db};
+
+	my $lineitemsURL = $db->getSettingValue('LTILineitemsURL');
+	return $self->{lineitemURLs} unless $lineitemsURL;
+
+	return $self->{lineitemURLs} unless (my $accessToken = await $self->get_access_token);
+
+	my $ua = Mojo::UserAgent->new;
+
+	my $lineitemsRequest =
+		await $ua->get_p($lineitemsURL, { Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })
+		->catch(sub ($err) {
+			$self->warning("Unable to obtain lineitems from the lineitems URL:\n" . $err);
+			return;
+		});
+
+	if ($lineitemsRequest) {
+		my $lineitemsResult = $lineitemsRequest->result;
+		if ($lineitemsResult->is_success) {
+			my $lineitems = $lineitemsResult->json;
+			for my $lineitem (@$lineitems) {
+				next unless $lineitem->{resourceId};
+				if ($self->{c}{ce}{LTIGradeMode} eq 'homework') {
+					next unless (my $set = $db->getGlobalSet($lineitem->{resourceId}));
+					if (!defined $set->lis_source_did || $set->lis_source_did ne $lineitem->{id}) {
+						$set->lis_source_did($lineitem->{id});
+						$db->putGlobalSet($set);
+					}
+					$self->{lineitemURLs}{ $set->{set_id} } = $lineitem->{id};
+				} elsif ($self->{c}{ce}{LTIGradeMode} eq 'course' && $lineitem->{resourceId} eq 'course_grade') {
+					$db->setSettingValue('LTIAdvantageCourseLineitem', $lineitem->{id});
+					$self->{lineitemURLs}{course} = $lineitem->{id};
+				}
+			}
+		} else {
+			$self->warning("Unable to obtain lineitems from the lineitems URL:\n" . $lineitemsResult->message);
+		}
+	}
+
+	return $self->{lineitemURLs};
 }
 
 # Load and possibly generate private/public keys for the site.  This is only generates new keys if the files do not

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -1123,6 +1123,31 @@ sub getConfigValues ($ce) {
 			type   => 'text',
 			secret => 1
 		},
+		'LTI{v1p3}{ignoreMissingSourcedID}' => {
+			var  => 'LTI{v1p3}{ignoreMissingSourcedID}',
+			doc  => x('Allow set access when the lineitem URL for a set is missing'),
+			doc2 => x(
+				'When grade passback mode is "homework", WeBWorK needs to have the lineitem URL for a set in order '
+					. 'for grade passback to occur. If WeBWorK has not yet stored this lineitem URL, then by default '
+					. 'students will not be able to access and work a set, and a message will be displayed for '
+					. 'students stating that the assignment must be accessed from the LMS before the assignment can '
+					. 'be worked. Set this option to true to disable that message and allow students to access and '
+					. 'work the set regardless of if WeBWorK has stored the lineitem URL.'
+			),
+			type => 'boolean'
+		},
+		'LTI{v1p3}{autoSyncSetDatesToLMS}' => {
+			var  => 'LTI{v1p3}{autoSyncSetDatesToLMS}',
+			doc  => x('Automatically synchronize set dates to LMS'),
+			doc2 => x(
+				'Set this to true if you want WeBWorK to automatically synchronize set dates to the LMS anytime that '
+					. q{a set's open or close date is changed in WeBWorK. Note that this will only work for sets for }
+					. 'which WeBWorK has or can obtain the lineitem URL. This will always work for sets created via '
+					. 'content selection from the LMS, but will only work for a manually created link in the LMS after '
+					. 'the link has been used.'
+			),
+			type => 'boolean'
+		},
 		'LTI{v1p3}{PlatformID}' => {
 			var    => 'LTI{v1p3}{PlatformID}',
 			doc    => x('LMS platform ID for LTI 1.3'),

--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -14,6 +14,7 @@ use constant ACTION_FORMS => [ [ filter => x('Filter') ], [ sort => x('Sort') ],
 # All tasks added in the Mojolicious::WeBWorK module need to be listed here.
 use constant TASK_NAMES => {
 	lti_mass_update        => x('LTI Mass Update'),
+	lti_set_date_sync      => x('LTI Set Date Synchronization'),
 	send_instructor_email  => x('Send Instructor Email'),
 	send_achievement_email => x('Send Achiement Email')
 };

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -1481,6 +1481,9 @@ sub initialize ($c) {
 				}
 			}
 		} else {
+			my $originalOpenDate = $setRecord->open_date;
+			my $originalDueDate  = $setRecord->due_date;
+
 			foreach my $field (@{ SET_FIELDS() }) {
 				next unless canChange($forUsers, $field);
 
@@ -1508,6 +1511,15 @@ sub initialize ($c) {
 				}
 			}
 			$db->putGlobalSet($setRecord);
+
+			if ($ce->{LTIVersion}
+				&& $ce->{LTIVersion} eq 'v1p3'
+				&& $ce->{LTIGradeMode} eq 'homework'
+				&& $ce->{LTI}{v1p3}{autoSyncSetDatesToLMS}
+				&& ($originalOpenDate != $setRecord->open_date || $originalDueDate != $setRecord->due_date))
+			{
+				$c->minion->enqueue(lti_set_date_sync => [$setID], { notes => { courseID => $ce->{courseName} } });
+			}
 
 			# Save IP restriction Location information
 			if (defined($c->param("set.$setID.restrict_ip")) && $c->param("set.$setID.restrict_ip") ne 'No') {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -73,7 +73,7 @@ use WeBWorK::File::SetDef      qw(importSetsFromDef exportSetsToDef);
 use constant HIDE_SETS_THRESHOLD => 500;
 
 use constant EDIT_FORMS   => [qw(save_edit cancel_edit)];
-use constant VIEW_FORMS   => [qw(filter sort edit publish import export score create delete)];
+use constant VIEW_FORMS   => [qw(filter sort edit publish import export score create delete lms_date_sync)];
 use constant EXPORT_FORMS => [qw(save_export cancel_export)];
 
 # Prepare the tab titles for translation by maketext
@@ -90,7 +90,8 @@ use constant FORM_TITLES => {
 	create        => x("Create"),
 	delete        => x("Delete"),
 	save_export   => x("Save Export"),
-	cancel_export => x("Cancel Export")
+	cancel_export => x("Cancel Export"),
+	lms_date_sync => x("Synchronize Set Dates with LMS")
 };
 
 use constant VIEW_FIELD_ORDER =>
@@ -101,15 +102,16 @@ use constant EXPORT_FIELD_ORDER => [qw(set_id problems users)];
 
 # permissions needed to perform a given action
 use constant FORM_PERMS => {
-	save_edit   => "modify_problem_sets",
-	edit        => "modify_problem_sets",
-	publish     => "modify_problem_sets",
-	import      => "create_and_delete_problem_sets",
-	export      => "modify_set_def_files",
-	save_export => "modify_set_def_files",
-	score       => "score_sets",
-	create      => "create_and_delete_problem_sets",
-	delete      => "create_and_delete_problem_sets",
+	save_edit     => "modify_problem_sets",
+	edit          => "modify_problem_sets",
+	publish       => "modify_problem_sets",
+	import        => "create_and_delete_problem_sets",
+	export        => "modify_set_def_files",
+	save_export   => "modify_set_def_files",
+	score         => "score_sets",
+	create        => "create_and_delete_problem_sets",
+	delete        => "create_and_delete_problem_sets",
+	lms_date_sync => "modify_problem_sets"
 };
 
 # Note that these are the only fields that are ever shown on this page.
@@ -617,14 +619,18 @@ sub save_edit_handler ($c) {
 	my $db = $c->db;
 	my $ce = $c->ce;
 
+	my @setsToSyncToLMS;
+
 	my @visibleSetIDs = @{ $c->{visibleSetIDs} };
-	foreach my $setID (@visibleSetIDs) {
+	for my $setID (@visibleSetIDs) {
 		next unless defined($setID);
 		my $Set = $db->getGlobalSet($setID);
-		# FIXME: we may not want to die on bad sets, they're not as bad as bad users
-		die "record for visible set $setID not found" unless $Set;
+		next unless $Set;
 
-		foreach my $field ($Set->NONKEYFIELDS()) {
+		my $originalOpenDate = $Set->open_date;
+		my $originalDueDate  = $Set->due_date;
+
+		for my $field ($Set->NONKEYFIELDS()) {
 			my $value = $c->param("set.$setID.$field");
 			if (defined $value) {
 				if ($field =~ /_date/) {
@@ -652,7 +658,7 @@ sub save_edit_handler ($c) {
 			return (0, $c->maketext('Error: Answer date must come after close date in set [_1].', $setID));
 		}
 
-		# check that the reduced scoring date is in the right place
+		# Check that the reduced scoring date is in the right place.
 		my $enable_reduced_scoring = $ce->{pg}{ansEvalDefaults}{enableReducedScoring}
 			&& (
 				defined($c->param("set.$setID.enable_reduced_scoring"))
@@ -675,7 +681,22 @@ sub save_edit_handler ($c) {
 			);
 		}
 
+		push(@setsToSyncToLMS, $setID)
+			if $Set->open_date != $originalOpenDate || $Set->due_date != $originalDueDate;
+
 		$db->putGlobalSet($Set);
+	}
+
+	if (@setsToSyncToLMS
+		&& $ce->{LTIVersion}
+		&& $ce->{LTIVersion} eq 'v1p3'
+		&& $ce->{LTIGradeMode} eq 'homework'
+		&& $ce->{LTI}{v1p3}{autoSyncSetDatesToLMS})
+	{
+		$c->minion->enqueue(
+			lti_set_date_sync => [ \@setsToSyncToLMS ],
+			{ notes => { courseID => $ce->{courseName} } }
+		);
 	}
 
 	if (defined $c->param("prev_visible_sets")) {
@@ -689,6 +710,27 @@ sub save_edit_handler ($c) {
 	$c->{editMode} = 0;
 
 	return (1, $c->maketext('Changes saved.'));
+}
+
+sub lms_date_sync_handler ($c) {
+	my $ce = $c->ce;
+
+	return (0, $c->maketext('This course is not configured to synchronize set dates with the LMS via LTI.'))
+		if !$ce->{LTIVersion} || $ce->{LTIVersion} ne 'v1p3' || $ce->{LTIGradeMode} ne 'homework';
+
+	my $lineitemsURL = $c->db->getSettingValue('LTILineitemsURL');
+	return (0, $c->maketext('Unable to perform date synchronization as the lineitems URL is not available.'))
+		unless $lineitemsURL;
+
+	$c->minion->enqueue(
+		lti_set_date_sync => [
+			$c->param('action.lms_date_sync.scope') eq 'all' ? $c->{allSetIDs} : [ $c->param('selected_sets') ],
+			$c->param('action.lms_date_sync.direction') eq 'to'
+		],
+		{ notes => { courseID => $ce->{courseName} } }
+	);
+
+	return (1, $c->maketext('Date synchronization for the requested sets queued.'));
 }
 
 1;

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -1,5 +1,5 @@
 package WeBWorK::ContentGenerator::Instructor::UserList;
-use Mojo::Base 'WeBWorK::ContentGenerator', -signatures;
+use Mojo::Base 'WeBWorK::ContentGenerator', -signatures, -async_await;
 
 =head1 NAME
 
@@ -47,36 +47,40 @@ Export users:
 
 use Mojo::File;
 
-use WeBWorK::File::Classlist qw(parse_classlist write_classlist);
-use WeBWorK::Utils           qw(cryptPassword x);
+use WeBWorK::File::Classlist   qw(parse_classlist write_classlist);
+use WeBWorK::Utils             qw(cryptPassword x);
+use WeBWorK::Utils::Instructor qw(assignSetsToUsers);
+use WeBWorK::Authen::LTIAdvantage::SubmitGrade;
 
 use constant HIDE_USERS_THRESHOLD => 200;
 use constant EDIT_FORMS           => [qw(save_edit cancel_edit)];
-use constant VIEW_FORMS           => [qw(filter sort edit import export add delete reset_2fa)];
+use constant VIEW_FORMS           => [qw(filter sort edit import export add delete reset_2fa lms_roster_sync)];
 
 # Prepare the tab titles for translation by maketext
 use constant FORM_TITLES => {
-	save_edit   => x('Save Edit'),
-	cancel_edit => x('Cancel Edit'),
-	filter      => x('Filter'),
-	sort        => x('Sort'),
-	edit        => x('Edit'),
-	import      => x('Import'),
-	export      => x('Export'),
-	add         => x('Add'),
-	delete      => x('Delete'),
-	reset_2fa   => x('Reset Two Factor Authentication')
+	save_edit       => x('Save Edit'),
+	cancel_edit     => x('Cancel Edit'),
+	filter          => x('Filter'),
+	sort            => x('Sort'),
+	edit            => x('Edit'),
+	import          => x('Import'),
+	export          => x('Export'),
+	add             => x('Add'),
+	delete          => x('Delete'),
+	reset_2fa       => x('Reset Two Factor Authentication'),
+	lms_roster_sync => x('Synchronize LMS Roster')
 };
 
 # permissions needed to perform a given action
 use constant FORM_PERMS => {
-	save_edit => 'modify_student_data',
-	edit      => 'modify_student_data',
-	reset_2fa => 'change_password',
-	import    => 'modify_student_data',
-	export    => 'modify_classlist_files',
-	add       => 'modify_student_data',
-	delete    => 'modify_student_data',
+	save_edit       => 'modify_student_data',
+	edit            => 'modify_student_data',
+	reset_2fa       => 'change_password',
+	import          => 'modify_student_data',
+	export          => 'modify_classlist_files',
+	add             => 'modify_student_data',
+	delete          => 'modify_student_data',
+	lms_roster_sync => 'modify_student_data'
 };
 
 use constant SORT_SUBS => {
@@ -136,7 +140,7 @@ use constant FIELD_PROPERTIES => {
 	password   => { name => x('Password'),         type => 'password' },
 };
 
-sub pre_header_initialize ($c) {
+async sub pre_header_initialize ($c) {
 	my $authz = $c->authz;
 	my $ce    = $c->ce;
 	my $db    = $c->db;
@@ -229,7 +233,14 @@ sub pre_header_initialize ($c) {
 		if (!FORM_PERMS()->{$actionID} || $authz->hasPermissions($user, FORM_PERMS()->{$actionID})) {
 			# Call the action handler
 			my $actionHandler = "${actionID}_handler";
-			$c->addgoodmessage($c->$actionHandler);
+			my @actionResult  = $c->$actionHandler;
+			@actionResult = await $actionResult[0]
+				if ref $actionResult[0] eq 'Future' || ref $actionResult[0] eq 'Mojo::Promise';
+			if ($actionResult[0]) {
+				$c->addgoodmessage($c->b($actionResult[1]));
+			} else {
+				$c->addbadmessage($c->b($actionResult[1]));
+			}
 		} else {
 			$c->addbadmessage($c->maketext('You are not authorized to perform this action.'));
 		}
@@ -314,7 +325,7 @@ sub filter_handler ($c) {
 		$c->{visibleUserIDs} = { map { $_ => 1 } @matchingUserIDs };
 	}
 
-	return $result;
+	return (1, $result);
 }
 
 sub sort_handler ($c) {
@@ -348,16 +359,19 @@ sub sort_handler ($c) {
 		$c->{ternarySortOrder}   = $c->param('action.sort.ternary.order');
 	}
 
-	return $c->maketext(
-		'Sets sorted by [_1] in [plural,_2,ascending,descending] order, '
-			. 'then by [_3] in [plural,_4,ascending,descending] order,'
-			. 'and then by [_5] in [plural,_6,ascending,descending] order.',
-		$c->maketext(FIELD_PROPERTIES()->{ $c->{primarySortField} }{name}),
-		$c->{primarySortOrder} eq 'ASC' ? 1 : 2,
-		$c->maketext(FIELD_PROPERTIES()->{ $c->{secondarySortField} }{name}),
-		$c->{secondarySortOrder} eq 'ASC' ? 1 : 2,
-		$c->maketext(FIELD_PROPERTIES()->{ $c->{ternarySortField} }{name}),
-		$c->{ternarySortOrder} eq 'ASC' ? 1 : 2
+	return (
+		1,
+		$c->maketext(
+			'Sets sorted by [_1] in [plural,_2,ascending,descending] order, '
+				. 'then by [_3] in [plural,_4,ascending,descending] order,'
+				. 'and then by [_5] in [plural,_6,ascending,descending] order.',
+			$c->maketext(FIELD_PROPERTIES()->{ $c->{primarySortField} }{name}),
+			$c->{primarySortOrder} eq 'ASC' ? 1 : 2,
+			$c->maketext(FIELD_PROPERTIES()->{ $c->{secondarySortField} }{name}),
+			$c->{secondarySortOrder} eq 'ASC' ? 1 : 2,
+			$c->maketext(FIELD_PROPERTIES()->{ $c->{ternarySortField} }{name}),
+			$c->{ternarySortOrder} eq 'ASC' ? 1 : 2
+		)
 	);
 }
 
@@ -368,7 +382,7 @@ sub edit_handler ($c) {
 	$c->{visibleUserIDs} = { map { $_ => 1 } @usersToEdit };
 	$c->{editMode}       = 1;
 
-	return $scope eq 'all' ? $c->maketext('Editing all users.') : $c->maketext('Editing selected users.');
+	return (1, $scope eq 'all' ? $c->maketext('Editing all users.') : $c->maketext('Editing selected users.'));
 }
 
 sub delete_handler ($c) {
@@ -377,7 +391,7 @@ sub delete_handler ($c) {
 	my $confirm = $c->param('action.delete.confirm');
 	my $num     = 0;
 
-	return $c->maketext('Deleted [_1] users.', $num) unless ($confirm eq 'yes');
+	return (1, $c->maketext('Deleted [_1] [plural,_1,user].', $num)) unless $confirm eq 'yes';
 
 	# grep on userIsEditable would still enforce permissions, but no UI feedback
 	my @userIDsToDelete = keys %{ $c->{selectedUserIDs} };
@@ -401,13 +415,13 @@ sub delete_handler ($c) {
 		$num++;
 	}
 
-	unshift @resultText, $c->maketext('Deleted [_1] users.', $num);
-	return join(' ', @resultText);
+	unshift @resultText, $c->maketext('Deleted [_1] [plural,_1,user].', $num);
+	return (1, join(' ', @resultText));
 }
 
 sub add_handler ($c) {
 	# This action is redirected to the AddUsers.pm module using ../instructor/add_user/...
-	return '';
+	return (1, '');
 }
 
 sub import_handler ($c) {
@@ -416,7 +430,7 @@ sub import_handler ($c) {
 
 	unless (defined($fileName) and $fileName =~ /\.lst$/) {
 		$c->addbadmessage($c->maketext('No class list file provided.'));
-		return $c->maketext('No users added.');
+		return (0, $c->maketext('No users added.'));
 	}
 	my $replaceExisting;
 	my @replaceList;
@@ -451,8 +465,17 @@ sub import_handler ($c) {
 	my $numAdded    = @$added;
 	my $numSkipped  = @$skipped;
 
-	return $c->maketext('[_1] users replaced, [_2] users added, [_3] users skipped. Skipped users: ([_4])',
-		$numReplaced, $numAdded, $numSkipped, join(', ', @$skipped));
+	return (
+		1,
+		$c->maketext(
+			'[_1] [plural,_1,user] replaced, [_2] [plural,_2,user] added, [_3] [plural,_3,user] skipped. '
+				. 'Skipped [plural,_3,user]: ([_4])',
+			$numReplaced,
+			$numAdded,
+			$numSkipped,
+			join(', ', @$skipped)
+		)
+	);
 }
 
 sub export_handler ($c) {
@@ -478,7 +501,7 @@ sub export_handler ($c) {
 	my @userIDsToExport = $scope eq 'all' ? @{ $c->{allUserIDs} } : keys %{ $c->{selectedUserIDs} };
 	$c->exportUsersToCSV($fileName, @userIDsToExport);
 
-	return $c->maketext('[_1] users exported to file [_2]', scalar @userIDsToExport, "$dir/$fileName");
+	return (1, $c->maketext('[_1] [plural,_1,user] exported to file [_2]', scalar @userIDsToExport, "$dir/$fileName"));
 }
 
 sub reset_2fa_handler ($c) {
@@ -488,7 +511,8 @@ sub reset_2fa_handler ($c) {
 	my $confirm = $c->param('action.reset_2fa.confirm');
 	my $num     = 0;
 
-	return $c->maketext('Reset two factor authentication for [_1] users.', $num) unless $confirm eq 'yes';
+	return (1, $c->maketext('Reset two factor authentication for [_1] [plural,_1,user].', $num))
+		unless $confirm eq 'yes';
 
 	# grep on userIsEditable would still enforce permissions, but no UI feedback
 	my @userIDsForReset = keys %{ $c->{selectedUserIDs} };
@@ -512,7 +536,257 @@ sub reset_2fa_handler ($c) {
 	}
 
 	unshift @resultText, $c->maketext('Reset two factor authentication for [quant,_1,user].', $num);
-	return join(' ', @resultText);
+	return (1, join(' ', @resultText));
+}
+
+async sub lms_roster_sync_handler ($c) {
+	my $db = $c->db;
+	my $ce = $c->ce;
+
+	return (0, $c->maketext('This course is not configured to import users from the LMS via LTI.'))
+		if !$ce->{LTIVersion}
+		|| $ce->{LTIVersion} ne 'v1p3'
+		|| !$ce->{LTI}{v1p3}{preferred_source_of_username};
+
+	my $namesRolesServiceURL = $db->getSettingValue('LTINamesRolesServiceURL');
+	return (0, $c->maketext('The LTI names/roles service URL is not available.')) unless $namesRolesServiceURL;
+
+	my $accessToken = await WeBWorK::Authen::LTIAdvantage::SubmitGrade->new($c)->get_access_token;
+	return (0, $c->maketext('Unable to obtain access token.')) unless $accessToken;
+
+	my $namesRolesServiceRequest = await Mojo::UserAgent->new->get_p($namesRolesServiceURL,
+		{ Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })->catch(sub ($err) {
+		return $err;
+		});
+	return (0, $c->maketext("Error communicating with the names and roles service URL: $namesRolesServiceRequest\n"))
+		unless ref $namesRolesServiceRequest;
+
+	my $namesRolesServiceResult = $namesRolesServiceRequest->result;
+	if ($namesRolesServiceResult->is_success) {
+		my $namesRoles = $namesRolesServiceResult->json->{members};
+		return (0, $c->maketext('Invalid data received from the LMS.')) unless ref $namesRoles eq 'ARRAY';
+
+		my (@addedUsers, @userAchievementRecordsToAdd, @globalAchievementRecordsToAdd, %usersInLMSCourse);
+		my $updatedUsers = 0;
+
+		my @achievements = $db->getAchievementsWhere({ enabled => 1 }, ['achievement_id']);
+
+		my $preferredSourceOfUsername = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
+			|| $ce->{LTI}{v1p3}{preferred_source_of_username};
+		my $fallbackPasswordSource = $ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
+			|| $ce->{LTI}{v1p3}{fallback_source_of_username};
+		my $preferredSourceOfStudentId = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_student_id}
+			|| $ce->{LTI}{v1p3}{preferred_source_of_student_id};
+
+		for my $user (@$namesRoles) {
+			my ($userIdSource, $typeOfSource) = ('', '');
+			my $userId = $user->{$preferredSourceOfUsername};
+			if (defined $userId) {
+				$userIdSource = $preferredSourceOfUsername;
+				$typeOfSource =
+					"$userIdSource which was "
+					. ($ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
+						? 'namesroles_service_preferred_source_of_username'
+						: 'preferred_source_of_username');
+			} elsif ($fallbackPasswordSource && !defined $userId && defined $user->{$fallbackPasswordSource}) {
+				$userIdSource = $fallbackPasswordSource;
+				$typeOfSource =
+					"$userIdSource which was"
+					. ($ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
+						? 'namesroles_service_fallback_source_of_username'
+						: 'fallback_source_of_username');
+				$userId = $user->{$fallbackPasswordSource};
+			}
+
+			unless (defined $userId) {
+				warn "=====================================\n"
+					. "Unable to determine a webwork user id for LMS user:\n"
+					. $c->dumper($user)
+					. "\n=====================================\n"
+					if $ce->{debug_lti_parameters};
+				next;
+			}
+
+			$userId =~ s/@.*$//   if $userIdSource eq 'email' && $ce->{LTI}{v1p3}{strip_domain_from_email};
+			$userId = lc($userId) if $ce->{LTI}{v1p3}{lowercase_username};
+
+			my $studentId = $preferredSourceOfStudentId ? ($user->{$preferredSourceOfStudentId} // '') : '';
+
+			if ($ce->{debug_lti_parameters}) {
+				warn "=========== USER SUMMARY ============\n";
+				warn "----------- LMS USER DATA -----------\n";
+				warn $c->dumper($user);
+				warn "\n-------------------------------------\n";
+				warn "User id is |$userId| (obtained from $typeOfSource)\n";
+				warn "User email address is |$user->{email}|\n";
+				warn "Student id is |$studentId|\n";
+				warn "=====================================\n";
+			}
+
+			$usersInLMSCourse{$userId} = 1;
+
+			if ($userId eq $c->param('user')) {
+				warn "Skipping $userId because this is you.\n" if $ce->{debug_lti_parameters};
+				next;
+			}
+
+			# Note that the only reliably obtained roles here are the membership roles. The issue is that these roles
+			# are allowed to be abbreviated (i.e., the http://purl.imsglobal.org/... part may be entirely omitted
+			# according to the specification). Moodle does this, but Canvas does not. However, both seem to add a prefix
+			# for non-membership roles. Also, "institution" roles are not sent, so it is not even possible to honor the
+			# $ce->{LTI}{v1p3}{AllowInstitutionRoles} setting.
+			my @LTIroles = map {s|^http://purl.imsglobal.org/vocab/lis/v2/membership#||r} @{ $user->{roles} };
+
+			warn "The LTI roles defined for $userId are: \n-- " . join("\n-- ", @LTIroles) . "\n"
+				if $ce->{debug_lti_parameters};
+
+			if (!defined($ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } })) {
+				warn "Skipping $userId. Cannot find a WeBWorK role that corresponds to the "
+					. "LMS role of $LTIroles[0] for this user.\n"
+					if $ce->{debug_lti_parameters};
+				next;
+			}
+
+			my $permissionLevel = $ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } };
+			if (@LTIroles > 1) {
+				for (@LTIroles[ 1 .. $#LTIroles ]) {
+					my $wwRole = $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{$_};
+					next unless defined $wwRole;
+					$permissionLevel = $ce->{userRoles}{$wwRole} if $permissionLevel < $ce->{userRoles}{$wwRole};
+				}
+			}
+			if ($permissionLevel > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }) {
+				warn "Skipping $userId. User has a role above the LTI "
+					. "account creation cutoff of $ce->{LTIAccountCreationCutoff}.\n"
+					if $ce->{debug_lti_parameters};
+				next;
+			}
+
+			if ($c->{allUsers}{$userId}) {
+				next unless $ce->{LMSManageUserData};
+
+				# Create a temporary user with the LMS credentials and compare the user to the existing user.
+				my $tempUser = $db->newUser(
+					user_id        => $userId,
+					lis_source_did => $user->{user_id},
+					last_name      => $user->{family_name} =~ s/\+/ /gr,
+					first_name     => $user->{given_name}  =~ s/\+/ /gr,
+					email_address  => $user->{email},
+					status         => $user->{status} eq 'Active' ? 'C' : 'D',
+					comment        => $c->formatDateTime(time),
+					student_id     => $studentId,
+					section        => '',
+					recitation     => ''
+				);
+
+				my $change_made = 0;
+				for my $element (qw(last_name first_name email_address status student_id)) {
+					if ($c->{allUsers}{$userId}->$element ne $tempUser->$element) {
+						$change_made = 1;
+						warn "WeBWorK user has $element: "
+							. $c->{allUsers}{$userId}->$element
+							. ", but LMS user has $element: "
+							. $tempUser->$element . "\n"
+							if $ce->{debug_lti_parameters};
+						# Update the data for this page.
+						$c->{allUsers}{$userId}->$element($tempUser->$element);
+					}
+				}
+
+				if ($change_made) {
+					++$updatedUsers;
+					$tempUser->comment($c->formatDateTime(time));
+					eval { $db->putUser($tempUser) };
+					if ($@) {
+						$c->log->error("Failed to update user $userId when importing LMS user: $@");
+						warn "Failed to update user $userId.\n" if $ce->{debug_lti_parameters};
+					} else {
+						warn "Updated user $userId.\n" if $ce->{debug_lti_parameters};
+					}
+				} else {
+					warn "$userId not changed.\n" if $ce->{debug_lti_parameters};
+				}
+			} else {
+				warn "Adding user $userId with permission level $permissionLevel.\n" if $ce->{debug_lti_parameters};
+				push(@addedUsers, $userId);
+
+				my $newUser = $db->newUser(
+					user_id        => $userId,
+					lis_source_did => $user->{user_id},
+					last_name      => $user->{family_name} =~ s/\+/ /gr,
+					first_name     => $user->{given_name}  =~ s/\+/ /gr,
+					email_address  => $user->{email},
+					status         => $user->{status} eq 'Active' ? 'C' : 'D',
+					comment        => $c->formatDateTime(time),
+					student_id     => $studentId,
+					section        => '',
+					recitation     => ''
+				);
+				$db->addUser($newUser);
+
+				$db->addPermissionLevel($db->newPermissionLevel(user_id => $userId, permission => $permissionLevel));
+
+				for (@achievements) {
+					push(@userAchievementRecordsToAdd,
+						$db->newUserAchievement(user_id => $userId, achievement_id => $_->achievement_id));
+				}
+				push(@globalAchievementRecordsToAdd,
+					$db->newGlobalUserAchievement(user_id => $userId, achievement_points => 0));
+
+				# Update the data for this page.
+				$newUser->{permission}        = $permissionLevel;
+				$newUser->{passwordExists}    = 0;
+				$c->{allUsers}{$userId}       = $newUser;
+				$c->{visibleUserIDs}{$userId} = 1;
+				$c->{userIsEditable}{$userId} = 1;
+			}
+		}
+
+		# Assign visible sets to the added users.
+		assignSetsToUsers($db, $ce, [ map { $_->[0] } $db->listGlobalSetsWhere({ visible => 1 }) ], \@addedUsers)
+			if @addedUsers;
+
+		# Assign achievements to the added users.
+		$db->UserAchievement->insert_records(\@userAchievementRecordsToAdd) if @userAchievementRecordsToAdd;
+		$db->GlobalUserAchievement->insert_records(\@globalAchievementRecordsToAdd)
+			if @globalAchievementRecordsToAdd;
+
+		# Mark all users not in the LMS roster and at or below the LTIAccountCreationCutoff as dropped.
+		my @droppedUsers;
+		for my $user (values %{ $c->{allUsers} }) {
+			next
+				if $usersInLMSCourse{ $user->user_id }
+				|| $user->{permission} > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }
+				|| $user->status eq 'D';
+			$user->status('D');
+			push(@droppedUsers, $user);
+		}
+		$db->User->update_records(\@droppedUsers) if @droppedUsers;
+
+		return (
+			1,
+			$ce->{LMSManageUserData}
+			? $c->maketext(
+				'[_1] [plural,_1,user] added, [_2] [plural,_2,user] updated, '
+					. '[_3] [plural,_3,user] not in LMS [plural,_3,was,were] dropped',
+				scalar(@addedUsers),
+				$updatedUsers,
+				scalar(@droppedUsers)
+				)
+			: $c->maketext(
+				'[_1] [plural,_1,user] added, [_2] [plural,_2,user] not in LMS [plural,_2,was,were] dropped',
+				scalar(@addedUsers), scalar(@droppedUsers)
+			)
+		);
+	} else {
+		return (
+			0,
+			$c->maketext(
+				'There was an error obtaining the list of users from the LMS: [_1]',
+				$namesRolesServiceResult->message
+			)
+		);
+	}
 }
 
 sub cancel_edit_handler ($c) {
@@ -523,7 +797,7 @@ sub cancel_edit_handler ($c) {
 	}
 	$c->{editMode} = 0;
 
-	return $c->maketext('Changes abandoned.');
+	return (1, $c->maketext('Changes abandoned.'));
 }
 
 sub save_edit_handler ($c) {
@@ -592,7 +866,7 @@ sub save_edit_handler ($c) {
 
 	$c->{editMode} = 0;
 
-	return $c->maketext('Changes saved.');
+	return (1, $c->maketext('Changes saved.'));
 }
 
 # Sort methods (ascending)

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -61,16 +61,19 @@ sub initializeRoute ($c, $routeCaptures) {
 			{
 				$c->stash->{isContentSelection} = 1;
 
+				my $siteEnvironment = WeBWorK::CourseEnvironment->new;
+
 				# The database object used here is not associated to any course,
 				# and so the only has access to non-native tables.
-				my @matchingCourses = WeBWorK::DB->new(WeBWorK::CourseEnvironment->new)->getLTICourseMapsWhere({
+				my $nonNativeDB     = WeBWorK::DB->new($siteEnvironment);
+				my @matchingCourses = $nonNativeDB->getLTICourseMapsWhere({
 					lms_context_id =>
 						$c->stash->{lti_jwt_claims}{'https://purl.imsglobal.org/spec/lti/claim/context'}{id}
 				});
 
 				if (@matchingCourses == 1) {
 					$c->stash->{courseID} = $matchingCourses[0]->course_id;
-				} else {
+				} elsif ($siteEnvironment->{LTI}{v1p3}{allowCourseSelection}) {
 					for (@matchingCourses) {
 						my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $_->course_id }) };
 						if ($@) { warn "Failed to initialize course environment for $_: $@\n"; next; }
@@ -84,6 +87,98 @@ sub initializeRoute ($c, $routeCaptures) {
 						{
 							$c->stash->{courseID} = $_->course_id;
 							last;
+						}
+					}
+
+					# If a matching course was not found in the LTI course map and the site is configured to allow
+					# course selection, then construct a list of all courses for which the LTI 1.3 authentication
+					# parameters match and that have a user that has the email address set that matches the email
+					# address sent from the LMS, and that has access_instructor_tools and modify_problem_sets
+					# permissions.
+					unless (defined $c->stash->{courseID}) {
+						my @userCourses;
+
+						my $claims        = $c->stash->{lti_jwt_claims};
+						my $extract_claim = sub ($key) {
+							my $value = $claims;
+							for (split '#', $key) {
+								if (defined $value->{$_}) {
+									$value = $value->{$_};
+								} else {
+									return;
+								}
+							}
+							return $value;
+						};
+
+						my %mappedCourses = map { $_->course_id => 1 } $nonNativeDB->getLTICourseMapsWhere;
+
+						my $firstFoundUserId;
+
+						for (listCourses(WeBWorK::CourseEnvironment->new)) {
+							next if $mappedCourses{$_};
+
+							my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $_ }) };
+							if ($@) { $c->log->error("Failed to initialize course environment for $_: $@"); next; }
+
+							if (($ce->{LTIVersion} // '') eq 'v1p3'
+								&& $ce->{LTI}{v1p3}{PlatformID}
+								&& $ce->{LTI}{v1p3}{PlatformID} eq $c->stash->{LTILaunchData}->data->{PlatformID}
+								&& $ce->{LTI}{v1p3}{ClientID}
+								&& $ce->{LTI}{v1p3}{ClientID} eq $c->stash->{LTILaunchData}->data->{ClientID}
+								&& $ce->{LTI}{v1p3}{DeploymentID}
+								&& $ce->{LTI}{v1p3}{DeploymentID} eq
+								$c->stash->{LTILaunchData}->data->{DeploymentID}
+								&& $ce->{LTI}{v1p3}{preferred_source_of_username})
+							{
+								my $userIdSource = '';
+								my $userId       = $extract_claim->($ce->{LTI}{v1p3}{preferred_source_of_username});
+								$userIdSource = $ce->{LTI}{v1p3}{preferred_source_of_username} if $userId;
+								if (!defined $userId && $ce->{LTI}{v1p3}{fallback_source_of_username}) {
+									$userId       = $extract_claim->($ce->{LTI}{v1p3}{fallback_source_of_username});
+									$userIdSource = $ce->{LTI}{v1p3}{fallback_source_of_username} if $userId;
+								}
+								next unless defined $userId;
+								$userId =~ s/@.*$//
+									if $userIdSource eq 'email' && $ce->{LTI}{v1p3}{strip_domain_from_email};
+								$userId = lc($userId) if $ce->{LTI}{v1p3}{lowercase_username};
+
+								# Assert that the user id for the user is the same in all courses offered for selection.
+								# Otherwise things will fall apart when the content_selection method attempts to sign
+								# the user out of the initial guess course and into a different selected course.
+								$firstFoundUserId = $userId unless defined $firstFoundUserId;
+								next                        unless $userId eq $firstFoundUserId;
+
+								my $db   = WeBWorK::DB->new($ce);
+								my $user = $db->getUser($userId);
+
+								# Only allow courses for which the user has the email address set, and the email address
+								# matches the email address sent from the LMS. This means that if one course has the LTI
+								# user selection parameters set differently than another, then not all courses for the
+								# user will actually be listed. This should be considered a configuration error, and the
+								# system administrator should not set courses up this way.
+								next unless $user && $user->email_address && $claims->{email} eq $user->email_address;
+
+								# Only allow courses for which the user has the access_instructor_tools and
+								# modify_problem_sets permissions.  The WeBWorK::Authz object for this request has not
+								# yet been constructed, so the permissions check has to be performed manually.
+								my $permission = $db->getPermissionLevel($userId);
+								next
+									unless $permission
+									&& $permission->permission >=
+									$ce->{userRoles}{ $ce->{permissionLevels}{access_instructor_tools} }
+									&& $permission->permission >=
+									$ce->{userRoles}{ $ce->{permissionLevels}{modify_problem_sets} };
+
+								push(@userCourses, $_);
+							}
+						}
+						if (@userCourses) {
+							# Use the first matching course for initial authentication. All matching courses have the
+							# same LTI 1.3 authentication parameters, and so presumably authentication will work an any
+							# of them.
+							$c->stash->{courseID}      = $userCourses[0];
+							$c->stash->{courseChoices} = \@userCourses;
 						}
 					}
 				}
@@ -182,6 +277,13 @@ sub launch ($c) {
 			? (
 				courseID        => $c->stash->{courseID},
 				initial_request => 1,
+				$c->stash->{courseChoices}
+				? (
+					course_choices => $c->stash->{courseChoices},
+					lms_context_id =>
+						$c->stash->{lti_jwt_claims}{'https://purl.imsglobal.org/spec/lti/claim/context'}{id}
+					)
+				: (),
 				accept_multiple =>
 					$c->stash->{lti_jwt_claims}{'https://purl.imsglobal.org/spec/lti-dl/claim/deep_linking_settings'}
 					{accept_multiple},
@@ -208,7 +310,64 @@ sub content_selection ($c) {
 		errorMessage => $c->maketext('You are not authorized to modify sets.'))
 		unless $c->authz->hasPermissions($c->authen->{user_id}, 'modify_problem_sets');
 
-	if ($c->param('initial_request')) {
+	if ($c->param('initial_request') || $c->authen->flash('courseChoices')) {
+		my @courseChoices = $c->param('course_choices');
+		@courseChoices = @{ $c->authen->flash('courseChoices') }
+			if !@courseChoices && $c->authen->flash('courseChoices') && !$c->param('selected_course');
+		if (@courseChoices > 1) {
+			$c->authen->flash(courseChoices => \@courseChoices);
+			return $c->render(
+				'ContentGenerator/LTI/content_item_course_selection',
+				courseChoices => \@courseChoices,
+				forwardParams => {
+					accept_multiple      => $c->param('accept_multiple'),
+					deep_link_return_url => $c->param('deep_link_return_url'),
+					lms_context_id       => $c->param('lms_context_id'),
+					$c->param('data') ? (data => $c->param('data')) : (),
+				}
+			);
+		} elsif (@courseChoices) {
+			# If only one course matched for this user, then just use it.
+			# Add it to the course map and skip course selection.
+			$c->db->setLTICourseMap($courseChoices[0], $c->param('lms_context_id'));
+		}
+
+		my $selectedCourse = $c->param('selected_course');
+		if ($selectedCourse && $selectedCourse ne $c->ce->{courseName}) {
+			# The user has selected a course that is not the initial guess (the first course found that the user fit
+			# into), and the user was authenticated into that initial guess course. So sign the user out of that course,
+			# and sign the user into the selected course.  This does not go through the entire authentication process,
+			# but presumably that would succeed since the authhentication parameters for the two courses match and the
+			# permissions of the user were checked in both courses already.
+			my $key = $c->db->getKey($c->authen->{user_id});
+			$c->db->deleteKey($c->authen->{user_id});
+			$c->signed_cookie(
+				'WeBWorKCourseSession.' . $c->ce->{courseName},
+				'',
+				{
+					domain   => $c->app->sessions->cookie_domain,
+					expires  => time,
+					httponly => 1,
+					path     => $c->app->sessions->cookie_path,
+					samesite => $c->app->sessions->samesite,
+					secure   => $c->app->sessions->secure
+				}
+			);
+
+			$c->stash->{courseID} = $selectedCourse;
+			my $ce = eval { WeBWorK::CourseEnvironment->new({ courseName => $selectedCourse }) };
+			if ($@) {
+				$c->log->error("Failed to initialize course environment for $selectedCourse: $@");
+				return $c->render('ContentGenerator/LTI/content_item_selection_error',
+					errorMessage => $c->maketext('The course [_1] is not correctly configured.', $selectedCourse));
+			}
+			$c->ce($ce);
+			my $db = WeBWorK::DB->new($ce);
+			$c->db($db);
+			$c->setSessionParams;
+		}
+		$c->db->setLTICourseMap($selectedCourse, $c->param('lms_context_id')) if $selectedCourse;
+
 		return $c->render(
 			'ContentGenerator/LTI/content_item_selection',
 			visibleSets    => [ $c->db->getGlobalSetsWhere({ visible => 1 }, [qw(due_date set_id)]) ],

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -446,7 +446,7 @@ sub purge_expired_lti_data ($c, $ce, $db) {
 
 async sub registration ($c) {
 	return $c->render(json => { error => 'invalid configuration request' }, status => 400)
-		unless defined $c->req->param('openid_configuration') && defined $c->req->param('registration_token');
+		unless defined $c->req->param('openid_configuration');
 
 	# If we want to allow options in the configuration such as whether grade passback is enabled or to allow the LMS
 	# administrator to choose a tool name, then this should render a form that the LMS will be presented in an iframe
@@ -480,7 +480,9 @@ async sub registration ($c) {
 	my $registrationResult = (await Mojo::UserAgent->new->post_p(
 		$lmsConfiguration->{registration_endpoint},
 		{
-			Authorization  => 'Bearer ' . $c->req->param('registration_token'),
+			defined $c->req->param('registration_token')
+			? (Authorization => 'Bearer ' . $c->req->param('registration_token'))
+			: (),
 			'Content-Type' => 'application/json'
 		},
 		json => {
@@ -501,14 +503,18 @@ async sub registration ($c) {
 				'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'),
 			'https://purl.imsglobal.org/spec/lti-tool-configuration' => {
 				domain          => $rootURL->host_port,
+				description     => $c->maketext('WeBWorK Course Content'),
 				target_link_uri => $rootURL->to_string,
 				claims          => [ 'iss', 'sub', 'name', 'given_name', 'family_name', 'email' ],
 				messages        => [ {
 					type            => 'LtiDeepLinkingRequest',
+					label           => $c->maketext('WeBWorK Assignments'),
 					target_link_uri => $c->url_for('ltiadvantage_content_selection')->to_abs->to_string,
-					# Placements are specific to the LMS.  The following placements are needed for Canvas, and Moodle
-					# completely ignores this parameter. Does D2L need any? What about Blackboard?
-					placements => [ 'assignment_selection', 'course_assignments_menu' ]
+					# The following placements are needed for Canvas, and Moodle completely ignores this parameter,
+					# but if they are added for D2L then the message is rejected.
+					index($lmsConfiguration->{issuer}, '.instructure.com') != -1
+					? (placements => [ 'assignment_selection', 'course_assignments_menu' ])
+					: ()
 				} ]
 			}
 		}

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -180,7 +180,6 @@ sub launch ($c) {
 			%{ Mojo::URL->new($c->stash->{LTILaunchRedirect})->query->to_hash },
 			$c->stash->{isContentSelection}
 			? (
-
 				courseID        => $c->stash->{courseID},
 				initial_request => 1,
 				accept_multiple =>
@@ -257,7 +256,12 @@ sub content_selection ($c) {
 							type  => 'ltiResourceLink',
 							title => $c->maketext('WeBWorK Assignments'),
 							url   => $c->url_for('set_list', courseID => $c->stash->{courseID})->to_abs->to_string,
-							$c->ce->{LTIGradeMode} eq 'course' ? (lineItem => { scoreMaximum => 100 }) : ()
+							$c->ce->{LTIGradeMode} eq 'course'
+							? (
+								lineItem => { resourceId => 'course_grade', scoreMaximum => 100 },
+								window   => { targetName => '_blank' }
+								)
+							: ()
 							}
 						: (),
 						map { {
@@ -268,7 +272,19 @@ sub content_selection ($c) {
 								$c->url_for('problem_list', courseID => $c->stash->{courseID}, setID => $_->set_id)
 								->to_abs->to_string,
 							$c->ce->{LTIGradeMode} eq 'homework'
-							? (lineItem => { scoreMaximum => $setMaxScores{ $_->set_id } })
+							? (
+								lineItem => {
+									resourceId   => $_->set_id,
+									scoreMaximum => $setMaxScores{ $_->set_id }
+								},
+								available => {
+									startDateTime => $c->formatDateTime($_->open_date, '%Y-%m-%dT%H:%M:%S%z')
+								},
+								submission => {
+									endDateTime => $c->formatDateTime($_->due_date, '%Y-%m-%dT%H:%M:%S%z')
+								},
+								window => { targetName => '_blank' }
+								)
 							: ()
 						} } @selectedSets
 					]
@@ -481,7 +497,8 @@ async sub registration ($c) {
 				'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem',
 				'https://purl.imsglobal.org/spec/lti-ags/scope/lineitem.readonly',
 				'https://purl.imsglobal.org/spec/lti-ags/scope/result.readonly',
-				'https://purl.imsglobal.org/spec/lti-ags/scope/score'),
+				'https://purl.imsglobal.org/spec/lti-ags/scope/score',
+				'https://purl.imsglobal.org/spec/lti-nrps/scope/contextmembership.readonly'),
 			'https://purl.imsglobal.org/spec/lti-tool-configuration' => {
 				domain          => $rootURL->host_port,
 				target_link_uri => $rootURL->to_string,

--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -78,6 +78,13 @@
 	% my $default_choice;
 	%
 	% for my $actionID (@$formsToShow) {
+		% next
+			% if $actionID eq 'lms_roster_sync' && (
+				% !$ce->{LTIVersion}
+				% || $ce->{LTIVersion} ne 'v1p3'
+				% || $ce->{LTIGradeMode} ne 'homework'
+				% || !$db->getSettingValue('LTILineitemsURL')
+			% );
 		% # Check permissions
 		% next if $formPerms->{$actionID} && !$authz->hasPermissions(param('user'), $formPerms->{$actionID});
 		%

--- a/templates/ContentGenerator/Instructor/ProblemSetList/lms_date_sync_form.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/lms_date_sync_form.html.ep
@@ -1,0 +1,29 @@
+<div>
+	<div class="row mb-2">
+		<%= label_for lms_date_sync_select => maketext('Synchronize dates for which sets?'),
+			class => 'col-form-label col-form-label-sm col-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.lms_date_sync.scope' => [
+					[ maketext('all course sets') => 'all' ],
+					[ maketext('selected sets')   => 'selected', selected => undef ]
+				],
+				id => 'lms_date_sync_select', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="row mb-2">
+		<%= label_for lms_date_sync_direction => maketext('Synchronize dates in which direction?'),
+			class => 'col-form-label col-form-label-sm col-auto' =%>
+		<div class="col-auto">
+			<%= select_field 'action.lms_date_sync.direction' => [
+					[ maketext('to the LMS')   => 'to', selected => undef ],
+					[ maketext('from the LMS') => 'from' ]
+				],
+				id => 'lms_date_sync_direction', class => 'form-select form-select-sm' =%>
+		</div>
+	</div>
+	<div class="d-inline-block alert alert-info p-1 mb-2">
+		<em>
+			<%= maketext('Note: Only dates of sets for which the linitem URL is available can be synchronized.') =%>
+		</em>
+	</div>
+</div>

--- a/templates/ContentGenerator/Instructor/UserList.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList.html.ep
@@ -48,6 +48,13 @@
 	%
 	% for my $actionID (@$formsToShow) {
 		% next if $actionID eq 'reset_2fa' && !$ce->two_factor_authentication_enabled;
+		% next
+			% if $actionID eq 'lms_roster_sync' && (
+				% !$ce->{LTIVersion}
+				% || $ce->{LTIVersion} ne 'v1p3'
+				% || !$ce->{LTI}{v1p3}{preferred_source_of_username}
+				% || !$db->getSettingValue('LTINamesRolesServiceURL')
+			% );
 		% next if $formPerms->{$actionID} && !$authz->hasPermissions(param('user'), $formPerms->{$actionID});
 		%
 		% my $disabled = $actionID eq 'import' && !@$CSVList ? ' disabled' : '';

--- a/templates/ContentGenerator/Instructor/UserList/lms_roster_sync_form.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/lms_roster_sync_form.html.ep
@@ -1,0 +1,1 @@
+<span><%= maketext('Synchronize roster from the LMS.') =%></span>

--- a/templates/ContentGenerator/LTI/content_item_course_selection.html.ep
+++ b/templates/ContentGenerator/LTI/content_item_course_selection.html.ep
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html <%== $c->output_course_lang_and_dir %>>
+%
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1.0">
+	<title><%= maketext('Available Courses') %></title>
+	<%= stylesheet $c->url({ type => 'webwork', name => 'theme', file => 'bootstrap.css' }) =%>
+</head>
+%
+<body class="m-3">
+	<div class="container-fluid">
+		<%= form_for current_route, method => 'POST', begin =%>
+			<%= $c->hidden_authen_fields =%>
+			<%= hidden_field courseID => $courseID =%>
+			% for (keys %$forwardParams) {
+				<%= hidden_field $_ => $forwardParams->{$_} =%>
+			% }
+			<fieldset class="mb-3">
+				<legend><%= maketext('Available Courses') %></legend>
+				% for (@$courseChoices) {
+					<div class="form-check">
+						<%= radio_button selected_course => $_, id => "${_}_id", class => 'form-check-input',
+							required => undef =%>
+						<%= label_for "${_}_id" => $_, class => 'form-check-label' =%>
+					</div>
+				% }
+			</fieldset>
+			<%= submit_button maketext('Submit Choice'), class => 'btn btn-primary' =%>
+		<% end =%>
+	</div>
+</body>
+%
+</html>

--- a/templates/HelpFiles/InstructorProblemSetList.html.ep
+++ b/templates/HelpFiles/InstructorProblemSetList.html.ep
@@ -76,4 +76,22 @@
 	</dd>
 	<dt><%= maketext('Delete') %></dt>
 	<dd><%= maketext('Delete the sets checked below. Be careful, this cannot be undone.') %></dd>
+
+	% if (
+		% $ce->{LTIVersion}
+		% && $ce->{LTIVersion} eq 'v1p3'
+		% && $ce->{LTIGradeMode} eq 'homework'
+		% && $db->getSettingValue('LTILineitemsURL')
+	% ) {
+		<dt><%= maketext('Synchronize Set Dates with LMS.') %></dt>
+		<dd>
+			<%= maketext('Synchronize the dates for a single set or multiple sets to or from the LMS. This task is '
+				. 'performed in the job queue, and this page only enqueus that task. Go to the Job Manager to see the '
+				. 'status of the enqueued job. This will only work for sets for which the lineitem for the set is '
+				. 'available or can be obtained. That is all sets that are created via content selection from the LMS, '
+				. 'or manually created links in the LMS that have been used at least once. Note that date '
+				. 'synchronization via LTI is not supported by all LMSs.'
+				) =%>
+		</dd>
+	% }
 </dl>

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -176,6 +176,25 @@
 
 	<dt><%= maketext('Change the number of attempts allowed on a problem.') %></dt>
 	<dd><%= maketext('This is done from the "Sets Manager" page or the "Instructor tools" page.') %></dd>
+
+	% if (
+		% $ce->{LTIVersion}
+		% && $ce->{LTIVersion} eq 'v1p3'
+		% && $ce->{LTI}{v1p3}{preferred_source_of_username}
+		% && $db->getSettingValue('LTINamesRolesServiceURL')
+	% ) {
+		<dt><%= maketext('Synchronize users with the associated course in the LMS.') %></dt>
+		<dd>
+			<%= maketext('Select the "Synchronize LMS Roster" tab and click "Synchronize LMS Roster". '
+				. 'This will enqueue a job that will contact the LMS and retrieve the list of users in the associated '
+				. 'LMS course. Users that are in the LMS course but not in the WeBWorK course will be added. Users '
+				. 'that are not in the LMS course will have their status changed to "Drop". Users that are in the LMS '
+				. 'course and the WeBWorK course will have their data updated unless $LMSManageUserData is false. Note '
+				. 'that users that have a permission level above the $LTIAccountCreationCutoff will not be added or '
+				. 'modified. Go to the Job Manager to see the status of this job.'
+				) =%>
+		</dd>
+	% }
 </dl>
 
 <p>


### PR DESCRIPTION
If the new `$LTI{v1p3}{allowCourseSelection}` option is set to 1 and an instructor attempts to sign in via LTI 1.3 authentication from an LMS course that is not in the LTI course map for the site, then a list of webwork courses will be compiled that have matching LTI 1.3 parameters, that have a user that works for the LMS user with email_address set that matches the email address sent from the LMS, and such that the user has the access_instructor_tools and modify_problem_sets permissions. So it is important that the email_address be set in the webwork courses for the user. Also note that the LTI user id selection parameters (`preferred_source_of_username`, `fallback_source_of_username`, strip_domain_from_email`, and `lowercase_username`) have to be the same for all matching courses (effectively the settings from the first course found are used).
    
Then the user will be presented a list of courses to choose from (or if only one matching course is found that course will be used). When the user selects a course (or only on course matches), it will be automatically added to the LTI course map, and then content selection will continue as usual with that course.
    
For this to work, the user is authenticated into the first matching course. Then if the user chooses a different course, that authentication is transfered to the selected course. Authentication should work in any of them since all of the matching courses have the same LTI 1.3 parameters and the user in each course has the same user id, email address, and permissions.
    
If no matching courses are found or if the `$LTI{v1p3}{allowCourseSelection}` option is set to 0, then the context id is shown as before.

Note that the `$LTI{v1p3}{allowCourseSelection}` is necessarily a site wide option that cannot be configured per course.

Note that this is built on top of #2993.