### PR TITLE
Switch the docker build to Ubuntu 26.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN echo Cloning branch $PG_BRANCH branch from $PG_GIT_URL \
 
 # We need to change FROM before setting the ENV variables.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 ENV WEBWORK_URL=/webwork2 \
 	WEBWORK_ROOT_URL=http://localhost:8080 \
@@ -79,12 +79,17 @@ RUN apt-get update \
 	libclass-tiny-antlers-perl \
 	libclass-tiny-perl \
 	libcpanel-json-xs-perl \
+	libcrypt-dev \
 	libcrypt-jwt-perl \
+	libcrypt-openssl-x509-perl \
 	libcryptx-perl \
 	libdata-dump-perl \
 	libdata-structure-util-perl \
 	libdatetime-perl \
+	libdatetime-format-xsd-perl \
+	libdatetime-hires-perl \
 	libdbd-mysql-perl \
+	libdbd-mariadb-perl \
 	libdevel-checklib-perl \
 	libemail-address-xs-perl \
 	libemail-date-format-perl \
@@ -98,12 +103,14 @@ RUN apt-get update \
 	libfile-copy-recursive-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
+	libfile-slurper-perl \
 	libfuture-asyncawait-perl \
 	libgd-barcode-perl \
 	libgd-perl \
 	libhtml-scrubber-perl \
 	libhtml-template-perl \
 	libhttp-async-perl \
+	libio-compress-perl \
 	libiterator-perl \
 	libiterator-util-perl \
 	liblocale-maketext-lexicon-perl \
@@ -117,6 +124,11 @@ RUN apt-get update \
 	libmodule-pluggable-perl \
 	libmojolicious-perl \
 	libmojolicious-plugin-renderfile-perl \
+	libmoose-perl \
+	libmoosex-types-common-perl \
+	libmoosex-types-datetime-perl \
+	libmoosex-types-perl \
+	libmoosex-types-uri-perl \
 	libnet-https-nb-perl \
 	libnet-ip-perl \
 	libnet-ldap-perl \
@@ -131,6 +143,7 @@ RUN apt-get update \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
 	libsql-abstract-perl \
+	libssl-dev \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
 	libsvg-perl \
@@ -146,9 +159,12 @@ RUN apt-get update \
 	libtext-csv-perl \
 	libthrowable-perl \
 	libtimedate-perl \
+	libtypes-serialiser-perl \
 	libuniversal-can-perl \
 	libuniversal-isa-perl \
+	liburi-encode-perl \
 	libuuid-tiny-perl \
+	libxml-generator-perl \
 	libxml-parser-easytree-perl \
 	libxml-parser-perl \
 	libxml-semanticdiff-perl \
@@ -174,6 +190,8 @@ RUN apt-get update \
 	texlive-science \
 	texlive-xetex \
 	tzdata \
+	util-linux-extra \
+	zlib1g-dev \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
 	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
@@ -184,7 +202,6 @@ RUN apt-get update \
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
 RUN cpanm -n \
-	DBD::MariaDB \
 	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \
@@ -213,9 +230,6 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 # 6. Install third party javascript files.
 # 7. Apply patches
 
-# Patch files that are applied below
-COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
-
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& mkdir /run/webwork2 /etc/ssl/local \
 	&& cd $APP_ROOT/webwork2/ \
@@ -225,14 +239,12 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 		&& /usr/sbin/locale-gen \
 		&& echo "locales locales/default_environment_locale select en_US.UTF-8\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt \
 		&& debconf-set-selections /tmp/preseed.txt \
-	&& rm /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
+	&& rm -f /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
 		&& dpkg-reconfigure -f noninteractive tzdata \
 	&& cd $WEBWORK_ROOT/htdocs \
 		&& npm install \
 	&& cd $PG_ROOT/htdocs \
-		&& npm install \
-	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
-	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
+		&& npm install
 
 # ==================================================================
 # Phase 7 - Final setup and prepare docker-entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -126,6 +126,7 @@ RUN apt-get update \
 	libpandoc-wrapper-perl \
 	libpath-class-perl \
 	libpath-tiny-perl \
+	libperl-critic-perl \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
@@ -174,7 +175,7 @@ RUN apt-get update \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
-	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
 	&& apt-get clean \
 	&& rm -fr /var/lib/apt/lists/* /tmp/*
@@ -182,10 +183,9 @@ RUN apt-get update \
 # ==================================================================
 # Phase 4 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n \
-	Statistics::R::IO \
+RUN cpanm -n \
 	DBD::MariaDB \
-	Perl::Tidy@20220613 \
+	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -88,6 +88,7 @@ RUN apt-get update \
 	libpandoc-wrapper-perl \
 	libpath-class-perl \
 	libpath-tiny-perl \
+	libperl-critic-perl \
 	libphp-serialization-perl \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
@@ -136,7 +137,7 @@ RUN apt-get update \
 	texlive-xetex \
 	tzdata \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
-	&& curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
 	&& apt-get clean \
 	&& rm -fr /var/lib/apt/lists/* /tmp/*
@@ -144,10 +145,9 @@ RUN apt-get update \
 # ==================================================================
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
-RUN cpanm install -n \
-	Statistics::R::IO \
+RUN cpanm -n \
 	DBD::MariaDB \
-	Perl::Tidy@20220613 \
+	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \
 	&& rm -fr ./cpanm /root/.cpanm /tmp/*

--- a/DockerfileStage1
+++ b/DockerfileStage1
@@ -1,7 +1,7 @@
 # This is the Stage 1 Dockerfile, which builds a base OS image (webwork-base)
 # on top of which the WeBWorK parts will be installed by the Stage 2 Dockerfile.
 
-FROM ubuntu:24.04
+FROM ubuntu:26.04
 
 # ==================================================================
 # Phase 1 - Set base OS image install stage ENV variables
@@ -41,12 +41,17 @@ RUN apt-get update \
 	libclass-tiny-antlers-perl \
 	libclass-tiny-perl \
 	libcpanel-json-xs-perl \
+	libcrypt-dev \
 	libcrypt-jwt-perl \
+	libcrypt-openssl-x509-perl \
 	libcryptx-perl \
 	libdata-dump-perl \
 	libdata-structure-util-perl \
 	libdatetime-perl \
+	libdatetime-format-xsd-perl \
+	libdatetime-hires-perl \
 	libdbd-mysql-perl \
+	libdbd-mariadb-perl \
 	libdevel-checklib-perl \
 	libemail-address-xs-perl \
 	libemail-date-format-perl \
@@ -60,16 +65,17 @@ RUN apt-get update \
 	libfile-copy-recursive-perl \
 	libfile-find-rule-perl-perl \
 	libfile-sharedir-install-perl \
+	libfile-slurper-perl \
 	libfuture-asyncawait-perl \
 	libgd-barcode-perl \
 	libgd-perl \
 	libhtml-scrubber-perl \
 	libhtml-template-perl \
 	libhttp-async-perl \
+	libio-compress-perl \
 	libiterator-perl \
 	libiterator-util-perl \
 	liblocale-maketext-lexicon-perl \
-	libmariadb-dev \
 	libmath-random-secure-perl \
 	libmime-base32-perl \
 	libmime-tools-perl \
@@ -79,6 +85,11 @@ RUN apt-get update \
 	libmodule-pluggable-perl \
 	libmojolicious-perl \
 	libmojolicious-plugin-renderfile-perl \
+	libmoose-perl \
+	libmoosex-types-common-perl \
+	libmoosex-types-datetime-perl \
+	libmoosex-types-perl \
+	libmoosex-types-uri-perl \
 	libnet-https-nb-perl \
 	libnet-ip-perl \
 	libnet-ldap-perl \
@@ -93,6 +104,7 @@ RUN apt-get update \
 	libpod-wsdl-perl \
 	libsoap-lite-perl \
 	libsql-abstract-perl \
+	libssl-dev \
 	libstring-shellquote-perl \
 	libsub-uplevel-perl \
 	libsvg-perl \
@@ -108,9 +120,12 @@ RUN apt-get update \
 	libtext-csv-perl \
 	libthrowable-perl \
 	libtimedate-perl \
+	libtypes-serialiser-perl \
 	libuniversal-can-perl \
 	libuniversal-isa-perl \
+	liburi-encode-perl \
 	libuuid-tiny-perl \
+	libxml-generator-perl \
 	libxml-parser-easytree-perl \
 	libxml-parser-perl \
 	libxml-semanticdiff-perl \
@@ -136,6 +151,8 @@ RUN apt-get update \
 	texlive-science \
 	texlive-xetex \
 	tzdata \
+	util-linux-extra \
+	zlib1g-dev \
 	zip $ADDITIONAL_BASE_IMAGE_PACKAGES \
 	&& curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
 	&& apt-get install -y --no-install-recommends --no-install-suggests nodejs \
@@ -146,7 +163,6 @@ RUN apt-get update \
 # Phase 3 - Install additional Perl modules from CPAN that are not packaged for Ubuntu or are outdated in Ubuntu.
 
 RUN cpanm -n \
-	DBD::MariaDB \
 	Perl::Tidy@20260204 \
 	Archive::Zip::SimpleZip \
 	Net::SAML2 \

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -73,9 +73,6 @@ COPY --from=base /opt/base/pg $APP_ROOT/pg
 # 6. Install third party javascript files.
 # 7. Apply patches
 
-# Patch files that are applied below
-COPY docker-config/pgfsys-dvisvmg-bbox-fix.patch /tmp
-
 RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 	&& mkdir /run/webwork2 /etc/ssl/local \
 	&& cd $APP_ROOT/webwork2/ \
@@ -85,14 +82,12 @@ RUN echo "PATH=$PATH:$APP_ROOT/webwork2/bin" >> /root/.bashrc \
 		&& /usr/sbin/locale-gen \
 		&& echo "locales locales/default_environment_locale select en_US.UTF-8\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt \
 		&& debconf-set-selections /tmp/preseed.txt \
-	&& rm /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
+	&& rm -f /etc/localtime /etc/timezone && echo "Etc/UTC" > /etc/timezone \
 		&& dpkg-reconfigure -f noninteractive tzdata \
 	&& cd $WEBWORK_ROOT/htdocs \
 		&& npm install \
 	&& cd $PG_ROOT/htdocs \
-		&& npm install \
-	&& patch -p1 -d / < /tmp/pgfsys-dvisvmg-bbox-fix.patch \
-	&& rm /tmp/pgfsys-dvisvmg-bbox-fix.patch
+		&& npm install
 
 # ==================================================================
 # Phase 5 - Final setup and prepare docker-entrypoint.sh

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:10.4
+    image: mariadb:10.11
 
     # Set a fixed container name, so it does not depend on the directory name
     container_name: webwork2_db_1

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -1,6 +1,6 @@
 services:
   db:
-    image: mariadb:10.11
+    image: mariadb:11.8
 
     # Set a fixed container name, so it does not depend on the directory name
     container_name: webwork2_db_1
@@ -93,12 +93,12 @@ services:
         #- WEBWORK2_BRANCH=develop
         #- PG_BRANCH=develop
 
-      # If you would like a 1 stage build process comment out the next line, and just run "docker-compose build".
+      # If you would like a 1 stage build process comment out the next line, and just run "docker compose build".
       dockerfile: DockerfileStage2
       # For the 2 stage build process run
       #     docker build --tag webwork-base:forWW221 -f DockerfileStage1 .
       # and then
-      #     docker-compose build
+      #     docker compose build
       # When rebuilding to get updated images add the "--no-cache" option to both commands.
       # You can add something like
       #         --build-arg ADDITIONAL_BASE_IMAGE_PACKAGES="nano less"

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -102,7 +102,7 @@ if [ ! -d "$APP_ROOT/courses/admin" ]; then
 	umask 2
 	cd $APP_ROOT/courses
 	wait_for_db
-	$WEBWORK_ROOT/bin/addcourse admin --db-layout=sql_single --users=$WEBWORK_ROOT/courses.dist/adminClasslist.lst --professors=admin
+	$WEBWORK_ROOT/bin/addcourse admin --users=$WEBWORK_ROOT/courses.dist/adminClasslist.lst --professors=admin
 	chown www-data:www-data -R $APP_ROOT/courses
 	echo "Admin course is created."
 	echo "user: admin password: admin added to course admin and tables upgraded"

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -30,10 +30,10 @@ if [ "$SYSTEM_TIMEZONE" != "UTC" ]; then
 fi
 
 # Modify default papersize based on environment variable PAPERSIZE
-echo "Setting libpaper1 papersize to $PAPERSIZE"
-echo "libpaper1 libpaper/defaultpaper select $PAPERSIZE\nlibpaper1:amd64 libpaper/defaultpaper select $PAPERSIZE\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt
+echo "Setting libpaper2 papersize to $PAPERSIZE"
+echo "libpaper2 libpaper/defaultpaper select $PAPERSIZE\nlibpaper2:amd64 libpaper/defaultpaper select $PAPERSIZE\ndebconf debconf/frontend select Noninteractive" > /tmp/preseed.txt
 debconf-set-selections /tmp/preseed.txt
-dpkg-reconfigure -f noninteractive libpaper1
+dpkg-reconfigure -f noninteractive libpaper2
 
 # Install some extra packages
 if [ "$ADD_APT_PACKAGES" != "0" ]; then


### PR DESCRIPTION
The `DBD::MariaDB` package is provided by the Ubuntu `libdb-mariadb-perl` package again. So that does not need to be installed from cpan anymore.
    
Also change the mariadb docker image to version 11.8 to match the version used by Ubuntu 26.
    
The `libio-compress-perl` Ubuntu package is a dependency of the `Archive::Zip::SimpleZip` Perl package that is needed since the Perl packages it provides fail to build when installed from cpan. It may be that they just need some other build dependency, but it is better to install the Ubuntu packages anyway.
    
Several dependencies of the Perl `Net::SAML2` package were added to speed up the build some and avoid these being installed from cpan.
    
Remove `install` from the `cpanm` command.  That isn't a command or option for the `cpanm` command and results in the `install` perl package being installed which isn't needed.
    
The `pgfsys-dvisvgm-bbox-fix.patch` file is not needed for Ubuntu 26.  Its changes are included in upstream file installed on the system.
    
Fix the comments about executing `docker compose`.  That is no longer executed as `docker-compose`.
    
Update the `docker-entrypoint.sh` to use `libpapers2`.  The `libpapers1` package no longer exists.
    
The `newgrp` command used in the `docker-entrypoint.sh` script is no longer is installed by default.  The `util-linux-extra` package is needed for that.

Note that this is built on top of #2958.