### PR TITLE
add-on conf files

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -277,6 +277,9 @@ $webworkDirs{bin}           = "$webworkDirs{root}/bin";
 # Location of configuration files.
 $webworkDirs{conf}          = "$webworkDirs{root}/conf";
 
+# Location of add-on configuration files.
+$webworkDirs{addOnConf}     = "$webworkDirs{conf}/addon";
+
 # Location of assets (tex, pg, themes)
 $webworkDirs{assets}        = "$webworkDirs{root}/assets";
 

--- a/htdocs/js/CourseAdmin/restrict_select.js
+++ b/htdocs/js/CourseAdmin/restrict_select.js
@@ -1,31 +1,33 @@
 (() => {
 	const addOnConfSelect = document.getElementById('add_on_conf');
-	const addOnConfOptgroups = [...addOnConfSelect.querySelectorAll('optgroup')];
+	if (!addOnConfSelect) return;
+
+	const addOnConfOptgroups = addOnConfSelect.querySelectorAll('optgroup');
 
 	// Track previously selected options to identify the newly clicked option
 	let previousSelection = [];
 
-	addOnConfSelect.addEventListener('change', (event) => {
-		const currentSelection = Array.from(addOnConfSelect.selectedOptions);
-
+	addOnConfSelect.addEventListener('change', () => {
 		// Find the option the user just clicked/selected
-		const newlySelected = currentSelection.find((option) => !previousSelection.includes(option));
+		const newlySelected = Array.from(addOnConfSelect.selectedOptions).find(
+			(option) => !previousSelection.includes(option)
+		);
 
 		if (newlySelected) {
 			// Find the parent optgroup
 			const parent = newlySelected.closest('optgroup');
 
 			// Loop through all options in the other groups and unselect them as appropriate
-			addOnConfOptgroups.forEach((group) => {
-				Array.from(group.children).forEach((option) => {
+			for (const group of addOnConfOptgroups) {
+				for (const option of group.children) {
 					if (
 						option !== newlySelected &&
 						(parent.dataset.single || (!parent.dataset.single && group.dataset.single))
 					) {
 						option.selected = false;
 					}
-				});
-			});
+				}
+			}
 		}
 
 		// Update tracking variable for the next change event

--- a/htdocs/js/CourseAdmin/restrict_select.js
+++ b/htdocs/js/CourseAdmin/restrict_select.js
@@ -1,0 +1,34 @@
+(() => {
+	const addOnConfSelect = document.getElementById('add_on_conf');
+	const addOnConfOptgroups = [...addOnConfSelect.querySelectorAll('optgroup')];
+
+	// Track previously selected options to identify the newly clicked option
+	let previousSelection = [];
+
+	addOnConfSelect.addEventListener('change', (event) => {
+		const currentSelection = Array.from(addOnConfSelect.selectedOptions);
+
+		// Find the option the user just clicked/selected
+		const newlySelected = currentSelection.find((option) => !previousSelection.includes(option));
+
+		if (newlySelected) {
+			// Find the parent optgroup
+			const parent = newlySelected.closest('optgroup');
+
+			// Loop through all options in the other groups and unselect them as appropriate
+			addOnConfOptgroups.forEach((group) => {
+				Array.from(group.children).forEach((option) => {
+					if (
+						option !== newlySelected &&
+						(parent.dataset.single || (!parent.dataset.single && group.dataset.single))
+					) {
+						option.selected = false;
+					}
+				});
+			});
+		}
+
+		// Update tracking variable for the next change event
+		previousSelection = Array.from(addOnConfSelect.selectedOptions);
+	});
+})();

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -377,9 +377,12 @@ sub do_add_course ($c) {
 	# Include any optional arguments, including a template course and the course title and course institution.
 	my %optional_arguments;
 	if ($copy_from_course ne '') {
-		%optional_arguments             = map { $_ => 1 } $c->param('copy_component');
-		$optional_arguments{copyFrom}   = $copy_from_course;
-		$optional_arguments{copyConfig} = $c->param('copy_config_file');
+		%optional_arguments = map { $_ => 1 } $c->param('copy_component');
+		$optional_arguments{copyFrom} = $copy_from_course;
+		$optional_arguments{copyConfig} =
+			$c->param('copy_config_file') || ($c->param('add_on_conf') && $c->param('add_on_conf') eq '*');
+		$optional_arguments{addOnConf} =
+			$c->param('add_on_conf') && $c->param('add_on_conf') ne '*' ? [ $c->param('add_on_conf') ] : [];
 	}
 	if ($add_courseTitle ne '') {
 		$optional_arguments{courseTitle} = $add_courseTitle;

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -424,7 +424,12 @@ sub addCourse {
 		my $courseEnvFile = $ce->{courseFiles}{environment};
 		open my $fh, ">:utf8", $courseEnvFile
 			or die "failed to open $courseEnvFile for writing.\n";
-		writeCourseConf($fh);
+		my $addOnConf     = $options{addOnConf} // [];
+		my $relConfFolder = File::Spec->abs2rel($ce->{webworkDirs}{addOnConf}, $ce->{webworkDirs}{root});
+		for (@$addOnConf) {
+			$_ = File::Spec->catfile($relConfFolder, $_);
+		}
+		writeCourseConf($fh, $addOnConf);
 		close $fh;
 	}
 
@@ -1172,24 +1177,36 @@ sub protectQString {
 	return $string;
 }
 
-=item writeCourseConf($fh)
+=item writeCourseConf($fh, $addOnConf)
 
 Writes an essentially empty course.conf file to $fh, a file handle. System
 administrators can use this file to override global settings for a course.
+$addOnConf should be an array reference of config files to tack on at the end.
 
 =back
 
 =cut
 
 sub writeCourseConf {
-	my ($fh) = @_;
+	my ($fh, $addOnConf) = @_;
 
-	print $fh <<'EOF';
+	my $content = <<'EOF';
 #!perl
 
 # This file is used to override the global WeBWorK course environment for this course.
 
 EOF
+
+	if ($addOnConf ne '') {
+		for my $conf (@$addOnConf) {
+			$content .= <<"EOF";
+
+include('$conf');
+EOF
+		}
+	}
+
+	print $fh $content;
 }
 
 sub get_SeedCE

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -1179,9 +1179,10 @@ sub protectQString {
 
 =item writeCourseConf($fh, $addOnConf)
 
-Writes an essentially empty course.conf file to $fh, a file handle. System
-administrators can use this file to override global settings for a course.
-$addOnConf should be an array reference of config files to tack on at the end.
+Writes the course.conf file to C<$fh>, a file handle. System administrators can
+use this file to override global settings for a course.  If C<$addOnConf> is
+provided, then it should be a reference to an array of config files to be
+included at the end of the course.conf file.
 
 =back
 
@@ -1197,12 +1198,9 @@ sub writeCourseConf {
 
 EOF
 
-	if ($addOnConf ne '') {
+	if (ref $addOnConf eq 'ARRAY') {
 		for my $conf (@$addOnConf) {
-			$content .= <<"EOF";
-
-include('$conf');
-EOF
+			$content .= "\ninclude('$conf');";
 		}
 	}
 

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -221,11 +221,10 @@
 				<%= maketext('course institution (will override "Institution" input above)') =%>
 			</label>
 		</div>
-		% my $addOnConfFolder = $ce->{webworkDirs}{addOnConf};
 		% my @addOnConfFiles;
-		% if (-d $addOnConfFolder) {
-			% @addOnConfFiles = glob "$addOnConfFolder/*.conf";
-			% for (0..$#addOnConfFiles){
+		% if (-d $ce->{webworkDirs}{addOnConf}) {
+			% @addOnConfFiles = glob "$ce->{webworkDirs}{addOnConf}/*.conf";
+			% for (0 .. $#addOnConfFiles){
 				% $addOnConfFiles[$_] =~ s/^.*\/|\.conf$//g;
 			% }
 		% }

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -1,5 +1,9 @@
 % use WeBWorK::Utils::CourseManagement qw(listCourses);
 %
+% content_for js => begin
+    <%= javascript getAssetURL($ce, 'js/CourseAdmin/restrict_select.js'), defer => undef =%>
+% end
+%
 % # Create an array of permission values for the permission selects.
 % my $permissionLevels = [];
 % for my $role (sort { $ce->{userRoles}{$a} <=> $ce->{userRoles}{$b} } keys %{ $ce->{userRoles} }) {
@@ -233,11 +237,13 @@
 					<%= select_field add_on_conf => [
 							c(
 								maketext('Use Default')
-									=> [ [ maketext('Distribution Default Config File') => '' ] ]
+									=> [ [ maketext('Distribution Default Config File') => '' ] ],
+								'data-single' => 'true'
 							),
 							c(
 								maketext('Source Course')
-									=> [ [ maketext("Source Course's Config File") => '*' ] ]
+									=> [ [ maketext("Source Course's Config File") => '*' ] ],
+								'data-single' => 'true'
 							),
 							c(
 								maketext('Append to Distribution Default')

--- a/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/add_course_form.html.ep
@@ -217,26 +217,62 @@
 				<%= maketext('course institution (will override "Institution" input above)') =%>
 			</label>
 		</div>
-		<div class="form-check mt-3 mb-2">
-			<label class="form-check-label">
-				<%= check_box copy_config_file => 1, class => 'form-check-input' =%>
-				<%= maketext('course configuration file') =%>
-				<a class="help-popup" role="button" tabindex="0" data-bs-placement="top" data-bs-toggle="popover"
-					 data-bs-content="<%= maketext('Copying the course configuration file may copy configuration '
-						. 'settings that are specific to the original course instructor. If this is a new course '
-						. 'for a new instructor, use the fields above to add the new instructor and do not copy '
-						. 'the course configuration file. Then if there is something in the course configuration '
-						. 'file that should be carried into the new course, the administrator can copy that manually. '
-						. 'Alternatively, do copy the course configuration file, but then the administrator should '
-						. 'inspect the new course configuration file and make adjustments for the new instructor.') =%>"
-					>
-					<i class="icon fas fa-question-circle" aria-hidden="true"></i>
-					<span class="visually-hidden">
-						<%= maketext('Notes regarding copying the course configuration file') =%>
-					</span>
-				</a>
-			</label>
-		</div>
+		% my $addOnConfFolder = $ce->{webworkDirs}{addOnConf};
+		% my @addOnConfFiles;
+		% if (-d $addOnConfFolder) {
+			% @addOnConfFiles = glob "$addOnConfFolder/*.conf";
+			% for (0..$#addOnConfFiles){
+				% $addOnConfFiles[$_] =~ s/^.*\/|\.conf$//g;
+			% }
+		% }
+		% if (@addOnConfFiles) {
+			<div class="row my-2">
+				<%= label_for add_on_conf => maketext('Configuration File:'),
+					class => 'col-auto col-form-label fw-bold' =%>
+				<div class="col-auto">
+					<%= select_field add_on_conf => [
+							c(
+								maketext('Use Default')
+									=> [ [ maketext('Distribution Default Config File') => '' ] ]
+							),
+							c(
+								maketext('Source Course')
+									=> [ [ maketext("Source Course's Config File") => '*' ] ]
+							),
+							c(
+								maketext('Append to Distribution Default')
+									=> [ map { [ $_ => "$_.conf" ] } @addOnConfFiles ]
+							)
+						],
+						id       => 'add_on_conf',
+						multiple => undef,
+						size     => 8,
+						class    => 'form-select' =%>
+				</div>
+			</div>
+		% } else {
+			<div class="form-check mt-3 mb-2">
+				<label class="form-check-label">
+					<%= check_box copy_config_file => 1, class => 'form-check-input' =%>
+					<%= maketext('course configuration file') =%>
+					<a class="help-popup" role="button" tabindex="0" data-bs-placement="top"
+						data-bs-toggle="popover" data-bs-content="<%= maketext('Copying the course configuration '
+							. 'file may copy configuration settings that are specific to the original course '
+							. 'instructor. If this is a new course for a new instructor, use the fields above to '
+							. 'add the new instructor and do not copy the course configuration file. Then if '
+							. 'there is something in the course configuration file that should be carried into '
+							. 'the new course, the administrator can copy that manually.  Alternatively, do copy '
+							. 'the course configuration file, but then the administrator should inspect the new '
+							. 'course configuration file and make adjustments for the new instructor.') =%>"
+						>
+						<i class="icon fas fa-question-circle" aria-hidden="true"></i>
+						<span class="visually-hidden">
+							<%= maketext('Notes regarding copying the course configuration file') =%>
+						</span>
+					</a>
+				</label>
+			</div>
+		% }
 	</fieldset>
 	<%= hidden_field last_page_was_add_course => 1 =%>
 	<%= $c->hidden_fields('number_of_additional_users') =%>

--- a/templates/HelpFiles/AdminAddCourse.html.ep
+++ b/templates/HelpFiles/AdminAddCourse.html.ep
@@ -18,10 +18,15 @@
 		. 'creating future courses, or manage and email course users.  Note, by default these new users will be '
 		. '"Dropped" and unable to login to the [_1] course.', $ce->{admin_course_id}) =%>
 </p>
-<p class="mb-0">
+<p>
 	<%= maketext('You may choose a course to copy components from. Select the course and which components to copy.  '
 		. 'If the course is not a true course (like the modelCourse) then only the templates and html folders, '
 		. 'and the simple and course config files can be copied. The "simple config" file contains the settings '
 		. 'made in the "Course Config" page. The "course config" file should only be copied if you know what you '
 		. 'are doing.') =%>
+</p>
+<p class="mb-0">
+	<%= maketext('If there are .conf files in the [_1] folder, you may select a number of these to include at the '
+		. 'end of the course.conf file. This only applies when not copying a course.conf file from another course.',
+		$ce->{webworkDirs}{addOnConf}) =%>
 </p>


### PR DESCRIPTION
This allows for there to be a folder `webwork2/conf/addon/` (or some other name, overridden in `localOverrides.conf`) where you can store `.conf` files. This has to do with #2999.

When adding a new course from the admin course, you can select one or more of these config files to be included at the end of the new course's `course.conf` file. If the new course is copying a `course.conf` file from some other course, nothing happens with `.conf` files from the `addon` folder.

If there is no `addon` folder, or if it has no `.conf` files in it, there is no change in the Add Course page. Otherwise, the checkbox for copying an old course's `course.conf` file is gone, and there is one select. The select has three optgroups:

1. The first has only one option, to just make the default `course.conf` file. This is also what will happen if the form is submitted with no selection made.
2. The second has only one option: copy the `course.conf` file from the indicated older course.
3. The third has all of the `.conf` files from the `addon` folder.

The select allows multiple selections. This needs one more thing where I need javascript help from @drgrice1. If the option from the first or second optgroup is selected, all other options need to be de-selected. Googling, I see how to do this with javascript. But I'm not sure where to build that javascript properly for its use here. That is, I'm not sure what I should do instead of writing inline script.