### PR TITLE
Make permissions for viewing an edit file consistent within the `Problem.pm` package.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1248,19 +1248,14 @@ sub output_misc ($c) {
 		$c->hidden_field(showOldAnswers => $c->{will}{showOldAnswers}),
 		$c->hidden_field(displayMode    => $c->{displayMode}));
 
-	push(@$output, $c->hidden_field(editMode => $c->{editMode}))
-		if defined $c->{editMode} && $c->{editMode} eq 'temporaryFile';
-
-	my $permissionLevel          = $c->db->getPermissionLevel($c->param('user'))->permission;
-	my $professorPermissionLevel = $c->ce->{userRoles}{professor};
-
-	# Only allow this for professors
-	push(@$output, $c->hidden_field(sourceFilePath => $c->{problem}{source_file}))
-		if defined $c->{problem}{source_file} && $permissionLevel >= $professorPermissionLevel;
-
-	# Only allow this for professors
-	push(@$output, $c->hidden_field(problemSeed => $c->param('problemSeed')))
-		if defined $c->param('problemSeed') && $permissionLevel >= $professorPermissionLevel;
+	# Only allow file editing for users that have the permission to modify problem sets.
+	if ($c->authz->hasPermissions($c->param('user'), 'modify_problem_sets')) {
+		push(@$output, $c->hidden_field(editMode => $c->{editMode}))
+			if defined $c->{editMode} && $c->{editMode} eq 'temporaryFile';
+		push(@$output, $c->hidden_field(sourceFilePath => $c->{problem}{source_file}))
+			if defined $c->{problem}{source_file};
+		push(@$output, $c->hidden_field(problemSeed => $c->param('problemSeed'))) if defined $c->param('problemSeed');
+	}
 
 	# Make sure the student nav filter setting is preserved when the problem form is submitted.
 	push(@$output, $c->hidden_field(studentNavFilter => $c->param('studentNavFilter')))


### PR DESCRIPTION
Currently if the `modify_problem_sets` permssion level is set to "ta", then a "ta" user can use the problem editor.  However, if the user selects "Open in a new window" with a different seed than is set in the database for that user or has made local edits saved to a temporary file, then the problem will initially render with that seed and temporary file, but if the "Check Answers" button is used the problem reverts to using the user's seed and source file for the problem from the database.  This is because the package is inconsistent on the permissions conditions that it uses.  When the problem to render is selected in initialization the `modify_problem_sets` permission is used. However, when it is deteremined if the `sourceFilePath` and `problemSeed` parameters can be hidden in the form, it is checked instead that the user has the "professor" permission level.

To fix this those checks need to be made consistent.  The "professor" permission level check was incorrect, and the `modify_problem_sets` permission should be used instead.

This fixes issue #746. Webwork2's oldest open issue!