### PR TITLE
Some odds and ends that I have had sitting here for a couple of years now.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -226,7 +226,7 @@ sub pre_header_initialize ($c) {
 				$method_to_call = 'do_registration';
 			}
 		} else {
-			@errors = "Unrecognized sub-display @{[ $c->tag('b', $subDisplay) ]}.";
+			@errors = "Unrecognized sub-display $subDisplay.";
 		}
 	}
 

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -29,7 +29,6 @@
 			% $seconds %= 3600;
 			% my $minutes = int($seconds / 60);
 			% $seconds %= 60;
-			% my $timeText = '';
 			%
 			% # Several cases are needed to format time to work well with translation.
 			% if ($hours && $minutes) {
@@ -40,7 +39,7 @@
 						$minutes
 					) =%>
 				</div>
-			% } elsif ($hours || ($minutes && (!$seconds || $seconds > 299))) {
+			% } elsif ($hours || ($minutes && (!$seconds || $continueTimeLeft > 299))) {
 				% # Translation Note: In this case only one of hours or minutes is non-zero,
 				% # so the zero case of the "quant" will be used for the other one.
 				<div class="alert alert-warning">
@@ -94,7 +93,6 @@
 	% if ($timeLimit > 0) {
 		% my $hours    = int($timeLimit / 3600);
 		% my $minutes  = int(($timeLimit % 3600) / 60);
-		% my $timeText = '';
 		%
 		% # Two cases to format time to work well with translation.
 		% if ($hours && $minutes) {


### PR DESCRIPTION
This is house cleaning for me.  I want to delete this branch.

Remove the bold tag from the unused sub-display error for the admin course.  The errors in the error list that message is added to are html escaped, and so it can not contain html.  The errors could be prevented from being escaped, but I see no reason to do so for that one message. None of the much more important errors added to that list use html.  This particular message will almost never be seen unless a user is manually editing the URL with an incorrect subDisplay parameter.

Remove an unused variable in `templates/ContentGenerator/ProblemSet/version_list.html.ep`, and fix a minor issue with the remaining time shown for tests when viewing the test information page and a timed test is in progress.