### PR TITLE
Fix contrast when viewing the xml of a hardcopy theme in the PG editor in dark mode.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -613,7 +613,8 @@
 			if (fileType === 'hardcopy_theme') {
 				const contents = webworkConfig?.pgCodeMirror?.source;
 				if (contents) {
-					renderArea.innerHTML = '<pre>' + contents.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</pre>';
+					renderArea.innerHTML =
+						'<pre class="text-dark">' + contents.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</pre>';
 				} else
 					renderArea.innerHTML =
 						'<div class="alert alert-danger p-1 m-2 fw-bold">The file has no content.</div>';


### PR DESCRIPTION
The `bg-white` class is set for the containing panel for the view area in the PG editor.  So for the text to be dark so that it works even in dark mode.

This is the quick and easy fix.  Better probably would be to use a color scheme responsive class such as the `bg-light` class (as is done for course info files). Then in dark mode you would get a dark background with light colored text.  However, that would change the background color in light mode.  Currently the background is actual white in light mode, and the `bg-light` class is an off white (same as the background of the site navigation).