### PR TITLE
Fix a warning due to the way the sort methods are called in the job manager.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/JobManager.pm
@@ -106,7 +106,7 @@ sub initialize ($c) {
 	# first three sorts do not determine a proper order.
 	$c->stash->{sortedJobs} = [
 		map  { $_->{id} }
-		sort { &$primarySortSub || &$secondarySortSub || &$ternarySortSub || byJobID }
+		sort { $primarySortSub->() || $secondarySortSub->() || $ternarySortSub->() || byJobID() }
 		grep { $c->stash->{visibleJobs}{ $_->{id} } } (values %{ $c->stash->{jobs} })
 	];
 


### PR DESCRIPTION
Currently the sort methods are called with the ampersand sigil.  That implies the argument of `@_` and with recent versions of Perl that causes the warning `Implicit use of @_ in subroutine entry with signatured subroutine is experimental`.

This exact same issue was fixed for the accounts manager page in #2607, and this is the same thing exactly and fixed in the same way.