### PR TITLE
Fix a major bug with the navigation that everyone has certainly seen.

### DIFF
--- a/htdocs/js/System/system.js
+++ b/htdocs/js/System/system.js
@@ -11,7 +11,7 @@
 			navigation_element.classList.remove('invisible');
 			content.classList.toggle('toggle-width');
 
-			if (currentWidth < threshold) {
+			if (currentWidth <= threshold) {
 				const overlay = document.createElement('div');
 				overlay.classList.add('sidebar-backdrop');
 				document.body.append(overlay);
@@ -27,28 +27,28 @@
 
 		document.getElementById('toggle-sidebar')?.addEventListener('click', toggleSidebar);
 
-		if (currentWidth < threshold) navigation_element.classList.add('invisible');
+		if (currentWidth <= threshold) navigation_element.classList.add('invisible');
 
 		navigation_element.addEventListener('transitionend', () => {
 			if (
-				(window.innerWidth >= threshold && navigation_element.classList.contains('toggle-width')) ||
-				(window.innerWidth < threshold && !navigation_element.classList.contains('toggle-width'))
+				(window.innerWidth > threshold && navigation_element.classList.contains('toggle-width')) ||
+				(window.innerWidth <= threshold && !navigation_element.classList.contains('toggle-width'))
 			)
 				navigation_element.classList.add('invisible');
 		});
 
 		// If the window width changes open or close the sidebar appropriately.
 		window.addEventListener('resize', () => {
-			if (!navigation_element.classList.contains('toggle-width') && window.innerWidth >= threshold)
+			if (!navigation_element.classList.contains('toggle-width') && window.innerWidth > threshold)
 				navigation_element.classList.remove('invisible');
 
 			if (
 				(navigation_element.classList.contains('toggle-width') &&
-					window.innerWidth < threshold &&
-					currentWidth >= threshold) ||
+					window.innerWidth <= threshold &&
+					currentWidth > threshold) ||
 				(navigation_element.classList.contains('toggle-width') &&
-					window.innerWidth >= threshold &&
-					currentWidth < threshold)
+					window.innerWidth > threshold &&
+					currentWidth <= threshold)
 			) {
 				currentWidth = window.innerWidth;
 				toggleSidebar();

--- a/htdocs/js/System/system.scss
+++ b/htdocs/js/System/system.scss
@@ -153,7 +153,7 @@ $site-nav-width: 250px !default;
 	padding: 2px;
 
 	&.toggle-width {
-		left: -20%;
+		left: -250px;
 		border-right-width: 0px;
 	}
 


### PR DESCRIPTION
Well, @somiaj has at least.  If you have your window size set to exactly the breakpoint (which is 768 pixels), then the site navigation will not open.  The `=` needs to be on the other side of the check in `htdocs/js/System/system.js`.