### PR TITLE
Re-render a problem in the PG problem editor after a perltidy failure.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -242,11 +242,13 @@
 				}
 				if (request_object.pgCode === data.result_data.tidiedPGCode) {
 					showMessage('There were no changes to the code.', true);
+					if (!(renderArea.firstChild instanceof HTMLIFrameElement)) render();
 				} else {
 					if (webworkConfig?.pgCodeMirror) webworkConfig.pgCodeMirror.source = data.result_data.tidiedPGCode;
 					else document.getElementById('problemContents').value = data.result_data.tidiedPGCode;
 					saveTempFile();
 					showMessage('Successfully perltidied code.', true);
+					if (!(renderArea.firstChild instanceof HTMLIFrameElement)) render();
 				}
 			})
 			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));


### PR DESCRIPTION
When editing a problem and the code has a syntax error that prevents perltidy from working, if perltidy is then used it shows the errors from running perltidy.  If you then fix those errors and run perltidy again, the toast shows that pertidy was successful, but the errors are still shown in the render window.

This pull request makes it so that when perltidy is successfully executed after a previous executing failed, then the problem is re-rendered, thus removing the perltidy errors.  This is detected simply by checking if the render area contains an iframe or not.

This addresses issue #3012.