### PR TITLE
Pgeditor critic dark mode

### DIFF
--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -179,7 +179,7 @@
 			<div class="pgedit-panel render mb-lg-0 order-first order-lg-last bg-white">
 				<div class="p-0" id="pgedit-render-area">
 					<div class="placeholder d-flex flex-column justify-content-center
-						 align-items-center bg-secondary h-100">
+						 align-items-center bg-secondary-subtle h-100">
 						<div class="fs-1"><%= maketext('Loading...') %></div>
 						<i class="fa-solid fa-spinner fa-spin fa-2x"></i>
 					</div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
@@ -1,6 +1,6 @@
 % Perl::Critic::Violation::set_format('%m at line %l, column %c.');
 %
-<div class="m-3 overflow-auto">
+<div class="m-3 overflow-auto text-dark">
 	<h2><%= maketext('PG Critic Violations') %></h2>
 	% my @pgCriticViolations   = grep { $_->policy =~ /^Perl::Critic::Policy::PG::/ } @$violations;
 	% my @perlCriticViolations = grep { $_->policy !~ /^Perl::Critic::Policy::PG::/ } @$violations;


### PR DESCRIPTION
This is basically the same fix used for the hardcopy theme xml preview. This just adds the `text-dark` class to the container.

Also switch the "Loading..." placeholder that shows while a problem is rendering to using the `bg-secondary-subtle` background instead of the `bg-secondary` background.  The `bg-secondary-subtle` background is responsive to the color scheme, and so works for both light or dark mode.

Maybe this fixes all the cases for the editor now?