### PR TITLE
Set default in achievement evaluator editor save as form.

### DIFF
--- a/templates/ContentGenerator/Instructor/AchievementEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/AchievementEditor/save_as_form.html.ep
@@ -1,5 +1,6 @@
 % # There are three things you can do with a new achievement editor.
 % # You can replace the current achievement, use it in a new achievement, or not use it at all.
+% param('action.save_as.saveMode', 'use_in_current') unless param('action.save_as.saveMode');
 <div>
 	<div class="row align-items-center mb-2">
 		<%= label_for 'action.save_as.target_file_id' => maketext('Save as:'), class => 'col-form-label col-auto' =%>


### PR DESCRIPTION
Set the first option to use the achievement evaluator in the current achievement as the default selected option in the save as form of the achievement evaluator editor if it was not already set from a previous post. This fixes #2795.

In testing this, this only fixes the issue I ran across where nothing was set as default. There are still some oddities and that could be improved. If you choose to `Save as` a new achievement, the new file is created, but the editor reverts back to the evaluator of the current achievement. Overall this form needs improved and is not addressed here, as any issues are just current behavior.