### PR TITLE
LTI 1.1 configure number of digits to round score.

### DIFF
--- a/conf/authen_LTI.conf.dist
+++ b/conf/authen_LTI.conf.dist
@@ -240,6 +240,7 @@ $LTIMassUpdateInterval = 86400;
 	#'LTISendGradesEarlyThreshold',
 	#'LTIMassUpdateInterval',
 	#'LMSManageUserData',
+	#'LTI{v1p1}{round_score_digits}',
 	#'LTI{v1p1}{BasicConsumerSecret}',
 	#'LTI{v1p3}{PlatformID}',
 	#'LTI{v1p3}{ClientID}',

--- a/conf/authen_LTI_1_1.conf.dist
+++ b/conf/authen_LTI_1_1.conf.dist
@@ -19,6 +19,13 @@ $LTI{v1p1}{LMS_name} = 'the LMS';
 $LTI{v1p1}{LMS_url} = '';
 #$LTI{v1p1}{LMS_url} = 'https://myschool.edu/lms/';
 
+# This sets the number of decimal digits to round the score (a value between 0 and 1) sent to the LMS.
+# A setting of 2 means the score is rounded to 2 digits or the nearest whole percent. Setting this to
+# a number less than 2 will disable rounding. Note that there maybe some rounding since floats are
+# used to compute and save scores in the database and LMS may round the score received.
+$LTI{v1p1}{round_score_digits} = 2;
+#$LTI{v1p1}{round_score_digits} = 0;  # Disable rounding.
+
 ################################################################################################
 # LTI 1.1 preferred and fallback source of WW user_id
 ################################################################################################

--- a/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced/SubmitGrade.pm
@@ -168,11 +168,13 @@ async sub submit_set_grade ($self, $userID, $setID, $submittedSet = undef) {
 
 # Submits a score of $score to the lms with $sourcedid as the identifier.
 async sub submit_grade ($self, $sourcedid, $score) {
-	my $c  = $self->{c};
-	my $ce = $c->{ce};
-	my $db = $c->{db};
+	my $c      = $self->{c};
+	my $ce     = $c->{ce};
+	my $db     = $c->{db};
+	my $digits = $ce->{LTI}{v1p1}{round_score_digits} // 2;
 
-	$score = wwRound(2, $score);
+	# Disable rounding unless rounding to two or more digits, which is the nearest whole percent.
+	$score = wwRound($digits, $score) if $digits > 1;
 
 	my $request_url = $db->getSettingValue('lis_outcome_service_url');
 	if (!$request_url) {

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -1087,6 +1087,21 @@ sub getConfigValues ($ce) {
 			),
 			type => 'boolean'
 		},
+		'LTI{v1p1}{round_score_digits}' => {
+			var => 'LTI{v1p1}{round_score_digits}',
+			doc => x(
+				'Number of digits to round the score (between 0 and 1) sent to the LMS using LTI 1.1. '
+					. '(0 => disable rounding)'
+			),
+			doc2 => x(
+				'This sets the number of decimal digits to round the set score (a value between 0 and 1) sent to the '
+					. 'LMS using LTI 1.1.  A setting of 2 means the score is rounded to 2 digits or the nearest whole '
+					. 'percent.  Setting this to a number less than 2 will disable rounding.  Note that there maybe '
+					. 'some rounding since floats are used to compute and save scores in the database and the LMS may '
+					. 'round the score it recives.'
+			),
+			type => 'number'
+		},
 		'LTI{v1p1}{BasicConsumerSecret}' => {
 			var  => 'LTI{v1p1}{BasicConsumerSecret}',
 			doc  => x('LMS shared secret for LTI 1.1 authentication'),


### PR DESCRIPTION
This adds a configuration option `$LTI{v1p1}{round_score_digits}` which sets the number of digits to round the score to before sending it to the LMS. If this is set to a number less than 2 (nearest whole percent), then rounding of the score is disabled. The default is `2` which is current behavior.

This was requested in #2785.