### PR TITLE
Disabled tabs for the PG editor.

### DIFF
--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -204,11 +204,12 @@
 		% my $line_contents = include("ContentGenerator/Instructor/PGProblemEditor/${actionID}_form");
 		% my $active        = '';
 		% my $disabled =
-			% $actionID eq 'revert'
-			% && (!defined($c->{tempFilePath}) || !-e $c->{tempFilePath})
-			% && !$c->getBackupTimes ? ' disabled' : '';
+			% ($actionID eq 'revert' && (!defined($c->{tempFilePath}) || !-e $c->{tempFilePath}) && !$c->getBackupTimes)
+			% || ($actionID eq 'save' && $line_contents eq '')
+			% || ($actionID eq 'add_problem' && $c->{is_pg} && $line_contents eq '')
+				% ? ' disabled' : '';
 		%
-		% if (($line_contents && $line_contents ne '') || $actionID eq 'revert') {
+		% if (($line_contents && $line_contents ne '') || $disabled) {
 			% unless ($default_choice) { $active = ' active'; $default_choice = $actionID; }
 			% content_for 'tab-list' => begin
 				<li class="nav-item" role="presentation">

--- a/templates/HelpFiles/InstructorPGProblemEditor.html.ep
+++ b/templates/HelpFiles/InstructorPGProblemEditor.html.ep
@@ -127,67 +127,99 @@
 </dl>
 
 <h2><%= maketext('Actions:') %></h2>
-<i><%= maketext('(If an action cannot be executed it will not appear.)') %></i>
 <dl>
 	<dt><%= maketext('View/Reload') %></dt>
 	<dd>
-		<%= maketext('Render or re-render the problem, course info file, or set header being edited. This does not '
-			. 'change the permanent file on the disk. You can view different versions of the same problem by changing '
-			. 'the seed. You can also change the manner in which the mathematics is typeset. If "Open in new window" '
-			. 'is checked, then the problem will open in a new tab or window showing the problem as it will be '
-			. 'rendered for students in the set.') =%>
+		<p>
+			<%= maketext('Render or re-render the problem, course info file, or set header being edited. This does not '
+				. 'change the permanent file on the disk. You can view different versions of the same problem by '
+				. 'changing the seed. You can also change the manner in which the mathematics is typeset. If "Open in '
+				. 'new window" is checked, then the problem will open in a new tab or window showing the problem as it '
+				. 'will be rendered for students in the set.') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is available for all file types except hardcopy header files.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Generate Hardcopy') %></dt>
 	<dd>
 		<p>
-		<%= maketext('Generate a hardcopy of the problem being edited. This does not change the permanent file on the '
-			. 'disk. You can generate a hardcopy for different versions of the same problem by changing the seed. You '
-			. 'can also change the format to "PDF" or "TeX Source". If "PDF" is selected, then a PDF file will be '
-			. 'generated for download, unless there are errors. If errors occur or "TeX Source" is selected, then a '
-			. 'zip file will be generated for download that contains the TeX source file and resources needed for '
-			. 'generating the PDF file using LaTeX.') =%>
+			<%= maketext('Generate a hardcopy of the problem being edited. This does not change the permanent file on '
+				. 'the disk. You can generate a hardcopy for different versions of the same problem by changing the '
+				. 'seed. You can also change the format to "PDF" or "TeX Source". If "PDF" is selected, then a PDF '
+				. 'file will be generated for download, unless there are errors. If errors occur or "TeX Source" is '
+				. 'selected, then a zip file will be generated for download that contains the TeX source file and '
+				. 'resources needed for generating the PDF file using LaTeX.') =%>
 		</p>
 		<p>
-		<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be saved '
-			. 'to the templates/hardcopyThemes folder.') =%>
+			<%= maketext('You can also click "Edit Selected Theme" to edit a hardcopy theme.  The new theme will be '
+				. 'saved to the templates/hardcopyThemes folder.') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is only available for PG problem files, set header files, and hardcopy header '
+				. 'files.') =%>
 		</p>
 	</dd>
 
 	<dt><%= maketext('Code Maintenance') %></dt>
 	<dd>
-		<%= maketext('Three code maintenance tools can be utilized. First, the code can be reformatted using perltidy. '
-		. 'Using perltidy will change the code in the editor window, and save changes to the temporary file. In some '
-		. 'cases (if the code contains backslashes or double tildes) this can result in odd spacing in the code. '
-		. 'Second the code can be converted to PGML. This changes the code in text blocks to use PGML features. '
-		. 'Generally the conversion of much of the formatting and LaTeX is performed correctly. However, answer '
-		. 'blanks need attention. In any case, make sure to inspect the formatted code, and edit further or revert '
-		. 'if needed. Third, the code can be analyzed by the "PG Critic." This checks that the code does not use '
-		. 'old or deprecated features of PG and conforms to current best-practices in problem authoring, and offers '
-		. 'suggestions on how to fix issues that are found.') =%>
+		<p>
+			<%= maketext('Three code maintenance tools can be utilized. First, the code can be reformatted using '
+				. 'perltidy. Using perltidy will change the code in the editor window, and save changes to the '
+				. 'temporary file. In some cases (if the code contains backslashes or double tildes) this can result '
+				. 'in odd spacing in the code. Second the code can be converted to PGML. This changes the code in text '
+				. 'blocks to use PGML features. Generally the conversion of much of the formatting and LaTeX is '
+				. 'performed correctly. However, answer blanks need attention. In any case, make sure to inspect the '
+				. 'formatted code, and edit further or revert if needed. Third, the code can be analyzed by the "PG '
+				. 'Critic." This checks that the code does not use old or deprecated features of PG and conforms to '
+				. 'current best-practices in problem authoring, and offers suggestions on how to fix issues that are '
+				. 'found.') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is only available for problem files, set header files, and hardcopy header '
+				. 'files. In addition, only the option to reformat code with perltidy is available for set header '
+				. 'files and hardcopy header files.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Save') %></dt>
 	<dd>
-		<%= maketext('Save the contents of the editor window to the file on disk and re-render the problem. If '
-			. '"Open in new window" is checked, then the problem will open in a new tab or window showing the problem '
-			. 'as it will be rendered for students in the set. If "Create backup" is checked then a backup of the '
-			. 'current file on disk will be created before overwriting it with the contents of the editor window. If a '
-			. 'backup already exists, then a "Delete oldest backup" check box will be present. If that is checked, '
-			. 'then the oldest backup will be deleted when "Save" is clicked. These backups can be reverted '
-			. 'to and managed on the "Revert" tab.') =%>
+		<p>
+			<%= maketext('Save the contents of the editor window to the file on disk and re-render the problem. If '
+				. '"Open in new window" is checked, then the problem will open in a new tab or window showing the '
+				. 'problem as it will be rendered for students in the set. If "Create backup" is checked then a backup '
+				. 'of the current file on disk will be created before overwriting it with the contents of the editor '
+				. 'window. If a backup already exists, then a "Delete oldest backup" check box will be present. If '
+				. 'that is checked, then the oldest backup will be deleted when "Save" is clicked. These backups can '
+				. 'be reverted to and managed on the "Revert" tab.') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is available for all files, but is only active for files in the course templates '
+				. 'directory that are writable by the server. For files outside of the course templates directory, '
+				. 'such as sample problems or a new problem template, or files that are not writable by the server, '
+				. 'such as OPL problems, first use the "Save As" tab to save to a file in the course templates '
+				. 'directory.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Save As') %></dt>
 	<dd>
 		<p>
 			<%= maketext(q{Makes a new copy of the file you are editing at the location relative to the course's }
-				. 'templates (~[TMPL~]) directory. You may choose to replace the current problem in the current set, '
+				. 'templates (~[TMPL~]) directory.') =%>
+		</p>
+		<p>
+			<%= maketext('For problem files you may choose to replace the current problem in the current set, '
 				. 'append to the end of an existing set as a new problem, or create a problem that is not attached '
 				. 'to a problem set.') =%>
 		</p>
 		<p>
-			<%= maketext('When saving the problem in a new location (directory), by default all auxiliary files, such '
+			<%= maketext('For set or hardcopy header files you may choose to set the file as the same kind of header '
+				. 'for an existing problem set, or create a header file that is not attached to a problem set.') =%>
+		</p>
+		<p>
+			<%= maketext('When saving a problem in a new location (directory), by default all auxiliary files, such '
 				. 'as images, or other files that do not end in ".pg", will also be copied to the new location.  To '
 				. 'stop this behavior, uncheck the "Copy auxiliary files" option.') =%>
 		</p>
@@ -196,25 +228,42 @@
 				. 'for a new problem. You can add the new file to a homework set from the Library Browser or via the '
 				. 'set detail page of the "Sets Manager".') =%>
 		</p>
-		<p class="mb-0">
+		<p>
 			<%= maketext('If the original problem cannot be edited than the path name must be changed in order to be '
 				. 'allowed to save the problem. Adding "local/" to the beginning of the original path is the default '
 				. 'solution. All locally created and edited files will then appear in a subdirectory named '
 				. '"local".') =%>
 		</p>
+		<p>
+			<%= maketext('This tab is available for all file types except for the course information file.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Append') %></dt>
 	<dd>
-		<%= maketext('Add this problem as the last problem of an existing set, either as a problem or as the set '
-			. 'header (the text that appears on the home page of a homework set). You can rearrange the order of the '
-			. 'problems later using the "Sets Manager".') =%>
+		<p>
+			<%= maketext('Add this problem as the last problem of an existing set, either as a problem, as the set '
+				. 'header (the text that appears on the home page of a homework set), or the hardcopy header (the text '
+				. 'that appears in the beginning of hardcopy for a set). You can rearrange the order of the problems '
+				. 'later using the "Sets Manager".') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is only available for problem files, set header files, and hardcopy header files, '
+				. 'but is not active for a new problem template or a sample problem. To append a new problem template '
+				. 'or sample problem to a set, first use "Save As" to save the file to the course templates '
+				. 'directory.') =%>
+		</p>
 	</dd>
 
 	<dt><%= maketext('Revert') %></dt>
 	<dd>
-		<%= maketext('Reverts to the copy of the file saved on the disk or to a backup file. All unsaved editing '
-			. 'changes will be lost. This option is only active when a temporary file or a backup file exists. You '
-			. 'may also delete backups that have been made with this tab.') =%>
+		<p>
+			<%= maketext('Reverts to the copy of the file saved on the disk or to a backup file. All unsaved editing '
+				. 'changes will be lost. You may also delete backups that have been made with this tab.') =%>
+		</p>
+		<p>
+			<%= maketext('This tab is available for all files, but is only active when a temporary file or backup file '
+				. 'exists.') =%>
+		</p>
 	</dd>
 </dl>


### PR DESCRIPTION
The "Save" tab will always shown for all file types, but will be disabled for any file not in the course's templates directory (symlinks do not count here, i.e., this tab will not be disabled for a file that is linked to from the course's templates directory assuming the server has write permission to the file), or the server does not have write permission to the file.

The "Append" tab will be shown for all PG file types (problems and set headers).  However, it will be disabled for any file not in the course's templates directory (again symlinks do not count here, i.e., this tab will not be disabled for a file that is linked to from the course's templates directory, even if the server does not have write permissions to the file).

Also the help has been updated. help for this. The help for each action tab now states when the tab is available and when it is active.