### PR TITLE
A better approach for dark mode for some rendering in the editor.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -574,7 +574,6 @@
 	const iframe = document.createElement('iframe');
 	iframe.title = 'Rendered content';
 	iframe.id = 'pgedit-render-iframe';
-	iframe.style.colorScheme = 'light';
 
 	// Adjust editor dimensions when the window is resized and when the iframe loads.
 	const adjustIFrameHeight = () => {
@@ -667,8 +666,7 @@
 			if (fileType === 'hardcopy_theme') {
 				const contents = webworkConfig?.pgCodeMirror?.source;
 				if (contents) {
-					renderArea.innerHTML =
-						'<pre class="text-dark">' + contents.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</pre>';
+					renderArea.innerHTML = '<pre>' + contents.replace(/&/g, '&amp;').replace(/</g, '&lt;') + '</pre>';
 				} else
 					renderArea.innerHTML =
 						'<div class="alert alert-danger p-1 m-2 fw-bold">The file has no content.</div>';

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -69,7 +69,6 @@
 						iframe = document.createElement('iframe');
 						iframe.id = `${renderArea.id}_iframe`;
 						iframe.style.border = 'none';
-						iframe.style.colorScheme = 'light';
 						while (renderArea.firstChild) renderArea.firstChild.remove();
 						renderArea.append(iframe);
 

--- a/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor.html.ep
@@ -175,7 +175,7 @@
             >
 				<i class="fa-solid fa-grip-lines-vertical fa-lg" aria-hidden="true"></i>
 			</div>
-			<div class="pgedit-panel render mb-lg-0 order-first order-lg-last bg-white">
+			<div class="pgedit-panel render mb-lg-0 order-first order-lg-last">
 				<div class="p-0" id="pgedit-render-area">
 					<div class="placeholder d-flex flex-column justify-content-center
 						 align-items-center bg-secondary-subtle h-100">

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/pg_critic.html.ep
@@ -1,6 +1,6 @@
 % Perl::Critic::Violation::set_format('%m at line %l, column %c.');
 %
-<div class="m-3 overflow-auto text-dark">
+<div class="m-3 overflow-auto">
 	<h2><%= maketext('PG Critic Violations') %></h2>
 	% my @pgCriticViolations   = grep { $_->policy =~ /^Perl::Critic::Policy::PG::/ } @$violations;
 	% my @perlCriticViolations = grep { $_->policy !~ /^Perl::Critic::Policy::PG::/ } @$violations;


### PR DESCRIPTION
This reworks what was done in #3008 and #3016. Rather than trying to force the PG critic and hardcopy xml into light mode, remove the `bg-white` class from the render panel and use the page colors. This means that these things are in a proper dark mode for those that use it.

Problems do not need the white background since by default iframes are given a white background.  Also the iframe elements do not need to have the `color-scheme` style set to `light`.  That has no effect inside the iframe anyway.