### PR TITLE
icon alert if a date has been overrided for a user on the Assignments…

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -752,6 +752,7 @@ $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];
 	access_instructor_tools => "ta",
 	score_sets              => "professor",
 	problem_grader          => "professor",
+	override_indicator      => "ta",
 	send_mail               => "professor",
 	receive_feedback        => [ 'ta', 'professor', 'admin' ],
 

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -606,6 +606,17 @@ sub getConfigValues ($ce) {
 				type => 'permission'
 			},
 			{
+				var  => 'permissionLevels{override_indicator}',
+				doc  => x('Indicate each date overriding an assignment date'),
+				doc2 => x(
+					"On the Assignments page, if a primary date is shown for an assignment, and if the user's value of "
+						. 'that date is overriding the course assignment data, then show an indicator that this is the '
+						. 'case. This will happen for all users at permission level at or above the selected '
+						. 'permission level.'
+				),
+				type => 'permission'
+			},
+			{
 				var  => 'permissionLevels{view_unopened_sets}',
 				doc  => x('Allowed to view problems in sets which are not open yet'),
 				type => 'permission'

--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -125,9 +125,13 @@ sub getSetStatus ($c, $set) {
 	my $status         = 'past-due';
 	my $other_messages = $c->c;
 	if ($c->submitTime < $set->open_date) {
-		$status = 'not-open';
-		$status_msg =
-			$c->maketext('Will open on [_1].', $c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat}));
+		$status     = 'not-open';
+		$status_msg = {
+			msg => $c->maketext(
+				'Will open on [_1].', $c->formatDateTime($set->open_date, $ce->{studentDateDisplayFormat})
+			),
+			override => $set->open_date != $c->db->getGlobalSet($set->set_id)->open_date
+		};
 		push(@$other_messages, $restricted_msg) if $restricted_msg;
 	} elsif ($c->submitTime < $set->due_date) {
 		$status = 'open';
@@ -141,7 +145,10 @@ sub getSetStatus ($c, $set) {
 		my $beginReducedScoringPeriod = $c->formatDateTime($set->reduced_scoring_date, $ce->{studentDateDisplayFormat});
 
 		if ($enable_reduced_scoring && $c->submitTime < $set->reduced_scoring_date) {
-			$status_msg = $c->maketext('Open. Due [_1].', $beginReducedScoringPeriod);
+			$status_msg = {
+				msg      => $c->maketext('Open. Due [_1].', $beginReducedScoringPeriod),
+				override => $set->reduced_scoring_date != $c->db->getGlobalSet($set->set_id)->reduced_scoring_date
+			};
 			push(
 				@$other_messages,
 				$c->maketext(
@@ -151,7 +158,10 @@ sub getSetStatus ($c, $set) {
 			);
 		} elsif ($enable_reduced_scoring && $set->reduced_scoring_date && $c->submitTime > $set->reduced_scoring_date) {
 			$status     = 'reduced';
-			$status_msg = $c->maketext('Due date [_1] has passed.', $beginReducedScoringPeriod);
+			$status_msg = {
+				msg      => $c->maketext('Due date [_1] has passed.', $beginReducedScoringPeriod),
+				override => $set->reduced_scoring_date != $c->db->getGlobalSet($set->set_id)->reduced_scoring_date
+			};
 			push(
 				@$other_messages,
 				$c->maketext(
@@ -160,16 +170,25 @@ sub getSetStatus ($c, $set) {
 				)
 			);
 		} else {
-			$status_msg =
-				$c->maketext('Open. Due [_1].', $c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat}));
+			$status_msg = {
+				msg => $c->maketext(
+					'Open. Due [_1].', $c->formatDateTime($set->due_date, $ce->{studentDateDisplayFormat})
+				),
+				override => $set->due_date != $c->db->getGlobalSet($set->set_id)->due_date
+			};
 		}
 
 		if ($restricted_msg) {
 			push(@$other_messages, $restricted_msg);
 		}
 	} elsif ($c->submitTime < $set->answer_date) {
-		$status_msg = $c->maketext('Answers available for review on [_1].',
-			$c->formatDateTime($set->answer_date, $ce->{studentDateDisplayFormat}));
+		$status_msg = {
+			msg => $c->maketext(
+				'Answers available for review on [_1].',
+				$c->formatDateTime($set->answer_date, $ce->{studentDateDisplayFormat})
+			),
+			override => $set->answer_date != $c->db->getGlobalSet($set->set_id)->answer_date
+		};
 	} else {
 		$status_msg = $c->maketext('Answers available for review.');
 	}

--- a/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
+++ b/templates/ContentGenerator/ProblemSets/set_list_row.html.ep
@@ -28,7 +28,21 @@
 				</a>
 			% }
 		</div>
-		<div class="font-sm"><%= $status_msg %></div>
+		<div class="font-sm">
+		% if (ref $status_msg) {
+			<%= $status_msg->{msg} %>
+			% if ($status_msg->{override} && $c->authz->hasPermissions(param('user'), 'override_indicator')) {
+				<a class="set-id-tooltip px-1" role="button" tabindex="0" data-bs-placement="right"
+						data-bs-toggle="tooltip" data-fallback-placements="top bottom"
+						data-bs-title="<%= maketext('This date overrides the assignment date.') =%>">
+					<i class="icon fas fa-calendar-plus" aria-hidden="true"></i>
+					<span class="visually-hidden"><%= maketext('Date override alert') =%></span>
+				</a>
+			% }
+		% } else {
+			<%= $status_msg %>
+		% }
+		</div>
 		% if (!$set->visible && $authz->hasPermissions(param('user'), 'view_unopened_sets')) {
 			<div class="font-sm"><em><%= maketext('(This set is hidden from students.)') %></em></div>
 		% }


### PR DESCRIPTION
On the Assignments page, if the date that is mentioned in the status message is actually an override date for that user, indicate this with an icon using the same structure as the set description.

This is motivated my instructors reaching out to me, because they do not understand why dates are not changing on a student's Assignment screen even though the instructor is changing the global set dates.

Here is a screenshot for a quick look.

<img width="659" height="536" alt="Screenshot 2026-06-24 at 10 49 23 PM" src="https://github.com/user-attachments/assets/c114c433-dc73-4f2b-b534-24f2c18b3d23" />

Note that if there are additional dates mentioned in subsequent messages, such as `'Afterward reduced credit can be earned until [_1].'`, there is no icon like this. It is only for the current date of primary importance.