### PR TITLE
typos identified by github.com/crate-ci/typos

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -258,7 +258,7 @@ COPY docker-config/docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# Add enviroment variables to control some things during container startup
+# Add environment variables to control some things during container startup
 ENV SSL=0 \
 	PAPERSIZE=letter \
 	SYSTEM_TIMEZONE=UTC \

--- a/DockerfileStage2
+++ b/DockerfileStage2
@@ -101,7 +101,7 @@ COPY docker-config/docker-entrypoint.sh /usr/local/bin/
 
 ENTRYPOINT ["docker-entrypoint.sh"]
 
-# Add enviroment variables to control some things during container startup
+# Add environment variables to control some things during container startup
 ENV SSL=0 \
 	PAPERSIZE=letter \
 	SYSTEM_TIMEZONE=UTC \

--- a/assets/pg/PGMLLab/PGML-lab.pg
+++ b/assets/pg/PGMLLab/PGML-lab.pg
@@ -286,7 +286,7 @@ TEXT(tag(
 						'External ANS' => [
 							<<~'ENDPG',
 								Context('Vector');
-								ANS(Vector(1, 2, 3)->cmp(showCoodinateHints => 0));
+								ANS(Vector(1, 2, 3)->cmp(showCoordinateHints => 0));
 								ENDPG
 							<<~'ENDPGML'
 								[:<1,2,3>:]* = [__________]

--- a/assets/pg/blankProblem2.pg
+++ b/assets/pg/blankProblem2.pg
@@ -1,5 +1,5 @@
 ##DESCRIPTION
-##  Arithemetic problem: give the value of pi
+##  Arithmetic problem: give the value of pi
 ##ENDDESCRIPTION
 
 ##KEYWORDS('arithmetic', 'pi')

--- a/assets/pg/defaultSetHeader.pg
+++ b/assets/pg/defaultSetHeader.pg
@@ -34,7 +34,7 @@ BEGIN_PGML
 END_PGML
 
 # The hardcopy theme defines headers and footers. If you would like to customize
-# those without changing the theme, they can be overriddden here by following the
+# those without changing the theme, they can be overridden here by following the
 # documentation for the LaTeX exam class. However the footer on the last page
 # displays a copyright claim that cannot be overridden here.
 # http://mirrors.ctan.org/macros/latex/contrib/exam/examdoc.pdf

--- a/assets/tex/webwork2.sty
+++ b/assets/tex/webwork2.sty
@@ -55,7 +55,7 @@
 \def\webworkLocalizePage{Page}
 \def\webworkLocalizePoint{point}
 
-% These can be used in a header or footer and their content can be overrided.
+% These can be used in a header or footer and their content can be overridden.
 \newcommand{\webworkLeftHeader}
 {%
 \ifthenelse{\thepage=1}{%

--- a/bin/OPL-update-legacy
+++ b/bin/OPL-update-legacy
@@ -532,7 +532,7 @@ if (open(IN, '<:encoding(UTF-8)', "$libraryRoot/Taxonomy2")) {
 # Taxonomy is a subset of Taxonomy2, so we can use the same code either way
 if ($canopenfile) {
 	my ($cursub, $curchap);      # these are strings
-	my ($subj, $chap, $sect);    # these are indeces
+	my ($subj, $chap, $sect);    # these are indices
 	while (my $line = <IN>) {
 		$line =~ /^(\t*)/;
 		my $count = length($1);
@@ -1019,7 +1019,7 @@ for my $chap (@{$dbchaps}) {
 }
 
 # Note: this used to build some JSON versions of the textbooks, subjects and directory trees
-# that could be used in the library browswer. It's functionality is now
+# that could be used in the library browser. It's functionality is now
 # in the updateOPLextras.pl script.
 
 $dbh->disconnect;

--- a/bin/OPLUtils.pm
+++ b/bin/OPLUtils.pm
@@ -5,8 +5,8 @@ use base qw(Exporter);
 #
 #  The following files are created:
 #		1. $webwork_htdocs/DATA/library-directory-tree.json  (the directory structure of the library)
-#		2. $webwork_htdocs/DATA/library-subject-tree.json  (the subject/chapter/section struture of the library)
-#		3. $webwork_htdocs/DATA/textbook-tree.json  (the subject/chapter/section struture of the library)
+#		2. $webwork_htdocs/DATA/library-subject-tree.json  (the subject/chapter/section structure of the library)
+#		3. $webwork_htdocs/DATA/textbook-tree.json  (the subject/chapter/section structure of the library)
 
 # the above JSON files can be used to load and more quickly lookup OPL information
 #

--- a/bin/dev_scripts/update-localization-files
+++ b/bin/dev_scripts/update-localization-files
@@ -6,7 +6,7 @@ function print_help_exit
 	printf " Update the webwork2.pot and language .po files with translation strings from the code.\n" >&2
 	printf "  options:\n" >&2
 	printf "    -p|--po-update  Update po files as well.  By default only the webwork2.pot file is updated.\n" >&2
-	printf "    -l|--langauge   Update the only given language in addition to updating the webwork2.pot file.\n" >&2
+	printf "    -l|--language   Update the only given language in addition to updating the webwork2.pot file.\n" >&2
 	printf "    -h|--help       Show this help.\n" >&2
 	exit 1
 }

--- a/conf/authen_saml2.conf.dist
+++ b/conf/authen_saml2.conf.dist
@@ -91,7 +91,7 @@ $saml2{sp}{entity_id} = 'http://localhost:8080/webwork2/saml2';
 # https://webwork.yourschool.edu/webwork2/saml2/metadata?courseID=myTestCourse
 # Further note that if multiple courses use that same identity provider then
 # just pick any one of the courses to use in the metadata URL. All of the other
-# courses share the same metedata.
+# courses share the same metadata.
 $saml2{sp}{org} = {
 	contact      => 'webwork@example.edu',
 	name         => 'webwork',

--- a/courses.dist/modelCourse/templates/achievements/achievement_items_readme.txt
+++ b/courses.dist/modelCourse/templates/achievements/achievement_items_readme.txt
@@ -1,5 +1,5 @@
 To use achievement items you should import the default_achievement_items.axp
-achievements using the editor.  
+achievements using the editor.
 
 If you want to change which items are given at which levels you need to do two 
 things.  
@@ -62,6 +62,6 @@ The available items are:
 	id : Surprise
 	name : Mysterious Package (with Ribbons)
 	description : What could be inside?
-        this opens the file suprise_message.txt in the achievements 
+        this opens the file surprise_message.txt in the achievements
         folder and then prints the contetnts of the file.  
 

--- a/courses.dist/modelCourse/templates/achievements/extensions.at
+++ b/courses.dist/modelCourse/templates/achievements/extensions.at
@@ -2,7 +2,7 @@
 # of ExtendDueDate, SuperExtendDueDate, and ResurrectHW reward items. How many of
 # each is specified below.  This could also give other extension type reward items
 # such as AddNewTestGW, ExtendDueDateGW, ExtendReducedDate, NoReducedCred, ReducedCred,
-# RessurectGW, and SuperExtendReducedDate.
+# ResurrectGW, and SuperExtendReducedDate.
 
 $globalData->{ExtendDueDate}      += 10;
 $globalData->{SuperExtendDueDate} += 5;

--- a/docker-config/db/my.cnf
+++ b/docker-config/db/my.cnf
@@ -13,7 +13,7 @@
 
 # This will be passed to all mysql clients
 # It has been reported that passwords should be enclosed with ticks/quotes
-# escpecially if they contain "#" chars...
+# especially if they contain "#" chars...
 # Remember to edit /etc/mysql/debian.cnf when changing the socket location.
 [client]
 port		= 3306

--- a/docker-config/docker-compose.dist.yml
+++ b/docker-config/docker-compose.dist.yml
@@ -28,7 +28,7 @@ services:
       # Provides read only access to the host system's /etc/localtime - tested on Linux hosts
       #- "/etc/localtime:/etc/localtime:ro"
 
-      # The ulimits lines were only tested on Linux hosts in conjuction woth the limits.conf file
+      # The ulimits lines were only tested on Linux hosts in conjunction with the limits.conf file
       #ulimits:
       #  nofile:
       #    soft: 4096

--- a/docker-config/docker-entrypoint.sh
+++ b/docker-config/docker-entrypoint.sh
@@ -85,7 +85,7 @@ done
 # Check first if the admin courses directory exists then check that at least one
 # of the tables associated with the course (the admin_user table) exists.
 #
-# The check for the database tables for the admin course is neccessary for the
+# The check for the database tables for the admin course is necessary for the
 # following situation. In rebuilding a docker box one might clear out the docker
 # containers, images and volumes including mariaDB, BUT leave the contents of
 # ww-docker-data directory in place.  It now holds the shell of the courses

--- a/docker-config/idp/config/module_metarefresh.php
+++ b/docker-config/idp/config/module_metarefresh.php
@@ -3,7 +3,7 @@
 $metadataURL = getenv('SP_METADATA_URL');
 
 if ($metadataURL === False) {
-	exit("Set the environment varable SP_METADATA_URL to the webwork2 service provider's metadata url.");
+	exit("Set the environment variable SP_METADATA_URL to the webwork2 service provider's metadata url.");
 }
 
 $config = [

--- a/htdocs/js/InstructorTools/instructortools.js
+++ b/htdocs/js/InstructorTools/instructortools.js
@@ -9,7 +9,7 @@
 			(option) => option.selected
 		);
 
-		// Check for the neccessary data for the requested module.
+		// Check for the necessary data for the requested module.
 		// Show a message and prevent submission if it is missing.
 		const messages = [];
 

--- a/htdocs/themes/math4-green/_theme-colors.scss
+++ b/htdocs/themes/math4-green/_theme-colors.scss
@@ -11,5 +11,5 @@ $link-color: #283f2b;
 // Webwork logo background color in the banner
 $ww-logo-background-color: darken($info, 8%);
 
-// Achievment level bar
+// Achievement level bar
 $ww-achievement-level-color: #708e74;

--- a/htdocs/themes/math4-red/_theme-colors.scss
+++ b/htdocs/themes/math4-red/_theme-colors.scss
@@ -13,5 +13,5 @@ $link-color-dark: tint-color($primary, 50%);
 // Webwork logo background color in the banner
 $ww-logo-background-color: darken($info, 8%);
 
-// Achievment level bar
+// Achievement level bar
 $ww-achievement-level-color: #08c;

--- a/htdocs/themes/math4-yellow/_theme-colors.scss
+++ b/htdocs/themes/math4-yellow/_theme-colors.scss
@@ -18,7 +18,7 @@ $link-color: shade-color($primary, 60%);
 // Webwork logo background color in the banner
 $ww-logo-background-color: $info;
 
-// Achievment level bar
+// Achievement level bar
 $ww-achievement-level-color: darken($primary, 15%);
 
 // Make the navbar colors dark.

--- a/htdocs/themes/math4/_theme-colors.scss
+++ b/htdocs/themes/math4/_theme-colors.scss
@@ -12,5 +12,5 @@ $link-color-dark: tint-color($primary, 50%);
 // Webwork logo background color in the banner
 $ww-logo-background-color: darken($info, 14%);
 
-// Achievment level bar
+// Achievement level bar
 $ww-achievement-level-color: #88d;

--- a/htdocs/themes/math4/math4-overrides.css.dist
+++ b/htdocs/themes/math4/math4-overrides.css.dist
@@ -4,7 +4,7 @@
  *
  * If you upgrade webwork this file will not be overwritten.  However, the math4.css and
  * math4-overrides.css.dist file may change.  If this happens it may cause problems with
- * your theme until your reconcile the changes with your modifactions here.  (Similar to
+ * your theme until your reconcile the changes with your modifications here.  (Similar to
  * how localOverrides.conf works.)
  *
  * Note that theming is no longer done with this file.  Instead copy one of the existing

--- a/htdocs/themes/math4/math4-overrides.js.dist
+++ b/htdocs/themes/math4/math4-overrides.js.dist
@@ -5,7 +5,7 @@
  *
  * If you upgrade your machine this file will not be overwritten, however, the math4.js
  * and math4-overrides.js.dist file may change.  If this happens it may cause problems
- * with your theme until your reconcile the changes with your modifactions here.  (Similar
+ * with your theme until your reconcile the changes with your modifications here.  (Similar
  * to how localOverrides.conf works.)
  *
  * Note that theming is no longer done with this file.  Instead copy one of the existing

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -152,7 +152,7 @@ async sub dispatch ($c) {
 
 		if ($authen->verify) {
 			# If this is the first phase of LTI 1.3 authentication, then return so its special content generator
-			# module will render and submit the login repost form.  This does not contain the neccessary information
+			# module will render and submit the login repost form.  This does not contain the necessary information
 			# to continue here.
 			return 1 if $c->current_route eq 'ltiadvantage_login';
 

--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -93,7 +93,7 @@ sub update_passback_data ($self, $userID) {
 		}
 	}
 
-	# Update the access token if neccessary.  No need to wait for it to finish here since the token is not needed yet.
+	# Update the access token if necessary.  No need to wait for it to finish here since the token is not needed yet.
 	# This just obtains it if needed for later.
 	$self->get_access_token;
 

--- a/lib/WeBWorK/ConfigObject/lms_context_id.pm
+++ b/lib/WeBWorK/ConfigObject/lms_context_id.pm
@@ -22,7 +22,7 @@ sub save_string ($self, $oldval, $use_current = 0) {
 		my @courseMaps = $c->db->getLTICourseMapsWhere;
 
 		# If a context id is going to be set and the course is configured for LTI 1.3, then make sure it has all of the
-		# valid LTI 1.3 authentication parameters. Note that it is not neccessary to check that the LTIVersion is set.
+		# valid LTI 1.3 authentication parameters. Note that it is not necessary to check that the LTIVersion is set.
 		# If it were not, then this configuration setting would not be listed.
 		if ($ce->{LTIVersion} eq 'v1p3'
 			&& !($ce->{LTI}{v1p3}{PlatformID} && $ce->{LTI}{v1p3}{ClientID} && $ce->{LTI}{v1p3}{DeploymentID}))

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1148,7 +1148,7 @@ sub save_as_handler ($c) {
 					$c->{setID}, $c->{prettyProblemNumber}
 				));
 			}
-		} elsif ($saveMode eq 'set_as_heaader_for_set' && -r $outputFilePath) {
+		} elsif ($saveMode eq 'set_as_header_for_set' && -r $outputFilePath) {
 			my $setID = $c->param('action.save_as.targetSet');
 			if (defined $setID && $setID =~ /\S/) {
 				$c->{setID} = $setID;
@@ -1262,7 +1262,7 @@ sub save_as_handler ($c) {
 		$problemPage                  = $c->url_for('instructor_problem_editor');
 		$new_file_type                = 'hardcopy_theme';
 		$extra_params{hardcopy_theme} = $new_file_name =~ s|^.*\/([^/]*\.xml)|$1|r;
-	} elsif ($saveMode eq 'rename' || $saveMode eq 'set_as_heaader_for_set') {
+	} elsif ($saveMode eq 'rename' || $saveMode eq 'set_as_header_for_set') {
 		$problemPage = $c->url_for(
 			'instructor_problem_editor_withset_withproblem',
 			setID     => $c->{setID},

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -32,7 +32,7 @@ our @EXPORT_OK = qw(
 # Performs functions of processing and recording the answer given in the page.
 # Returns the appropriate scoreRecordedMessage.
 # Note that $c must be a WeBWorK::ContentGenerator object whose associated route is parented by the set_list route.
-# In addition $c must have the neccessary hash data values set for this method.
+# In addition $c must have the necessary hash data values set for this method.
 # Those are 'will', 'problem', 'pg', and 'set'.
 async sub process_and_log_answer ($c) {
 	my $ce            = $c->ce;

--- a/templates/ContentGenerator/Base/footer.html.ep
+++ b/templates/ContentGenerator/Base/footer.html.ep
@@ -5,7 +5,7 @@
 			<%== maketext(
 				'WeBWorK &copy; [_1] | theme: [_2] | ww_version: [_3] | pg_version [_4]',
 				$ce->{WW_COPYRIGHT_YEARS} || 'unknown',
-				$ce->{defaultTheme}       || 'unknown -- set defaultTheme in localOverides.conf',
+				$ce->{defaultTheme}       || 'unknown -- set defaultTheme in localOverrides.conf',
 				$ce->{WW_VERSION}         || 'unknown -- set WW_VERSION in VERSION',
 				$ce->{PG_VERSION}         || 'unknown -- set PG_VERSION in ../pg/VERSION'
 			) %>

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -33,7 +33,7 @@
 		<h2><%= maketext('Directory permission errors') %></h2>
 		<p>
 			<%= maketext(
-				'The webwork server must be able to write to these directories. Please correct the permssion errors.'
+				'The webwork server must be able to write to these directories. Please correct the permission errors.'
 			) =%>
 		</p>
 		<ul>

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -12,7 +12,7 @@
 	%
 	% # Add CSS files requested by problems via ADD_CSS_FILE() in the PG file
 	% # or via a setting of $ce->{pg}{specialPGEnvironmentVars}{extra_css_files}
-	% # which can be set in course.conf (the value should be an anonomous array).
+	% # which can be set in course.conf (the value should be an anonymous array).
 	% my @cssFiles;
 	% if (ref($ce->{pg}{specialPGEnvironmentVars}{extra_css_files}) eq 'ARRAY') {
 		% push(@cssFiles, { file => $_, external => 0 }) for @{ $ce->{pg}{specialPGEnvironmentVars}{extra_css_files} };

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/file_chooser.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/file_chooser.html.ep
@@ -26,7 +26,7 @@
 				<%= text_field sourceFilePath => '',
 					id => 'source_file_path', class => 'form-control form-control-sm', size => 60, dir  => 'ltr' =%>
 				<div class="invalid-feedback">
-					<%= maketext('Plese enter a file with path relative to the course templates directory.') %>
+					<%= maketext('Please enter a file with path relative to the course templates directory.') %>
 				</div>
 			</div>
 		</div>

--- a/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
+++ b/templates/ContentGenerator/Instructor/PGProblemEditor/save_as_form.html.ep
@@ -14,7 +14,7 @@
 	% : $isHardcopyTheme ? 'hardcopyThemes/' . ($c->{editFilePath} =~ s|^.*\/||r)
 		% : ($c->{editFilePath} =~ s|^$ce->{courseDirs}{templates}/||r) =~ s|^$ce->{webworkDirs}{assets}/pg/||r;
 %
-% # Suggest that modifications be saved to the "local" subdirectory if its not in a writeable directory
+% # Suggest that modifications be saved to the "local" subdirectory if its not in a writable directory
 % $shortFilePath = "local/$shortFilePath" unless $isTemplate || $isHardcopyTheme || -w dirname($c->{editFilePath});
 %
 % # If it is an absolute path make it relative.
@@ -22,7 +22,7 @@
 %
 % # Don't add to or replace problems in sets or replace set/hardcopy headers if the set is the Undefined_Set or
 % # if the problem is the blank_problem or a sample problem.
-% my $fileIsAsociatedWithSet = $c->{setID} && $c->{setID} ne 'Undefined_Set' && !$isTemplate;
+% my $fileIsAssociatedWithSet = $c->{setID} && $c->{setID} ne 'Undefined_Set' && !$isTemplate;
 %
 <div>
 	<div class="row align-items-center mb-2">
@@ -50,7 +50,7 @@
 			<%= hidden_field copyAuxFiles => 0 =%>
 			<%= label_for copyAuxFiles => maketext('Copy auxiliary files.'), class => 'form-check-label' =%>
 		</div>
-		% if ($fileIsAsociatedWithSet) {
+		% if ($fileIsAssociatedWithSet) {
 			<div class="form-check">
 				<%= radio_button 'action.save_as.saveMode' => 'rename', id => 'action_save_as_saveMode_rename_id',
 					checked => undef, class => 'form-check-input' =%>
@@ -86,16 +86,16 @@
 		<div class="form-check">
 			<%= radio_button 'action.save_as.saveMode' => 'new_independent_file',
 				id => 'action_save_as_saveMode_independent_problem_id', class => 'form-check-input',
-				$fileIsAsociatedWithSet ? () : (checked => undef) =%>
+				$fileIsAssociatedWithSet ? () : (checked => undef) =%>
 			<%= label_for action_save_as_saveMode_independent_problem_id => maketext('Create unattached problem'),
 				class => 'form-check-label' =%>
 		</div>
 	% } elsif ($c->{file_type} =~ /header/) {
 		% my $headerLabel = $c->{file_type} eq 'hardcopy_header' ? maketext('hardcopy header') : maketext('set header');
 		<div class="form-check">
-			<%= radio_button 'action.save_as.saveMode' => 'set_as_heaader_for_set',
+			<%= radio_button 'action.save_as.saveMode' => 'set_as_header_for_set',
 				id => 'action_save_as_saveMode_set_header_id', class => 'form-check-input',
-				$fileIsAsociatedWithSet ? (checked => undef) : () =%>
+				$fileIsAssociatedWithSet ? (checked => undef) : () =%>
 			<%= label_for action_save_as_saveMode_set_header_id => maketext('Set as [_1] for', $headerLabel),
 				class => 'form-check-label' %>
 			<%= label_for action_save_as_target_set_id => maketext('set:'), class => 'form-check-label' =%>
@@ -114,7 +114,7 @@
 		<div class="form-check">
 			<%= radio_button 'action.save_as.saveMode' => 'new_independent_file',
 				id => 'action_save_as_saveMode_independent_problem_id', class => 'form-check-input',
-				$fileIsAsociatedWithSet ? () : (checked => undef) =%>
+				$fileIsAssociatedWithSet ? () : (checked => undef) =%>
 			<%= label_for action_save_as_saveMode_independent_problem_id => maketext('Create unattached header file'),
 				class => 'form-check-label' =%>
 		</div>

--- a/templates/ContentGenerator/Instructor/SetMaker/problem_row.html.ep
+++ b/templates/ContentGenerator/Instructor/SetMaker/problem_row.html.ep
@@ -50,7 +50,7 @@
 					data-bs-content="<%= maketext(
 						'Global data on problem usage is contributed by many institutions using '
 							. 'WeBWorK all over the world. The Usage figure is the total number of  '
-							. 'individuals who have attemped this problem at least once. A high figure '
+							. 'individuals who have attempted this problem at least once. A high figure '
 							. 'represents a problem which has been assigned to many students and is  '
 							. 'both popular with instructors and likely bug free.'
 					) %>"
@@ -106,7 +106,7 @@
 					data-bs-content="<%= tag('p', maketext(
 						'Local data on problem usage is generated and maintained by your institution. '
 							. 'The Usage figure is the total number of local '
-							. 'individuals who have attemped this problem at least once. A high figure '
+							. 'individuals who have attempted this problem at least once. A high figure '
 							. 'represents a problem which has been assigned to many students and is  '
 							. 'both popular with instructors and likely bug free.'
 					))

--- a/templates/ContentGenerator/Instructor/ShowAnswers.html.ep
+++ b/templates/ContentGenerator/Instructor/ShowAnswers.html.ep
@@ -3,7 +3,7 @@
 	% last;
 % }
 %
-% # Only instructors should be able to veiw other people's answers.
+% # Only instructors should be able to view other people's answers.
 % my $isInstructor = $authz->hasPermissions(param('user'), 'access_instructor_tools');
 %
 % if ($isInstructor) {

--- a/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
+++ b/templates/ContentGenerator/Instructor/Stats/set_stats.html.ep
@@ -17,7 +17,7 @@
 				<a class="help-popup ms-2" role="button" tabindex="0" data-bs-placement="top" data-bs-toggle="popover"
 					data-bs-content="<%= maketext(
 						'This gives the status and dates of the main set. '
-							. 'Indvidual students may have different settings.'
+							. 'Individual students may have different settings.'
 					) %>">
 					<i class="icon fas fa-question-circle" aria-hidden="true"></i>
 					<span class="visually-hidden"><%= maketext('Set Status Help') =%></span>
@@ -173,7 +173,7 @@
 	barLinks    => [ map { $_->{statsLink} } @$problems ],
 ) =%>
 %
-% # Table showing indvidual problem stats.
+% # Table showing individual problem stats.
 <div class="table-responsive">
 	<table class="table table-bordered">
 		<tr>

--- a/templates/ContentGenerator/Problem.html.ep
+++ b/templates/ContentGenerator/Problem.html.ep
@@ -8,7 +8,7 @@
 	%
 	% # Add CSS files requested by problems via ADD_CSS_FILE() in the PG file
 	% # or via a setting of $ce->{pg}{specialPGEnvironmentVars}{extra_css_files}
-	% # which can be set in course.conf (the value should be an anonomous array).
+	% # which can be set in course.conf (the value should be an anonymous array).
 	% my @cssFiles;
 	% if (ref($ce->{pg}{specialPGEnvironmentVars}{extra_css_files}) eq 'ARRAY') {
 		% push(@cssFiles, { file => $_, external => 0 }) for @{ $ce->{pg}{specialPGEnvironmentVars}{extra_css_files} };

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -14,7 +14,7 @@
 	% # Display information about the current test and a continue open test button.
 	% if ($continueVersion->version_time_limit > 0) {
 		% if ($timeNow >= $continueVersion->due_date) {
-			% # If the currently open test is in the grace period, display a mesage stating this.
+			% # If the currently open test is in the grace period, display a message stating this.
 			<div class="alert alert-danger">
 				<%= maketext(
 					'There is no time remaining on the currently open test. '

--- a/templates/HelpFiles/InstructorScoring.html.ep
+++ b/templates/HelpFiles/InstructorScoring.html.ep
@@ -62,7 +62,7 @@
 </p>
 <p class="mb-0">
 	<%== maketext('If you upload your file on the web with the name: [_1] and also create an email message with the '
-		. 'name [_2] with the approriate [_3] variables then not only can you email the message with the embedded '
+		. 'name [_2] with the appropriate [_3] variables then not only can you email the message with the embedded '
 		. 'grades to the students, but files with those exact names are automatically appended to the "Grades" page '
 		. 'seen by the students.',
 		'<code>report_grades_data.csv</code>', '<code>report_grade.msg</code>', '<code>$COL</code>') =%>

--- a/templates/HelpFiles/InstructorSetMaker.html.ep
+++ b/templates/HelpFiles/InstructorSetMaker.html.ep
@@ -1,5 +1,5 @@
 % layout 'help_macro';
-% title maketext('Library Broswer Help');
+% title maketext('Library Browser Help');
 %
 <p>
 	<%= maketext('This page is used to browse problems that will be used to fill problem sets. '
@@ -8,10 +8,10 @@
 		. 'Then choose which set you want to work on in the drop down menu.') =%>
 </p>
 <p>
-	<%= maketext('Use the options in the second box to pick a collection of problems decribed below. In each '
+	<%= maketext('Use the options in the second box to pick a collection of problems described below. In each '
 		. 'case, clicking "View Problems" will render a fixed number of problems (default of 20). After '
 		. 'problems are shown, there will be options to show the next/previous batch of problems, add all problems '
-		. 'to the target set (set at the top of the page) or clear the curent batch of problems.') =%>
+		. 'to the target set (set at the top of the page) or clear the current batch of problems.') =%>
 </p>
 <dl>
 	<dt><%= maketext('Open Problem Library') %></dt>

--- a/templates/HelpFiles/InstructorUserList.html.ep
+++ b/templates/HelpFiles/InstructorUserList.html.ep
@@ -72,7 +72,7 @@
 	<dd>
 		<%= maketext('This is done by first entering the user as a student and then changing the permission level of '
 			. 'the user. First edit the user by clicking on the pencil next to their name (or using the technique '
-			. 'above for several users), then change their permssion level -- an entry blank at the far right of the '
+			. 'above for several users), then change their permission level -- an entry blank at the far right of the '
 			. 'screen, you may have to scroll to see it. The permission levels are') =%>
 		<ul>
 			<li><%= maketext('Guest:') %> -5</li>
@@ -174,7 +174,7 @@
 			. 'page or the "Instructor Tools" page.') =%>
 	</dd>
 
-	<dt><%= maketext('Change the number of atttempts allowed on a problem.') %></dt>
+	<dt><%= maketext('Change the number of attempts allowed on a problem.') %></dt>
 	<dd><%= maketext('This is done from the "Sets Manager" page or the "Instructor tools" page.') %></dd>
 </dl>
 
@@ -190,15 +190,15 @@
 <ul>
 	<li>
 		<%= maketext('Clicking on any active link at the top of the column sorts the page by that column. You can do '
-			. 'lexigraphic sorts: click on "First name" then "Last name" to sort by last name, sorting those with the '
-			. 'same last name by their first name.') =%>
+			. 'lexicographic sorts: click on "First name" then "Last name" to sort by last name, sorting those with '
+			. 'the same last name by their first name.') =%>
 	</li>
 	<li><%== maketext('The <strong>login name</strong> column links allow you to "act as" a student.') %></li>
 	<li>
 		<%== maketext(q{The <strong>pencil</strong> in the login column allows you to edit that student's data.}) =%>
 	</li>
 	<li>
-		<%== maketext('The <strong>Assigned sets</strong> column (x/y) indicates that x sets out of y sets avaiable '
+		<%== maketext('The <strong>Assigned sets</strong> column (x/y) indicates that x sets out of y sets available '
 			. 'have been assigned to this student. Click this link to assign or unassign sets to this student, to '
 			. 'adjust due dates, or to adjust the grades on an assignment for a student.') =%>
 	</li>

--- a/templates/HelpFiles/instructor_links.html.ep
+++ b/templates/HelpFiles/instructor_links.html.ep
@@ -39,7 +39,7 @@
 	<dt><%= maketext('Statistics') %></dt>
 	<dd><%= maketext(q{View statistics of students' performance on homework either by individual or by set.}) %></dd>
 	<dt><%= maketext('Student Progress') %></dt>
-	<dd><%= maketext('View details of student perofrmance either by individual or by set.') %></dd>
+	<dd><%= maketext('View details of student performance either by individual or by set.') %></dd>
 	<dt><%= maketext('Scoring Tools') %></dt>
 	<dd>
 		<%= maketext('Score one or more sets. This can also be done from the "Sets Manager" or from the '
@@ -52,7 +52,7 @@
 	</dd>
 	<dt><%= maketext('Achievements Manager') %></dt>
 	<dd>
-		<%= maketext('Edit achivements for the course. This link is only present if achievements '
+		<%= maketext('Edit achievements for the course. This link is only present if achievements '
 			. 'are enabled for the course.') =%>
 	</dd>
 	<dt><%= maketext('Email') %></dt>

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -159,7 +159,7 @@
 			</div>
 		% }
 	</main>
-	% # Show the footer unless it is explicity disabled.
+	% # Show the footer unless it is explicitly disabled.
 	% if ($showFooter ne '0') {
 		<footer id="footer" data-iframe-height="1">
 			WeBWorK &copy; <%= $ce->{WW_COPYRIGHT_YEARS} || 'unknown' %> |


### PR DESCRIPTION
These are typos identified by `github.com/crate-ci/typos`, except not typos in `lib`. Except a few that are in `lib` that I either already had on my typos branch, or that are connected to a typo in `templates` and can only be fixed at the same time.