### PR TITLE
LTI self-posting form fix - hot fix for WW 2.20 (same change as #3032)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -132,7 +132,6 @@ sub login ($c) {
 		'ContentGenerator/LTI/self_posting_form',
 		form_target => $c->ce->{LTI}{v1p3}{AuthReqURL},
 		form_params => {
-			repost           => 1,
 			response_type    => 'id_token',
 			response_mode    => 'form_post',
 			scope            => 'openid',


### PR DESCRIPTION
Drop the repost parameter form the LTI self-posting form used after the login stage to trigger the authentication stage on the LMS.

The parameter was is not part of the LTI standard, and is used by Moodle to prevent the authentication stage from entering a self-reposting loop, as a self-reposting mechanism is used to pull in the Moodle session cookie which is no longer provided by browsers when SameSite=Lax is set on the LMS side and the sites are considered cross-site.

Having this unneeded parameter set breaks the Moodle to WeBWorK login/launch and content selection mechanism after Moodle changed to defaulting to SameSite=Lax.

Fix for https://github.com/openwebwork/webwork2/issues/2982

Hotfix version of https://github.com/openwebwork/webwork2/pull/3032