### PR TITLE
Remove the html2xml endpoint.

### DIFF
--- a/conf/webwork2.mojolicious.dist.yml
+++ b/conf/webwork2.mojolicious.dist.yml
@@ -49,14 +49,9 @@ JSON_ERROR_LOG: 0
 # origins without an explicit directive from the server that it is safe.
 # Uncomment the extra_headers setting as is to set the header to enable
 # Cross-Origin Resource Sharing (CORS) for url responses to requests to urls
-# that start with /webwork2/render_rpc, /webwork2/html2xml, and /webwork2_files.
-# This may be needed to use the client formats if they are accessed from a
-# *remote* server.
-#
-# Note that the /webwork2/html2xml url is deprecated, and code should be adapted
-# to use the /webwork2/render_rpc path instead.  They both do the same thing
-# that the /webwork2/html2xml endpoint did before, but they no longer pass
-# through the XMLRPC middle man.
+# that start with /webwork2/render_rpc, /webwork2_files, and /pg_files.  This
+# may be needed to use the client formats if they are accessed from a *remote*
+# server.
 #
 # Additional urls may also be added, and multiple headers may be set per url.
 # The headers will be added to all responses to urls that start with the url
@@ -64,8 +59,6 @@ JSON_ERROR_LOG: 0
 
 #extra_headers:
 #  /webwork2/render_rpc:
-#    Access-Control-Allow-Origin: '*'
-#  /webwork2/html2xml:
 #    Access-Control-Allow-Origin: '*'
 #  /webwork2_files:
 #    Access-Control-Allow-Origin: '*'
@@ -212,10 +205,13 @@ hypnotoad:
   # Try to set to provide enough spare time to avoid such problems!
   graceful_timeout: 120
 
-  # The following timeout settings will be sufficient in most cases.  However, if you have large class sizes they may
-  # not be enough.  If you are seeing long requests fail then increase these.  This may happen, for example, if you have
-  # a class with thousands of users and try to assign a set to all users.  In that case you may need much larger values.
-  # Note that if you are serving via a proxy, you may also need to increase the timeouts for the proxy server.
+  # The following timeout settings will be sufficient in most cases.  However,
+  # if you have large class sizes they may not be enough.  If you are seeing
+  # long requests fail then increase these.  This may happen, for example, if
+  # you have a class with thousands of users and try to assign a set to all
+  # users.  In that case you may need much larger values.  Note that if you are
+  # serving via a proxy, you may also need to increase the timeouts for the
+  # proxy server.
   inactivity_timeout: 60
   heartbeat_timeout: 60
 
@@ -250,12 +246,11 @@ hardcopy:
   # If 1, don't delete temporary files created when a hardcopy is generated.
   preserve_temp_files: 0
 
-# Set this to 1 to allow the html2xml and render_rpc endpoints to disable
-# cookies and thus skip two factor authentication for all courses. To disable
-# cookies for a single course, set this to a hash whose keys are the course
-# IDs with a value of 1. Further to only disable cookies for specific users
-# in a course, set the course ID to a hash whose keys are user IDs with a
-# value of 1. For example:
+# Set this to 1 to allow the render_rpc endpoint to disable cookies and thus
+# skip two factor authentication for all courses. To disable cookies for a
+# single course, set this to a hash whose keys are the course IDs with a value
+# of 1. Further to only disable cookies for specific users in a course, set the
+# course ID to a hash whose keys are user IDs with a value of 1. For example:
 # allow_unsecured_rpc:
 #   # Disable cookies for full PreTeXt course.
 #   PreTeXt: 1

--- a/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
+++ b/lib/WeBWorK/ContentGenerator/RenderViaRPC.pm
@@ -45,15 +45,6 @@ sub initializeRoute ($c, $routeCaptures) {
 	$c->stash(disable_cookies => 1)
 		if $c->current_route eq 'render_rpc' && $c->param('disableCookies') && $disable_cookies;
 
-	# This provides compatibility for legacy html2xml parameters.
-	# This should be deleted when the html2xml endpoint is removed.
-	if ($c->current_route eq 'html2xml') {
-		$c->stash(disable_cookies => 1) if $disable_cookies;
-		for ([ 'userID', 'user' ], [ 'course_password', 'passwd' ], [ 'session_key', 'key' ]) {
-			$c->param($_->[1], $c->param($_->[0])) if defined $c->param($_->[0]) && !defined $c->param($_->[1]);
-		}
-	}
-
 	# Get the courseID from the parameters.
 	$routeCaptures->{courseID} = $c->stash->{courseID} = $c->param('courseID') if $c->param('courseID');
 

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -15,7 +15,6 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
 
  render_rpc                          /render_rpc
  instructor_rpc                      /instructor_rpc
- html2xml                            /html2xml
 
  ltiadvanced_content_selection       /ltiadvanced/content_selection
 
@@ -140,7 +139,6 @@ my %routeParameters = (
 		# 'course_admin' is also a child of 'root' but that is a special case that is setup separately.
 		children => [ qw(
 			render_rpc
-			html2xml
 			instructor_rpc
 			ltiadvanced_content_selection
 			ltiadvantage_login
@@ -175,14 +173,6 @@ my %routeParameters = (
 		title  => 'instructor_rpc',
 		module => 'InstructorRPCHandler',
 		path   => '/instructor_rpc'
-	},
-
-	# The html2xml route is an deprecated alias to the render_rpc route above.
-	# It no longer has anything to do with xml, and so the route title does not make sense anymore.
-	html2xml => {
-		title  => 'html2xml',
-		module => 'RenderViaRPC',
-		path   => '/html2xml'
 	},
 
 	ltiadvanced_content_selection => {


### PR DESCRIPTION
This has been deprecated since the release of webwork 2.18. It is time for it to go.  I believe that everyone that used to use this endpoint have now updated to use the `render_rpc` endpoint. If not, then we can wait another release for this.