### PR TITLE
Add a margin to the bottom of the "Future Assignments" on the student grades page.

### DIFF
--- a/templates/ContentGenerator/Grades/student_grades.html.ep
+++ b/templates/ContentGenerator/Grades/student_grades.html.ep
@@ -48,7 +48,7 @@
 	<h2><%= maketext('Future Assignments') %></h2>
 	<ul class="list-group">
 		% for my $item (@$notOpen) {
-			<li class="list-group-item">
+			<li class="list-group-item mb-3">
 				<div>
 					% if ($item->{link}) {
 						<%= link_to $item->{name} => $item->{link}, class => "fw-bold" %>


### PR DESCRIPTION
If the "Additional Grade Information" is shown then the lack of a margin is not good.  If that is not shown the margin doesn't do anything particularly harmful to the layout.