### PR TITLE
Upgrade MathJax to version 4.1.3.

### DIFF
--- a/htdocs/js/MathJaxConfig/bs-color-scheme.js
+++ b/htdocs/js/MathJaxConfig/bs-color-scheme.js
@@ -1,4 +1,4 @@
-if (MathJax.loader) MathJax.loader.checkVersion('[bs-color-scheme]', '4.1.2', 'extension');
+if (MathJax.loader) MathJax.loader.checkVersion('[bs-color-scheme]', '4.1.3', 'extension');
 
 const switchToBSStyle = (obj, key = '@media (prefers-color-scheme: dark)') => {
 	obj["[data-bs-theme='dark']"] = obj[key];
@@ -23,12 +23,6 @@ for (const [immediate, extension, ready] of [
 			for (const region of ['LiveRegion', 'HoverRegion', 'ToolTip']) {
 				if (':root' in Region[region].style.styles) {
 					Region[region].style.styles["[data-bs-theme='light']"] = Region[region].style.styles[':root'];
-
-					// The variable --mjx-bg1-color is defined to be 'rgba(var(--mjx-bg-blue), var(--mjx-bg-alpha))'.
-					// I suspect this is a typo as the variable -mjx-bg-alpha is not defined anywhere. In any case this
-					// change is needed to get the correct background color on the focused element in the explorer.
-					Region[region].style.styles["[data-bs-theme='light']"]['--mjx-bg1-color'] =
-						'rgba(var(--mjx-bg-blue), var(--mjx-bg1-alpha))';
 				}
 				Region[region].style.styles["[data-bs-theme='dark']"] =
 					Region[region].style.styles['@media (prefers-color-scheme: dark)'];

--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -15,7 +15,7 @@
 				"jquery": "^4.0.0",
 				"jquery-ui-dist": "^1.13.3",
 				"luxon": "^3.7.2",
-				"mathjax": "^4.1.2",
+				"mathjax": "^4.1.3",
 				"minisearch": "^7.2.0",
 				"shortcut-buttons-flatpickr": "^0.4.0",
 				"sortablejs": "^1.15.7"
@@ -325,9 +325,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@mathjax/mathjax-newcm-font": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.2.tgz",
-			"integrity": "sha512-lZHMjNP2XbABHA3kVn40rbse5ERUeMEmrGH03qLkCwxq4/5Z/eNLr0akw1MmQcqTwCbvkx1BFcmJ7RCfbRlw3Q==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/@mathjax/mathjax-newcm-font/-/mathjax-newcm-font-4.1.3.tgz",
+			"integrity": "sha512-gzAB3dFHilHX1l5x2xUqRL+1jDQt3Fyza1DkEMVXWC4E8SvsGdlgEza47HYi2WhVcgfkvf4zgUGzuhbq3Pjlew==",
 			"license": "Apache-2.0"
 		},
 		"node_modules/@openwebwork/codemirror-lang-pg": {
@@ -1531,12 +1531,12 @@
 			}
 		},
 		"node_modules/mathjax": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.2.tgz",
-			"integrity": "sha512-EQDS8xBpVg179BXoLeZ9JlwUFftOC5qylw20UlAMDhrTuooENigOocY79aNkkFSyvj/AST/89ZAo12+r5bPI4w==",
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/mathjax/-/mathjax-4.1.3.tgz",
+			"integrity": "sha512-BN/8Pkgn7G1pIDYJqd9md+JHsE/jydSYbyOZnSdSA0WziuVO8mRxdYiWFumkVVly/8U+hm9DpIIoWuvySverzw==",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@mathjax/mathjax-newcm-font": "^4.1.2"
+				"@mathjax/mathjax-newcm-font": "^4.1.3"
 			}
 		},
 		"node_modules/mdn-data": {

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -21,7 +21,7 @@
 		"jquery": "^4.0.0",
 		"jquery-ui-dist": "^1.13.3",
 		"luxon": "^3.7.2",
-		"mathjax": "^4.1.2",
+		"mathjax": "^4.1.3",
 		"minisearch": "^7.2.0",
 		"shortcut-buttons-flatpickr": "^0.4.0",
 		"sortablejs": "^1.15.7"


### PR DESCRIPTION
This version fixes the issue with certain expressions causing the browser to run out of memory and crash. See
https://github.com/mathjax/MathJax/issues/3578,
https://forums.openwebwork.org/mod/forum/discuss.php?d=8819, and https://github.com/openwebwork/pg/issues/1451.