### PR TITLE
Abort a course archive when the database dump actually fails

### DIFF
--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -359,19 +359,22 @@ sub delete_tables {
 sub dump_tables {
 	my ($self, $dump_dir) = @_;
 
+	my $success = 1;
 	foreach my $table (keys %$self) {
 		next if $table =~ /^_/;                         # skip non-table self fields (none yet)
 		next if $self->{$table}{params}{non_native};    # skip non-native tables
 		my $schema_obj = $self->{$table};
-		if ($schema_obj->can("dump_table")) {
-			my $dump_file = "$dump_dir/$table.sql";
-			$schema_obj->dump_table($dump_file);
-		} else {
+		unless ($schema_obj->can("dump_table")) {
 			warn "skipping dump of '$table' table: no dump_table method\n";
+			next;
 		}
+		# A course created with an earlier version of WeBWorK may not have every
+		# table; skip the missing ones rather than counting them as failures.
+		next         unless $schema_obj->tableExists;
+		$success = 0 unless $schema_obj->dump_table("$dump_dir/$table.sql");
 	}
 
-	return 1;
+	return $success;
 }
 
 sub restore_tables {
@@ -383,6 +386,9 @@ sub restore_tables {
 		my $schema_obj = $self->{$table};
 		if ($schema_obj->can("restore_table")) {
 			my $dump_file = "$dump_dir/$table.sql";
+			# Tables absent when the course was archived have no dump file; skip
+			# them rather than restoring from a nonexistent file.
+			next unless -e $dump_file;
 			$schema_obj->restore_table($dump_file);
 		} else {
 			warn "skipping restore of '$table' table: no restore_table method\n";

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -200,10 +200,10 @@ sub dump_table {
 		my $exit   = $? >> 8;
 		my $signal = $? & 127;
 		my $core   = $? & 128;
-		warn "Warning: Failed to dump table '"
+		warn "Failed to dump table '"
 			. $self->sql_table_name
 			. "' with command '$dump_cmd' (exit=$exit signal=$signal core=$core): $dump_out\n";
-		warn "This can be expected if the course was created with an earlier version of WeBWorK.";
+		return 0;
 	}
 
 	return 1;


### PR DESCRIPTION

## Description:
### Problem
A failed database dump produces a **"successful" archive with no database**. Because `WeBWorK::DB::dump_tables` and `NewSQL::Std::dump_table` both `return 1` unconditionally, `archiveCourse`'s existing guard —

```perl
  my $dump_db_result = $db->dump_tables($dump_dir);
  unless ($dump_db_result) { ...; croak "$courseID: course database dump failed.\n"; }
```

— never fires. Any mysqldump failure (wrong mysqldump path, auth failure, disk full, a MariaDB column-statistics incompatibility, …) is swallowed with only a warn to the server log, and the archive is written anyway. The empty database is discovered only later, when the archive is unarchived and no tables are restored.

### Fix

Make the failure propagate:

  - dump_table returns 0 when mysqldump exits non-zero.
  - dump_tables aggregates the per-table results and returns false if any table's dump
  failed, so archiveCourse aborts instead of writing a DB-less archive.

The existing tolerance for courses created with an earlier version of WeBWorK (which may predate some tables) is preserved: dump_tables skips tables that don't exist (via tableExists) rather than counting them as failures, so only a genuine mysqldump error aborts the archive. Because absent tables now produce no dump file, restore_tables skips missing dump files instead of restoring from a nonexistent path.

### Scope note

This intentionally does not change the restore side to abort on failure — restore_tables/restore_table still return success and only warn, matching current behavior where a partial restore is preferred over none. Only the missing-file skip was added there, as a direct consequence of no longer dumping absent tables.

### Testing

  - Point $externalPrograms{mysqldump} at a nonexistent path (or otherwise break the dump,
  e.g. a mysqldump that rejects --column-statistics against MariaDB) and archive a course.
    - Before: archive completes "successfully"; the .tar.gz has an empty/absent
  DATA/mysqldump, and a later unarchive restores no tables.
    - After: archiveCourse dies with course database dump failed. and no archive is left behind.
  - Regression: archive a normal current course — all tables dump and the archive is byte-for-byte
  equivalent to before.
  - Regression: archive a course missing a newer table — that table is skipped (no longer a warn),
  the rest dump, and the archive succeeds.