### PR TITLE
typos identified by github.com/crate-ci/typos

### DIFF
--- a/lib/Caliper/Actor.pm
+++ b/lib/Caliper/Actor.pm
@@ -19,7 +19,7 @@ sub generate_anonymous_actor {
 
 sub generate_default_actor {
 	my ($ce, $db, $user) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	return {
 		'id'   => $resource_iri->actor_homepage($user->user_id()),

--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -17,7 +17,7 @@ use Caliper::Actor;
 
 sub webwork_app {
 	my ($ce, $db) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	# $ce doesn't have WW_VERSION when doing login/logout for some reason
 	my $seed_ce    = WeBWorK::CourseEnvironment->new;
@@ -33,7 +33,7 @@ sub webwork_app {
 
 sub session {
 	my ($ce, $db, $actor, $session_key) = @_;
-	my $resource_iri     = Caliper::ResourseIri->new($ce);
+	my $resource_iri     = Caliper::ResourceIri->new($ce);
 	my $session_key_hash = sha1_base64($session_key);
 
 	return {
@@ -46,7 +46,7 @@ sub session {
 
 sub client {
 	my ($ce, $db, $session_key_hash) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $ip_address = '';
 	if ($ENV{HTTP_X_FORWARDED_FOR}) {
@@ -68,7 +68,7 @@ sub client {
 
 sub membership {
 	my ($ce, $db, $actor, $user_id) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $user       = $db->getUser($user_id);
 	my $permission = $db->getPermissionLevel($user_id);
@@ -112,7 +112,7 @@ sub membership {
 
 sub course {
 	my ($ce, $db) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $course_entity = {
 		'id'   => $resource_iri->course(),
@@ -128,7 +128,7 @@ sub course {
 
 sub problem_set {
 	my ($ce, $db, $set_id) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $problem_set = $db->getGlobalSet($set_id);
 
@@ -189,7 +189,7 @@ sub problem_set {
 
 sub problem {
 	my ($ce, $db, $set_id, $problem_id) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $problem = $db->getGlobalProblem($set_id, $problem_id);
 
@@ -226,7 +226,7 @@ sub problem {
 
 sub problem_user {
 	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $problem_user =
 		$version_id
@@ -282,7 +282,7 @@ sub problem_user {
 
 sub answer {
 	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $last_answer_id =
 		$db->latestProblemPastAnswer($user_id, ($version_id ? "$set_id,v$version_id" : $set_id), $problem_id);
@@ -314,7 +314,7 @@ sub answer {
 
 sub answer_attempt {
 	my ($ce, $db, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $problem_user =
 		$version_id
@@ -353,7 +353,7 @@ sub answer_attempt {
 
 sub problem_set_attempt {
 	my ($ce, $db, $set_id, $version_id, $user_id, $start_time, $end_time) = @_;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 
 	my $problem_set_user =
 		$version_id ? $db->getMergedSetVersion($user_id, $set_id, $version_id) : $db->getMergedSet($user_id, $set_id);

--- a/lib/Caliper/ResourceIri.pm
+++ b/lib/Caliper/ResourceIri.pm
@@ -1,4 +1,4 @@
-package Caliper::ResourseIri;
+package Caliper::ResourceIri;
 
 ##### Library Imports #####
 use strict;

--- a/lib/Caliper/Sensor.pm
+++ b/lib/Caliper/Sensor.pm
@@ -50,7 +50,7 @@ sub sendEvents {
 	}
 
 	my $ce           = $c->ce;
-	my $resource_iri = Caliper::ResourseIri->new($ce);
+	my $resource_iri = Caliper::ResourceIri->new($ce);
 	my $async        = HTTP::Async->new;
 	$async->timeout(5);
 	$async->max_request_time(10);
@@ -130,7 +130,7 @@ sub formatted_timestamp {
 sub formatted_duration {
 	my ($duration) = @_;
 
-	# gererate the time portion of a ISO 8601 formatted duration
+	# generate the time portion of a ISO 8601 formatted duration
 	my $seconds = $duration % 60;
 	my $minutes = int($duration / 60) % 60;
 	my $hours   = int($duration / 3600);

--- a/lib/HardcopyRenderedProblem.pm
+++ b/lib/HardcopyRenderedProblem.pm
@@ -51,7 +51,7 @@ sub hardcopyRenderedProblem {
 	}
 
 	# Use the basename of the source file path without the extension prefixed with the course id and user id for the
-	# working directory namd and download filename.
+	# working directory name and download filename.
 	my $returnFileName =
 		"$courseID.$userID." . ((($ws->{inputs_ref}{sourceFilePath} =~ s/^.*\///r) =~ s/\.[^.]*$//r) || 'hardcopy');
 

--- a/lib/WeBWorK/AchievementItems.pm
+++ b/lib/WeBWorK/AchievementItems.pm
@@ -122,7 +122,7 @@ sub remaining_title ($self, $c) {
 	}
 }
 
-# Utility method for outputing a form row with a label and popup menu.
+# Utility method for outputting a form row with a label and popup menu.
 # The id, label_text, and values are required parameters.
 sub form_popup_menu_row ($c, %options) {
 	my %params = (

--- a/lib/WeBWorK/AchievementItems/Surprise.pm
+++ b/lib/WeBWorK/AchievementItems/Surprise.pm
@@ -1,7 +1,7 @@
 package WeBWorK::AchievementItems::Surprise;
 use Mojo::Base 'WeBWorK::AchievementItems', -signatures;
 
-# Item to print a suprise message
+# Item to print a surprise message
 
 use WeBWorK::Utils qw(x);
 

--- a/lib/WeBWorK/Authen/LTIAdvanced.pm
+++ b/lib/WeBWorK/Authen/LTIAdvanced.pm
@@ -577,7 +577,7 @@ sub create_user {
 	$self->{user} = $newUser;
 	$self->write_log_entry("New user $userID added via LTIAdvanced login");
 
-	# Assign permssion level
+	# Assign permission level
 	my $newPermissionLevel = $db->newPermissionLevel();
 	$newPermissionLevel->user_id($userID);
 	$newPermissionLevel->permission($LTI_webwork_permissionLevel);

--- a/lib/WeBWorK/Authen/Saml2.pm
+++ b/lib/WeBWorK/Authen/Saml2.pm
@@ -194,7 +194,7 @@ sub sp ($self) {
 # with the identity provider's signing key which is extracted from the retrieved metadata.  On later requests the
 # metadata and certificate are used from the saved files.  This prevents the need to retrieve the metadata on every
 # login request.
-sub idp ($self, $ceritificateOnly = 0) {
+sub idp ($self, $certificateOnly = 0) {
 	if (!$self->{idp_certificate_file} || !$self->{idp}) {
 		my $ce = $self->{c}->ce;
 
@@ -218,12 +218,12 @@ sub idp ($self, $ceritificateOnly = 0) {
 				$self->{idp_certificate_file} = $certificateFile;
 			} else {
 				debug("Unable to retrieve metadata from identity provider $ce->{saml2}{active_idp} with "
-						. "metadata URL $ce->{samle}{idps}{$ce->{saml2}{active_idp}}");
+						. "metadata URL $ce->{saml2}{idps}{$ce->{saml2}{active_idp}}");
 			}
 		}
 	}
 
-	return $self->{idp_certificate_file} if $ceritificateOnly;
+	return $self->{idp_certificate_file} if $certificateOnly;
 	return $self->{idp};
 }
 

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -165,7 +165,7 @@ sub setCachedUser {
 
 Checks the %permissionLevels hash in the course environment to determine if the
 user $userID has permission to engage in the activity $activity. If the user's
-permission level is greater than or equal to the level associated with $activty,
+permission level is greater than or equal to the level associated with $activity,
 a true value is returned. Otherwise, a false value is returned.
 
 If $userID has been cached using the setCachedUser() call, the cached data is
@@ -272,7 +272,7 @@ sub hasPermissions {
 			}
 		} else {
 			#			warn "Undefined Role, -- assuming no one has permission to perform $activity.";
-			return 0;    # undefiend $activity_role, no one has permission to perform $activity
+			return 0;    # undefined $activity_role, no one has permission to perform $activity
 		}
 	} else {
 		#		warn "Activity '$activity' not found in \%permissionLevels -- assuming no permission.";

--- a/lib/WeBWorK/ConfigValues.pm
+++ b/lib/WeBWorK/ConfigValues.pm
@@ -1123,7 +1123,7 @@ sub getConfigValues ($ce) {
 			type   => 'text',
 			secret => 1
 		},
-		'LTI{v1p3}{PlatfromID}' => {
+		'LTI{v1p3}{PlatformID}' => {
 			var    => 'LTI{v1p3}{PlatformID}',
 			doc    => x('LMS platform ID for LTI 1.3'),
 			doc2   => x('LMS platform ID used to validate logins from an LMS using LTI 1.3.'),

--- a/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Std.pm
@@ -468,7 +468,7 @@ sub get_fields_where {
 	return @results;
 }
 
-# returns an Iterator that generates refs to arrays containg field values for each matching row
+# returns an Iterator that generates refs to arrays containing field values for each matching row
 sub get_fields_where_i {
 	my ($self, $fields, $where, $order) = @_;
 	$fields ||= [ $self->fields ];
@@ -872,7 +872,7 @@ sub sql_field_name {
 	return $field;
 }
 
-# returns fully quoted expression refering to the specified field
+# returns fully quoted expression referring to the specified field
 # if $include_table is true, the field name is prefixed with the table name
 sub sql_field_expression {
 	my ($self, $field, $table) = @_;

--- a/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
@@ -125,7 +125,7 @@ sub keyparts_to_where {
 # overrides to fake version_id field
 ################################################################################
 
-# replace the virutal set_id and version_id fields with expressions that extract
+# replace the virtual set_id and version_id fields with expressions that extract
 # the set and version IDs from the real set_id field
 sub _get_fields_where_prepex {
 	my ($self, $fields, $where, $order) = @_;

--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -500,7 +500,7 @@ sub readSetDef ($ce, $fileName) {
 				# Anything left?
 				push(@line, $curr) if ($curr);
 
-				# Exract the problem data from the line.
+				# Extract the problem data from the line.
 				my ($name, $weight, $attemptLimit, $showMeAnother) = @line;
 
 				# Clean up problem values

--- a/lib/WeBWorK/Upload.pm
+++ b/lib/WeBWorK/Upload.pm
@@ -237,7 +237,7 @@ sub dispose {
 
 =head3 disposeTo
 
-    $upload->diposeTo($path);
+    $upload->disposeTo($path);
 
 Remove the file from the upload cache, and move it to C<$path>. Returns the
 destination as a C<Mojo::File> object if the upload was successfully moved, or

--- a/lib/WeBWorK/Utils.pm
+++ b/lib/WeBWorK/Utils.pm
@@ -617,7 +617,7 @@ appropriate method.
 
 Usage: C<encode_utf8_base64($in)>
 
-UTF-8 encodes, and then base 64 endcodes the input and returns the result.
+UTF-8 encodes, and then base 64 encodes the input and returns the result.
 
 =head2 decode_utf8_base64
 
@@ -730,7 +730,7 @@ that sender.
 Usage: C<processEmailMessage($text, $user_record, $STATUS, $merge_data, $for_preview)>
 
 Process the email message in C<$text> and replace macros with values from the
-C<$user_record>, the C<$STATUS>, and C<$merge_data>. If C<$for_prevew> is true
+C<$user_record>, the C<$STATUS>, and C<$merge_data>. If C<$for_preview> is true
 then the result is formatted to be display in HTML.
 
 The replaceable macros and what they will be replaced with are

--- a/lib/WeBWorK/Utils/CourseDBIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseDBIntegrityCheck.pm
@@ -96,7 +96,7 @@ sub checkCourseTables {
 	my @tableNames = map {@$_} @$result;    # Drill down in the result to the table name level
 
 	# Table names are of the form courseID_table (with an underscore). So if we have two courses mth101 and
-	# mth101_fall09 when we check the tables for mth101 we will inadvertantly pick up the tables for mth101_fall09.
+	# mth101_fall09 when we check the tables for mth101 we will inadvertently pick up the tables for mth101_fall09.
 	# Thus we find all courseID's and exclude the extraneous tables.
 	my @courseIDs = listCourses($ce);
 	my @similarIDs;

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -227,13 +227,12 @@ sub addCourse {
 	{
 		# does the directory already exist?
 		-e $root and croak "Can't create the course '$courseID' because the root directory '$root' already exists.";
-		# is the parent directory writeable?
+		# is the parent directory writable?
 		my @rootElements = File::Spec->splitdir($root);
 		pop @rootElements;
 		my $rootParent = File::Spec->catdir(@rootElements);
 		-w $rootParent
-			or croak
-			"Can't create the course '$courseID' because the courses directory '$rootParent' is not writeable.";
+			or croak "Can't create the course '$courseID' because the courses directory '$rootParent' is not writable.";
 		# try to create it
 		eval { path($root)->make_path };
 		croak "Can't create the course '$courseID' because the root directory '$root' could not be created: $@." if $@;
@@ -252,12 +251,12 @@ sub addCourse {
 			next;
 		}
 
-		# is the parent directory writeable?
+		# is the parent directory writable?
 		my @courseDirElements = File::Spec->splitdir($courseDir);
 		pop @courseDirElements;
 		my $courseDirParent = File::Spec->catdir(@courseDirElements);
 		unless (-w $courseDirParent) {
-			warn "Can't create $courseDirName directory '$courseDir', since the parent directory is not writeable. "
+			warn "Can't create $courseDirName directory '$courseDir', since the parent directory is not writable. "
 				. "You will have to create this directory manually.\n";
 			next;
 		}
@@ -585,23 +584,23 @@ sub renameCourse {
 				next;
 			}
 
-			# is oldDir's parent writeable
+			# is oldDir's parent writable
 			my @oldDirElements = File::Spec->splitdir($oldDir);
 			pop @oldDirElements;
 			my $oldDirParent = File::Spec->catdir(@oldDirElements);
 			unless (-w $oldDirParent) {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the source parent directory is not "
-					. "writeable. You will have to move this directory manually.\n";
+					. "writable. You will have to move this directory manually.\n";
 				next;
 			}
 
-			# is newDir's parent writeable?
+			# is newDir's parent writable?
 			my @newDirElements = File::Spec->splitdir($newDir);
 			pop @newDirElements;
 			my $newDirParent = File::Spec->catdir(@newDirElements);
 			unless (-w $newDirParent) {
 				warn "$courseDirName: Can't move '$oldDir' to '$newDir', since the destination parent directory is "
-					. "not writeable. You will have to move this directory manually.\n";
+					. "not writable. You will have to move this directory manually.\n";
 				next;
 			}
 
@@ -713,7 +712,7 @@ sub deleteCourse {
 
 	my %courseDirs = %{ $ce->{courseDirs} };
 
-	##### step 0: make sure course directory is deleteable #####
+	##### step 0: make sure course directory is deletable #####
 
 	# deal with root directory first -- if we won't be able to delete it, we have to give up.
 
@@ -722,13 +721,12 @@ sub deleteCourse {
 		"Can't delete the course '$courseID' because no root directory is specified in the '%courseDirs' hash.";
 	my $root = $courseDirs{root};
 	if (-e $root) {
-		# is the parent directory writeable?
+		# is the parent directory writable?
 		my @rootElements = File::Spec->splitdir($root);
 		pop @rootElements;
 		my $rootParent = File::Spec->catdir(@rootElements);
 		-w $rootParent
-			or croak
-			"Can't delete the course '$courseID' because the courses directory '$rootParent' is not writeable.";
+			or croak "Can't delete the course '$courseID' because the courses directory '$rootParent' is not writable.";
 	} else {
 		warn "Warning: the course root directory '$root' does not exist. "
 			. "Attempting to delete the course database and other course directories...\n";
@@ -760,13 +758,13 @@ sub deleteCourse {
 				next;
 			}
 
-			# is the parent writeable
+			# is the parent writable
 			my @courseDirElements = File::Spec->splitdir($courseDir);
 			pop @courseDirElements;
 			my $courseDirParent = File::Spec->catdir(@courseDirElements);
 			unless (-w $courseDirParent) {
 				warn "Can't delete $courseDirName directory '$courseDir', since its parent directory is not "
-					. "writeable. If it is not wanted, you will have to delete it manually.\n";
+					. "writable. If it is not wanted, you will have to delete it manually.\n";
 				next;
 			}
 

--- a/lib/WeBWorK/Utils/Files.pm
+++ b/lib/WeBWorK/Utils/Files.pm
@@ -117,7 +117,7 @@ returned after transforming line endings into UNIX line feeds.
 
 =head2 listFilesRecursive
 
-    listFilesRecusive($dir, $match_qr, $prune_qr, $match_full, $prune_full)
+    listFilesRecursive($dir, $match_qr, $prune_qr, $match_full, $prune_full)
 
 Traverses the directory tree rooted at C<$dir>, returning a list of files, named
 pipes, and sockets matching the regular expression C<$match_qr>. Directories

--- a/lib/WeBWorK/Utils/JITAR.pm
+++ b/lib/WeBWorK/Utils/JITAR.pm
@@ -112,7 +112,7 @@ sub is_jitar_problem_hidden ($db, $userID, $setID, $problemID) {
 		}
 
 		# the child problems are closed unless the number of incorrect attempts is above the
-		# attempts to open children, or if they have exausted their max_attempts
+		# attempts to open children, or if they have exhausted their max_attempts
 		# if att_to_open_children is -1 we just use max attempts
 		# if max_attempts is -1 then they are always less than max attempts
 		if (

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -267,7 +267,7 @@ sub compute_unreduced_score ($ce, $problem, $set) {
 		&& defined $problem->sub_status
 		&& $problem->sub_status < $problem->status)
 	{
-		# Note that if the status has been modified by an instructor using a problem grader or an achivement, then the
+		# Note that if the status has been modified by an instructor using a problem grader or an achievement, then the
 		# computed unreduced score can be greater than one.  So make sure to cap the score.
 		my $unreducedScore =
 			($problem->status - $problem->sub_status) / $ce->{pg}{ansEvalDefaults}{reducedScoringValue} +

--- a/lib/WebworkSOAP.pm
+++ b/lib/WebworkSOAP.pm
@@ -1244,7 +1244,7 @@ sub delete_user_set {
 }
 
 ###########################################
-# grading utilties -- to be moved to Utils::Grades
+# grading utilities -- to be moved to Utils::Grades
 ############################################
 
 ############################################

--- a/lib/WebworkWebservice/RenderProblem.pm
+++ b/lib/WebworkWebservice/RenderProblem.pm
@@ -236,7 +236,7 @@ async sub renderProblem {
 		),
 		showMessages => (
 			$rh->{WWcorrectAnsOnly} ? 0
-			: ($rh->{showMessages} // ($rh->{previewAsnwers} || $rh->{WWsubmit} || $rh->{WWcorrectAns}))
+			: ($rh->{showMessages} // ($rh->{previewAnswers} || $rh->{WWsubmit} || $rh->{WWcorrectAns}))
 		),
 		showCorrectAnswers =>
 			($rh->{WWcorrectAnsOnly} ? 1 : ($rh->{showCorrectAnswers} // ($rh->{WWcorrectAns} ? 2 : 0))),


### PR DESCRIPTION
These are typos in `lib`, but not in `lib/WeBWorK/`.

The misnaming of `ResourceIri` as `ResourseIri` was consistent. Someone who knows Caliper should weigh in about this, if the package is used outside of this code. @andrew-gardener, does changing this typo matter?

I have not thought hard about the typo in `lib/WebworkWebservice/RenderProblem.pm`. If that code gets used, certainly it is broken with the typo in place.
