### PR TITLE
typos identified by github.com/crate-ci/typos

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -2647,7 +2647,7 @@ sub copy_otp_secrets_confirm ($c) {
 					}
 				} elsif ($d_user_password->otp_secret) {
 					$dest_error    = 'danger';
-					$error_message = $c->maketext('OTP Secret is not empty - Overwritting');
+					$error_message = $c->maketext('OTP Secret is not empty - Overwriting');
 				}
 			}
 

--- a/lib/WeBWorK/ContentGenerator/Feedback.pm
+++ b/lib/WeBWorK/ContentGenerator/Feedback.pm
@@ -14,7 +14,7 @@ use Try::Tiny;
 use WeBWorK::Upload;
 use WeBWorK::Utils qw(createEmailSenderTransportSMTP fetchEmailRecipients formatEmailSubject);
 
-# request paramaters used
+# request parameters used
 #
 # user
 # key

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -73,7 +73,7 @@ sub can_showCorrectAnswers ($c, $user, $permissionLevel, $effectiveUser, $set, $
 	);
 }
 
-# This version is the same as the above version except that it ignores elevated permisions. So it will be true if this
+# This version is the same as the above version except that it ignores elevated permissions. So it will be true if this
 # set is in the state that anyone can show correct answers regardless of if they have the
 # show_correct_answers_before_answer_date or view_hidden_work permissions.  In this case, feedback is shown even without
 # a form submission, and correct answers are shown in the feedback, if the $pg{options}{automaticAnswerFeedback} option

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -72,7 +72,7 @@ our @HC_FORMAT_DISPLAY_ORDER = ('tex', 'pdf');
 #   used by add_error(), has_errors(), get_errors()
 #
 # at_least_one_problem_rendered_without_error
-#   set to a true value by write_problem_tex if it is able to sucessfully render
+#   set to a true value by write_problem_tex if it is able to successfully render
 #   a problem. checked by generate_hardcopy to determine whether to continue
 #   with the generation process.
 #
@@ -508,7 +508,7 @@ async sub generate_hardcopy ($c, $format, $userIDsRef, $setIDsRef) {
 		return;
 	}
 	unless (-w $temp_dir_path) {
-		$c->add_error('Temporary directory "', $c->tag('code', $temp_dir_path), '" is not writeable.');
+		$c->add_error('Temporary directory "', $c->tag('code', $temp_dir_path), '" is not writable.');
 		$c->delete_temp_dir($temp_dir_path);
 		return;
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementEditor.pm
@@ -103,7 +103,7 @@ sub getRelativeSourceFilePath ($c, $sourceFilePath) {
 }
 
 # saveFileChanges does most of the work. It is a separate method so that it can
-# be called from either pre_header_initialize or initilize, depending on
+# be called from either pre_header_initialize or initialize, depending on
 # whether a redirect is needed or not.
 sub saveFileChanges ($c, $outputFilePath, $achievementContents = undef) {
 	my $ce = $c->ce;
@@ -121,7 +121,7 @@ sub saveFileChanges ($c, $outputFilePath, $achievementContents = undef) {
 	my $do_not_save = 0;                            # flag to prevent saving of file
 	my $editErrors  = '';
 
-	# write changes to the approriate files
+	# write changes to the appropriate files
 	# FIXME  make sure that the permissions are set correctly!!!
 	# Make sure that the warning is being transmitted properly.
 

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementList.pm
@@ -532,7 +532,7 @@ sub save_export_handler ($c) {
 
 	my $csv = Text::CSV->new({ eol => "\n" });
 
-	# Iterate over achievements outputing data as csv list.  This format is not documented anywhere.
+	# Iterate over achievements outputting data as csv list.  This format is not documented anywhere.
 	for my $achievement ($db->getAchievements(@achievementIDsToExport)) {
 		my $line = [
 			$achievement->achievement_id, $achievement->name,            $achievement->number,

--- a/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/AchievementNotificationEditor.pm
@@ -96,7 +96,7 @@ sub getRelativeSourceFilePath ($c, $sourceFilePath) {
 }
 
 # saveFileChanges does most of the work. It is a separate method so that it can
-# be called from either pre_header_initialize or initilize, depending on
+# be called from either pre_header_initialize or initialize, depending on
 # whether a redirect is needed or not.
 sub saveFileChanges ($c, $outputFilePath) {
 	my $ce = $c->ce;

--- a/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/FileManager.pm
@@ -982,7 +982,7 @@ sub checkPWD ($c, $pwd, $renameError = 0) {
 
 	# check for bad symbolic links
 	my @dirs = split('/', $pwd);
-	pop(@dirs) if $renameError;               # don't check file iteself in this case
+	pop(@dirs) if $renameError;               # don't check file itself in this case
 	my @path = ($c->{ce}{courseDirs}{root});
 	for my $dir (@dirs) {
 		push @path, $dir;

--- a/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/PGProblemEditor.pm
@@ -1241,7 +1241,7 @@ sub save_as_handler ($c) {
 			$c->addgoodmessage($c->maketext('No changes have been made to set [_1]', $c->{setID}))
 				if $c->{setID} && $c->{setID} ne 'Undefined_Set';
 		} else {
-			$c->addbadmessage($c->maketext('Unkown saveMode: [_1].', $saveMode));
+			$c->addbadmessage($c->maketext('Unknown saveMode: [_1].', $saveMode));
 			return;
 		}
 	}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -65,7 +65,7 @@ use constant JITAR_SET_FIELD_ORDER => [qw(restrict_prob_progression email_instru
 #                                     [min, max, step] will introduce validation, so should not be used on just any
 #                                     input where we expect numbers
 #     size      => "50",            # size of the edit box (if any)
-#     override  => "all",           # none, one, any, all - defines for whom this data can be overidden
+#     override  => "all",           # none, one, any, all - defines for whom this data can be overridden
 #     module    => "problem_list",  # WeBWorK module
 #     default   => 0                # if a field cannot default to undefined/empty what should it default to
 #     labels    => {                # Display labels for type "choose" or type "[min, max, step]".
@@ -1813,7 +1813,7 @@ sub initialize ($c) {
 			}
 		}
 
-		# Change problem_ids from regular style to jitar style if appropraite.  (Not applicable when editing for users.)
+		# Change problem_ids from regular style to jitar style if appropriate.  (Not applicable when editing for users.)
 		# This is a very long operation because we are shuffling the whole database around.
 		if ($oldAssignmentType ne $setRecord->assignment_type
 			&& ($oldAssignmentType eq 'jitar' || $setRecord->assignment_type eq 'jitar'))

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetList.pm
@@ -168,7 +168,7 @@ sub initialize ($c) {
 	my $setID      = $c->stash('setID');
 	my $user       = $c->param('user');
 
-	# Make sure these are defined for the templats.
+	# Make sure these are defined for the templates.
 	$c->stash->{fieldNames}     = VIEW_FIELD_ORDER();
 	$c->stash->{formsToShow}    = VIEW_FORMS();
 	$c->stash->{formTitles}     = FORM_TITLES();
@@ -178,7 +178,7 @@ sub initialize ($c) {
 	$c->stash->{sets}           = [];
 	$c->stash->{setDefList}     = [];
 
-	# Determine if the user has permisson to do anything here.
+	# Determine if the user has permission to do anything here.
 	return unless $authz->hasPermissions($user, 'access_instructor_tools');
 
 	# Determine if edit mode or export mode is request, and check permissions for these modes.
@@ -581,7 +581,7 @@ sub save_export_handler ($c) {
 
 	if (defined $c->param('prev_visible_sets')) {
 		$c->{visibleSetIDs} = [ $c->param('prev_visible_sets') ];
-	} elsif (defined $c->param('no_prev_visble_sets')) {
+	} elsif (defined $c->param('no_prev_visible_sets')) {
 		$c->{visibleSetIDs} = [];
 	}
 
@@ -630,7 +630,7 @@ sub save_edit_handler ($c) {
 				if ($field =~ /_date/) {
 					$Set->$field($value);
 				} elsif ($field eq 'enable_reduced_scoring') {
-					# If we are enableing reduced scoring, make sure the reduced scoring date
+					# If we are enabling reduced scoring, make sure the reduced scoring date
 					# is set and in a proper interval.
 					$Set->enable_reduced_scoring($value);
 					if (!$Set->reduced_scoring_date) {
@@ -680,7 +680,7 @@ sub save_edit_handler ($c) {
 
 	if (defined $c->param("prev_visible_sets")) {
 		$c->{visibleSetIDs} = [ $c->param("prev_visible_sets") ];
-	} elsif (defined $c->param("no_prev_visble_sets")) {
+	} elsif (defined $c->param("no_prev_visible_sets")) {
 		$c->{visibleSetIDs} = [];
 	} else {
 		# leave it alone

--- a/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Scoring.pm
@@ -615,9 +615,9 @@ sub writeCSV ($c, $filename, @csv) {
 	return;
 }
 
-# As soon as backwards compatability is no longer a concern and we don't expect to have
+# As soon as backwards compatibility is no longer a concern and we don't expect to have
 # to use old ww1.x code to read the output anymore, I recommend switching to using
-# these routines, which are more versatile and compatable with other programs which
+# these routines, which are more versatile and compatible with other programs which
 # deal with CSV files.
 sub readStandardCSV ($c, $fileName) {
 	my @result;

--- a/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/SetMaker.pm
@@ -306,13 +306,13 @@ sub process_search ($c, @dbsearch) {
 	# Build a hash of MLT entries keyed by morelt_id
 	my %mlt = ();
 	my $mltind;
-	for my $indx (0 .. $#dbsearch) {
-		$dbsearch[$indx]{oindex} = $indx;
-		if ($mltind = $dbsearch[$indx]{morelt}) {
+	for my $index (0 .. $#dbsearch) {
+		$dbsearch[$index]{oindex} = $index;
+		if ($mltind = $dbsearch[$index]{morelt}) {
 			if (defined($mlt{$mltind})) {
-				push @{ $mlt{$mltind} }, $indx;
+				push @{ $mlt{$mltind} }, $index;
 			} else {
-				$mlt{$mltind} = [$indx];
+				$mlt{$mltind} = [$index];
 			}
 		}
 	}
@@ -325,12 +325,12 @@ sub process_search ($c, @dbsearch) {
 		if (scalar(@idlist) > 1) {
 			my $leader = WeBWorK::Utils::ListingDB::getMLTleader($c, $mltid) || 0;
 			my $hold   = undef;
-			for my $subindx (@idlist) {
-				if ($dbsearch[$subindx]->{pgid} == $leader) {
-					$dbsearch[$subindx]->{children} = [];
-					$hold = $subindx;
+			for my $subindex (@idlist) {
+				if ($dbsearch[$subindex]->{pgid} == $leader) {
+					$dbsearch[$subindex]->{children} = [];
+					$hold = $subindex;
 				} else {
-					$dbsearch[$subindx]->{noshow} = 1;
+					$dbsearch[$subindex]->{noshow} = 1;
 				}
 			}
 			do {    # we did not find the leader
@@ -689,7 +689,7 @@ sub pre_header_initialize ($c) {
 		}
 	}
 
-	# Now store data in self for retreival by body
+	# Now store data in self for retrieval by body
 	$c->{first_shown}           = $first_shown;
 	$c->{last_shown}            = $last_shown;
 	$c->{first_index}           = $first_index;

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -50,9 +50,9 @@ use Mojo::File;
 use WeBWorK::File::Classlist qw(parse_classlist write_classlist);
 use WeBWorK::Utils           qw(cryptPassword x);
 
-use constant HIDE_USERS_THRESHHOLD => 200;
-use constant EDIT_FORMS            => [qw(save_edit cancel_edit)];
-use constant VIEW_FORMS            => [qw(filter sort edit import export add delete reset_2fa)];
+use constant HIDE_USERS_THRESHOLD => 200;
+use constant EDIT_FORMS           => [qw(save_edit cancel_edit)];
+use constant VIEW_FORMS           => [qw(filter sort edit import export add delete reset_2fa)];
 
 # Prepare the tab titles for translation by maketext
 use constant FORM_TITLES => {
@@ -123,7 +123,7 @@ use constant FIELD_PROPERTIES => {
 			my $value = shift;
 			return $value !~ /^(\d+(\.\d*)?|\.\d+)$/ || $value <= 0
 				? (x(
-					'Accomodation time factor for [_1] unchanged. '
+					'Accommodation time factor for [_1] unchanged. '
 					. 'A value was given that is not a decimal number or is not greater than or equal to 1.'
 				))[0]
 				: 0;
@@ -197,7 +197,7 @@ sub pre_header_initialize ($c) {
 
 	if (defined $c->param('visible_users')) {
 		$c->{visibleUserIDs} = { map { $_ => 1 } @{ $c->every_param('visible_users') } };
-	} elsif (@allUsersDB > HIDE_USERS_THRESHHOLD || defined $c->param('no_visible_users')) {
+	} elsif (@allUsersDB > HIDE_USERS_THRESHOLD || defined $c->param('no_visible_users')) {
 		$c->{visibleUserIDs} = {};
 	} else {
 		$c->{visibleUserIDs} = { map { $_ => 1 } @{ $c->{allUserIDs} } };

--- a/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
+++ b/lib/WeBWorK/ContentGenerator/LTIAdvantage.pm
@@ -441,7 +441,7 @@ async sub registration ($c) {
 	$c->render_later;
 
 	my $configurationResult = (await Mojo::UserAgent->new->get_p($c->req->param('openid_configuration')))->result;
-	return $c->render(json => { error => 'unabled to obtain openid configuration' }, status => 400)
+	return $c->render(json => { error => 'unable to obtain openid configuration' }, status => 400)
 		unless $configurationResult->is_success;
 	my $lmsConfiguration = $configurationResult->json;
 

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -910,7 +910,7 @@ sub page_title ($c) {
 		$subheader .= ' ' . $problem->source_file;
 	}
 
-	# Add the edit link to the sub header if the user has the permisions ot edit problems.
+	# Add the edit link to the sub header if the user has the permissions to edit problems.
 	if ($c->authz->hasPermissions($c->param('user'), 'modify_problem_sets')) {
 		$subheader = $c->c(
 			$subheader,
@@ -1098,7 +1098,7 @@ sub output_score_summary ($c) {
 		push(@$output, $pg->{state}{state_summary_msg});
 	}
 
-	# Print jitar specific informaton for students (and notify instructor if necessary).
+	# Print jitar specific information for students (and notify instructor if necessary).
 	if ($set->set_id ne 'Undefined_Set' && $set->assignment_type() eq 'jitar') {
 		my @problemIDs =
 			map { $_->[2] }
@@ -1107,7 +1107,7 @@ sub output_score_summary ($c) {
 		my @problemSeqs;
 		my $index;
 
-		# This sets of an array of the sequence assoicated to the problem_id
+		# This sets of an array of the sequence associated to the problem_id
 		for (my $i = 0; $i <= $#problemIDs; $i++) {
 			$index = $i if ($problemIDs[$i] == $problem->problem_id);
 			my @seq = jitar_id_to_seq($problemIDs[$i]);
@@ -1116,7 +1116,7 @@ sub output_score_summary ($c) {
 
 		my $next_id = $index + 1;
 		my @seq     = @{ $problemSeqs[$index] };
-		my @children_counts_indexs;
+		my @children_counts_indices;
 		my $hasChildren = 0;
 
 		# Find the index of the next problem at the same level as the current one, check to see if there are any
@@ -1124,7 +1124,7 @@ sub output_score_summary ($c) {
 		while ($next_id <= $#problemIDs && scalar(@{ $problemSeqs[$index] }) < scalar(@{ $problemSeqs[$next_id] })) {
 			my $childProblem = $db->getMergedProblem($effectiveUser, $set->set_id, $problemIDs[$next_id]);
 			$hasChildren = 1;
-			push @children_counts_indexs, $next_id
+			push @children_counts_indices, $next_id
 				if scalar(@{ $problemSeqs[$index] }) + 1 == scalar(@{ $problemSeqs[$next_id] })
 				&& $childProblem->counts_parent_grade;
 			$next_id++;
@@ -1150,24 +1150,24 @@ sub output_score_summary ($c) {
 				)
 			);
 
-			if (scalar(@children_counts_indexs) == 1) {
+			if (scalar(@children_counts_indices) == 1) {
 				push(
 					@$output,
 					$c->tag('br'),
 					$c->maketext(
 						'The grade for this problem is the larger of the score for this problem, '
 							. 'or the score of problem [_1].',
-						join('.', @{ $problemSeqs[ $children_counts_indexs[0] ] })
+						join('.', @{ $problemSeqs[ $children_counts_indices[0] ] })
 					)
 				);
-			} elsif (scalar(@children_counts_indexs) > 1) {
+			} elsif (scalar(@children_counts_indices) > 1) {
 				push(
 					@$output,
 					$c->tag('br'),
 					$c->maketext(
 						'The grade for this problem is the larger of the score for this problem, '
 							. 'or the weighted average of the problems: [_1].',
-						join(', ', map({ join('.', @{ $problemSeqs[$_] }) } @children_counts_indexs))
+						join(', ', map({ join('.', @{ $problemSeqs[$_] }) } @children_counts_indices))
 					)
 				);
 			}

--- a/lib/WeBWorK/ContentGenerator/Skeleton.pm
+++ b/lib/WeBWorK/ContentGenerator/Skeleton.pm
@@ -5,7 +5,7 @@
 # create your very own module.
 #
 # When you've finished, I recommend you do some cleanup. These modules are much
-# easier to maintain if they doesn't contain "vestigal" garbage code. Remove the
+# easier to maintain if they don't contain "vestigial" garbage code. Remove the
 # "SKEL" comments and anything else that you're not using in your module.
 
 # SKEL: Declare the name and superclass of your module here:


### PR DESCRIPTION
These are the typos from `lib/WeBWorK/ContentGenerator/`. There are not as many as I thought. Maybe when I did an initial count there was something wrong with the sytnax I used.

In a few places, things like variable names are changed. I believe they are changed consistently over their scope and the changes should cause no trouble. But they will lighten future scans for typos.