### PR TITLE
Add error handling in the pg problem editor

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -272,6 +272,19 @@
 			.then((data) => {
 				if (data.error) throw new Error(data.error);
 				if (!data.result_data) throw new Error('An invalid response was received.');
+				if (data.result_data.errors) {
+					renderArea.innerHTML =
+						'<div class="alert alert-danger p-1 m-2">' +
+						'<p class="fw-bold">PGML conversion errors:</p>' +
+						'<pre><code>' +
+						data.result_data.errors
+							.replace(/^[\s\S]*Begin Error Output Stream\n\n/, '')
+							.replace(/\n\d*: To save a full \.LOG file rerun with -g/, '') +
+						'</code></pre>';
+
+					showMessage('Errors occurred when converting code to PGML.', false);
+					return;
+				}
 				if (request_object.pgCode === data.result_data.pgmlCode) {
 					showMessage('There were no changes to the code.', true);
 				} else {
@@ -279,6 +292,7 @@
 					else document.getElementById('problemContents').value = data.result_data.pgmlCode;
 					saveTempFile();
 					showMessage('Successfully converted code to PGML', true);
+					if (!(renderArea.firstChild instanceof HTMLIFrameElement)) render();
 				}
 			})
 			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -159,13 +159,11 @@ sub tidyPGCode {
 
 sub convertCodeToPGML {
 	my ($invocant, $self, $params) = @_;
-	my $code = $params->{pgCode};
 
 	return {
-		ra_out => { pgmlCode => convertToPGML($code) },
+		ra_out => convertToPGML($params->{pgCode}),
 		text   => 'Converted to PGML'
 	};
-
 }
 
 sub runPGCritic {


### PR DESCRIPTION
This adds error handling for the PGML converter to the PGProblemEditor.  This mimics the pg tidy interface and code. 

If there is an error in parsing the PG problem--currently only the loadMacros command will throw an error--then the error is shown in the right pane of the PG problem editor.  Upon fixing the error and rerunning the "Convert to PGML" in the "Code Maintenance" table, the code is updated and pre-rendered.  Note, previously, the code was not rerendered after code conversion. 

Also, openwebwork/pg#1425 is needed to test this. 