### PR TITLE
show file size of archived courses when unarchiving

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -29,7 +29,6 @@ use WeBWorK::Utils::Instructor qw(assignSetsToUsers);
 our @EXPORT_OK = qw(
 	listCourses
 	listArchivedCourses
-	statArchivedCourses
 	addCourse
 	renameCourse
 	retitleCourse
@@ -110,7 +109,17 @@ sub listCourses {
 
 =item listArchivedCourses($ce)
 
-Lists the courses which have been archived (end in .tar.gz).
+Lists the courses which have been archived (end in .tar.gz). The courses found
+are returned as a hash whose keys are the course ids and the values are
+references to hashes containing the C<filename> (the basename of the file
+including the .tar.gz extension) and file C<size>. For example,
+
+    {
+        myTestCourse => {
+            filename => 'myTestCourse.tar.gz',
+            size     => '605 KB'
+        }
+    }
 
 =cut
 
@@ -118,30 +127,24 @@ sub listArchivedCourses {
 	my ($ce) = @_;
 	my $archivesDir = path("$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives");
 	surePathToFile($ce->{webworkDirs}{courses}, "$archivesDir/test");    # Ensure archives directory exists.
-	return @{ $archivesDir->list->grep(qr/\.tar\.gz$/)->map('basename') };
-}
 
-=item statArchivedCourses($ce)
+	my $archives = $archivesDir->list->grep(qr/\.tar\.gz$/i);
 
-File info for the courses which have been archived (end in .tar.gz).
-
-=cut
-
-sub statArchivedCourses {
-	my ($ce)        = @_;
-	my @archives    = listArchivedCourses($ce);
-	my $archivesDir = path("$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives");
 	my %return;
-	for (@archives) {
-		my @stat     = stat("$archivesDir/$_");
-		my $size     = $stat[7];
+	for (@$archives) {
+		my $size     = $_->stat->size;
 		my @units    = qw(B KB MB GB);
 		my $unit_idx = 0;
-		while ($size >= 1024 && $unit_idx < @units - 1) {
+		while ($size >= 1024 && $unit_idx < $#units) {
 			$size /= 1024;
-			$unit_idx++;
+			++$unit_idx;
 		}
-		$return{ $_ =~ s/\.tar\.gz$//ir } = { filename => $_, size => sprintf("%s %s", int($size), $units[$unit_idx]) };
+		my $basename = $_->basename;
+		my $round    = 10**($unit_idx > 0 ? $unit_idx - 1 : 0);
+		$return{ $basename =~ s/\.tar\.gz$//ir } = {
+			filename => $basename,
+			size     => sprintf("%s %s", int($size * $round) / $round, $units[$unit_idx])
+		};
 	}
 	return %return;
 }

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -140,8 +140,19 @@ sub listArchivedCourses {
 			++$unit_idx;
 		}
 		my $basename = $_->basename;
-		my $round    = 10**($unit_idx > 0 ? $unit_idx - 1 : 0);
-		$return{ $basename =~ s/\.tar\.gz$//ir } = {
+		my $arch     = Archive::Tar->new($_);
+		my %top_level;
+		for my $file ($arch->get_files) {
+			(my $first = $file->full_path) =~ s{/.*}{}s;
+			$top_level{$first} = 1 if length $first;
+		}
+		unless (keys %top_level == 1) {
+			warn "The archive $basename does not contain a single top-level course directory.\n";
+			next;
+		}
+		my ($currCourseID) = keys %top_level;
+		my $round = 10**($unit_idx > 0 ? $unit_idx - 1 : 0);
+		$return{$currCourseID} = {
 			filename => $basename,
 			size     => sprintf("%s %s", int($size * $round) / $round, $units[$unit_idx])
 		};

--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -29,6 +29,7 @@ use WeBWorK::Utils::Instructor qw(assignSetsToUsers);
 our @EXPORT_OK = qw(
 	listCourses
 	listArchivedCourses
+	statArchivedCourses
 	addCourse
 	renameCourse
 	retitleCourse
@@ -118,6 +119,31 @@ sub listArchivedCourses {
 	my $archivesDir = path("$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives");
 	surePathToFile($ce->{webworkDirs}{courses}, "$archivesDir/test");    # Ensure archives directory exists.
 	return @{ $archivesDir->list->grep(qr/\.tar\.gz$/)->map('basename') };
+}
+
+=item statArchivedCourses($ce)
+
+File info for the courses which have been archived (end in .tar.gz).
+
+=cut
+
+sub statArchivedCourses {
+	my ($ce)        = @_;
+	my @archives    = listArchivedCourses($ce);
+	my $archivesDir = path("$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives");
+	my %return;
+	for (@archives) {
+		my @stat     = stat("$archivesDir/$_");
+		my $size     = $stat[7];
+		my @units    = qw(B KB MB GB);
+		my $unit_idx = 0;
+		while ($size >= 1024 && $unit_idx < @units - 1) {
+			$size /= 1024;
+			$unit_idx++;
+		}
+		$return{ $_ =~ s/\.tar\.gz$//ir } = { filename => $_, size => sprintf("%s %s", int($size), $units[$unit_idx]) };
+	}
+	return %return;
 }
 
 ################################################################################

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -65,8 +65,9 @@
 		) =%>
 	</p>
 	<ol>
-		% for (sort { lc($a) cmp lc($b) } listArchivedCourses($ce)) {
-			<li><%= $_ %></li>
+		% my %courseArchives = listArchivedCourses($ce);
+		% for (sort { lc($a) cmp lc($b) } keys %courseArchives) {
+			<li><%= "$_ ($courseArchives{$_}{size})" %></li>
 		% }
 	</ol>
 % }

--- a/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_form.html.ep
@@ -5,7 +5,7 @@
 		<%= maketext(
 			'Courses are listed either alphabetically or in order by the time of most recent login activity, oldest '
 				. 'first. To change the listing order check the mode you want and click "Refresh Listing".  The '
-				. 'listing format is: Course_Name (status :: date/time of most recent login) where status is "hidden" '
+				. 'listing format is: Course_ID (status :: date/time of most recent login) where status is "hidden" '
 				. 'or "visible".'
 		) =%>
 	</p>
@@ -35,7 +35,7 @@
 		<%= $c->hidden_fields('subDisplay') =%>
 		<div class="mb-2"><%= maketext('Select course(s) to archive.') %></div>
 		<div class="row mb-2">
-			<%= label_for archive_courseIDs => maketext('Course Name:'), class => 'col-auto col-form-label fw-bold' =%>
+			<%= label_for archive_courseIDs => maketext('Course ID:'), class => 'col-auto col-form-label fw-bold' =%>
 			<div class="col-auto">
 				<%= select_field archive_courseIDs => [ map { [ $courseLabels->{$_} => $_ ] } @$courseIDs ],
 					id       => 'archive_courseIDs',

--- a/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/delete_course_form.html.ep
@@ -6,7 +6,7 @@
 			<%= maketext(
 				'Courses are listed either alphabetically or in order by the time of most recent login activity, '
 					. 'oldest first. To change the listing order check the mode you want and click "Refresh Listing". '
-					. 'The listing format is: Course_Name (status :: date/time of most recent login) where status is '
+					. 'The listing format is: Course_ID (status :: date/time of most recent login) where status is '
 					. '"hidden" or "visible".'
 			) =%>
 		</p>
@@ -35,7 +35,7 @@
 		<%= $c->hidden_fields('subDisplay') =%>
 		<div class="mb-2"><%= maketext('Select a course to delete.') %></div>
 		<div class="row mb-2">
-			<%= label_for delete_courseID => maketext('Course Name:'), class => 'col-auto col-form-label fw-bold' =%>
+			<%= label_for delete_courseID => maketext('Course ID:'), class => 'col-auto col-form-label fw-bold' =%>
 			<div class="col-auto">
 				<%= select_field delete_courseID => [ map { [ $courseLabels->{$_} => $_ ] } @$courseIDs ],
 					id       => 'delete_courseID',

--- a/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/hide_inactive_course_form.html.ep
@@ -12,7 +12,7 @@
 	<%= maketext(
 		'Courses are listed either alphabetically or in order by the time of most recent login activity, '
 			. 'oldest first. To change the listing order check the mode you want and click "Refresh Listing".  '
-			. 'The listing format is: Course_Name (status :: date/time of most recent login) where status is "hidden" '
+			. 'The listing format is: Course_ID (status :: date/time of most recent login) where status is "hidden" '
 			. 'or "visible".'
 	) =%>
 </p>
@@ -43,7 +43,7 @@
 	%
 	<div class="mb-2"><%= maketext('Select course(s) to hide or unhide.') %></div>
 	<div class="row mb-2">
-		<%= label_for hide_courseIDs => maketext('Course Name:'), class => 'col-auto col-form-label fw-bold' =%>
+		<%= label_for hide_courseIDs => maketext('Course ID:'), class => 'col-auto col-form-label fw-bold' =%>
 		<div class="col-auto">
 			<%= select_field hide_courseIDs => [ map { [ $courseLabels->{$_} => $_ ] } @$hideCourseIDs ],
 				id       => 'hide_courseIDs',

--- a/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
@@ -16,10 +16,10 @@
 					. 'string.'
 			) =%>
 		</p>
-		<div class="col-lg-10 col-md-11">
+		<div class="col-lg-9 col-md-11">
 			<div class="row mb-2">
 				<%= label_for rename_oldCourseID => maketext('Course ID:'),
-					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+					class => 'col-lg-3 col-md-4 pe-0 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= select_field rename_oldCourseID => [ map { [ $_ => $_ ] } @courseIDs ],
 						class    => 'form-select',
@@ -28,7 +28,7 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-lg-3 col-md-4">
+				<div class="col-lg-3 col-md-4 pe-0">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseID_label">
 							<%= maketext('New ID:') %>
@@ -42,7 +42,7 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-lg-3 col-md-4">
+				<div class="col-lg-3 col-md-4 pe-0">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseTitle_label">
 							<%= maketext('New Title:') %>
@@ -56,7 +56,7 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-lg-3 col-md-4">
+				<div class="col-lg-3 col-md-4 pe-0">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseInstitution_label">
 							<%= maketext('New Institution:') %>

--- a/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_form.html.ep
@@ -16,11 +16,11 @@
 					. 'string.'
 			) =%>
 		</p>
-		<div class="col-lg-7 col-md-8">
+		<div class="col-lg-10 col-md-11">
 			<div class="row mb-2">
 				<%= label_for rename_oldCourseID => maketext('Course ID:'),
-					class => 'col-sm-6 col-form-label fw-bold' =%>
-				<div class="col-sm-6">
+					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+				<div class="col-lg-9 col-md-8">
 					<%= select_field rename_oldCourseID => [ map { [ $_ => $_ ] } @courseIDs ],
 						class    => 'form-select',
 						size     => 10,
@@ -28,43 +28,43 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-sm-6">
+				<div class="col-lg-3 col-md-4">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseID_label">
-							<%= maketext('Change CourseID to:') %>
+							<%= maketext('New ID:') %>
 							<%= check_box rename_newCourseID_checkbox => 'on', class => 'form-check-input' %>
 						</label>
 					</div>
 				</div>
-				<div class="col-sm-6">
+				<div class="col-lg-9 col-md-8">
 					<%= text_field rename_newCourseID => '',
 						class => 'form-control', 'aria-labelledby' => 'rename_newCourseID_label' =%>
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-sm-6">
+				<div class="col-lg-3 col-md-4">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseTitle_label">
-							<%= maketext('Change Course Title to:') %>
+							<%= maketext('New Title:') %>
 							<%= check_box rename_newCourseTitle_checkbox => 'on', class => 'form-check-input' %>
 						</label>
 					</div>
 				</div>
-				<div class="col-sm-6">
+				<div class="col-lg-9 col-md-8">
 					<%= text_field rename_newCourseTitle => '',
 						class => 'form-control', 'aria-labelledby' => 'rename_newCourseTitle_label' =%>
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<div class="col-sm-6">
+				<div class="col-lg-3 col-md-4">
 					<div class="form-check">
 						<label class="form-check-label" id="rename_newCourseInstitution_label">
-							<%= maketext('Change Institution to:') %>
+							<%= maketext('New Institution:') %>
 							<%= check_box rename_newCourseInstitution_checkbox => 'on', class => 'form-check-input' %>
 						</label>
 					</div>
 				</div>
-				<div class="col-sm-6">
+				<div class="col-lg-9 col-md-8">
 					<%= text_field rename_newCourseInstitution => '',
 						class => 'form-control', 'aria-labelledby' => 'rename_newCourseInstitution_label' =%>
 				</div>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -13,10 +13,10 @@
 		%
 		<div class="mb-2"><%= maketext('Select a course to unarchive.') =%></div>
 		%
-		<div class="col-lg-10 col-md-11">
+		<div class="col-lg-9 col-md-11">
 			<div class="row mb-2">
 				<%= label_for 'unarchive_courseID' => maketext('Course ID:'),
-					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+					class => 'col-md-2 pe-0 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= select_field
 						unarchive_courseID => [
@@ -30,7 +30,7 @@
 			</div>
 			<div class="row mb-2 align-items-center">
 				<%= label_for new_courseID => maketext('New ID:'),
-					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+					class => 'col-md-2 pe-0 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= text_field new_courseID => '',
 						id        => 'new_courseID',

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -1,9 +1,10 @@
-% use WeBWorK::Utils::CourseManagement qw(listArchivedCourses);
+% use WeBWorK::Utils::CourseManagement qw(statArchivedCourses);
 %
 <h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
 %
 % # Find courses which have been archived.
-% my @courseIDs = sort { lc($a) cmp lc($b) } listArchivedCourses($ce);
+% my %stat = statArchivedCourses($ce);
+% my @courseIDs = sort { lc($a) cmp lc($b) } keys %stat;
 %
 % if (@courseIDs) {
 	<%= form_for current_route, method => 'POST', begin =%>
@@ -16,10 +17,11 @@
 			<div class="row mb-2">
 				<%= label_for 'unarchive_courseID' => maketext('Course Name:'), class => 'col-sm-4 col-form-label' =%>
 				<div class="col-sm-8">
-					<%= select_field unarchive_courseID => \@courseIDs,
-						id       => 'unarchive_courseID',
-						class    => 'form-select',
-						size     => 10
+					<%= select_field
+						unarchive_courseID => [map {["$_ ($stat{$_}{size})" => $stat{$_}{filename}]} @courseIDs],
+						id                 => 'unarchive_courseID',
+						class              => 'form-select',
+						size               => 10
 					=%>
 				</div>
 			</div>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -13,10 +13,10 @@
 		%
 		<div class="mb-2"><%= maketext('Select a course to unarchive.') =%></div>
 		%
-		<div class="col-lg-7 col-md-8">
+		<div class="col-lg-10 col-md-11">
 			<div class="row mb-2">
-				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-sm-4 col-form-label fw-bold' =%>
-				<div class="col-sm-8">
+				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+				<div class="col-lg-9 col-md-8">
 					<%= select_field
 						unarchive_courseID => [map {["$_ ($stat{$_}{size})" => $stat{$_}{filename}]} @courseIDs],
 						id                 => 'unarchive_courseID',
@@ -26,8 +26,8 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<%= label_for new_courseID => maketext('New ID:'), class => 'col-sm-4 col-form-label fw-bold' =%>
-				<div class="col-sm-8">
+				<%= label_for new_courseID => maketext('New ID:'), class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+				<div class="col-lg-9 col-md-8">
 					<%= text_field new_courseID => '',
 						id        => 'new_courseID',
 						size      => 25,

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -1,10 +1,10 @@
-% use WeBWorK::Utils::CourseManagement qw(statArchivedCourses);
+% use WeBWorK::Utils::CourseManagement qw(listArchivedCourses);
 %
 <h2><%= maketext('Unarchive Course') %> <%= $c->helpMacro('AdminUnarchiveCourse') %></h2>
 %
 % # Find courses which have been archived.
-% my %stat = statArchivedCourses($ce);
-% my @courseIDs = sort { lc($a) cmp lc($b) } keys %stat;
+% my %courseArchives = listArchivedCourses($ce);
+% my @courseIDs    = sort { lc($a) cmp lc($b) } keys %courseArchives;
 %
 % if (@courseIDs) {
 	<%= form_for current_route, method => 'POST', begin =%>
@@ -15,18 +15,22 @@
 		%
 		<div class="col-lg-10 col-md-11">
 			<div class="row mb-2">
-				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+				<%= label_for 'unarchive_courseID' => maketext('Course ID:'),
+					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= select_field
-						unarchive_courseID => [map {["$_ ($stat{$_}{size})" => $stat{$_}{filename}]} @courseIDs],
-						id                 => 'unarchive_courseID',
-						class              => 'form-select',
-						size               => 10
+						unarchive_courseID => [
+							map { [ "$_ ($courseArchives{$_}{size})" => $courseArchives{$_}{filename} ] } @courseIDs
+						],
+						id    => 'unarchive_courseID',
+						class => 'form-select',
+						size  => 10
 					=%>
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<%= label_for new_courseID => maketext('New ID:'), class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
+				<%= label_for new_courseID => maketext('New ID:'),
+					class => 'col-lg-3 col-md-4 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= text_field new_courseID => '',
 						id        => 'new_courseID',

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -15,7 +15,7 @@
 		%
 		<div class="col-lg-7 col-md-8">
 			<div class="row mb-2">
-				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-sm-4 col-form-label' =%>
+				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-sm-4 col-form-label fw-bold' =%>
 				<div class="col-sm-8">
 					<%= select_field
 						unarchive_courseID => [map {["$_ ($stat{$_}{size})" => $stat{$_}{filename}]} @courseIDs],
@@ -26,7 +26,7 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<%= label_for new_courseID => maketext('New ID:'), class => 'col-sm-4 col-form-label' =%>
+				<%= label_for new_courseID => maketext('New ID:'), class => 'col-sm-4 col-form-label fw-bold' =%>
 				<div class="col-sm-8">
 					<%= text_field new_courseID => '',
 						id        => 'new_courseID',

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -15,7 +15,7 @@
 		%
 		<div class="col-lg-7 col-md-8">
 			<div class="row mb-2">
-				<%= label_for 'unarchive_courseID' => maketext('Course Name:'), class => 'col-sm-4 col-form-label' =%>
+				<%= label_for 'unarchive_courseID' => maketext('Course ID:'), class => 'col-sm-4 col-form-label' =%>
 				<div class="col-sm-8">
 					<%= select_field
 						unarchive_courseID => [map {["$_ ($stat{$_}{size})" => $stat{$_}{filename}]} @courseIDs],
@@ -26,7 +26,7 @@
 				</div>
 			</div>
 			<div class="row mb-2 align-items-center">
-				<%= label_for new_courseID => maketext('New Name:'), class => 'col-sm-4 col-form-label' =%>
+				<%= label_for new_courseID => maketext('New ID:'), class => 'col-sm-4 col-form-label' =%>
 				<div class="col-sm-8">
 					<%= text_field new_courseID => '',
 						id        => 'new_courseID',


### PR DESCRIPTION
When at the Unarchive courses page, the list of courses now leaves off the ".tar.gz" and includes the size of the file to be unarchived. This will help me identify inefficiencies with how RS users are handling their courses. If I am about to unarchive a particularly large course, I will then go into it and see what can be trimmed. Usually, the faculty have put course archive files in their course. Or they are using images inefficiently. Or they copied entire folder trees for backup before editing local pg files.

I did this in a way to make it extensible. Perhaps there would be interest in also showing the date the archive file was last modified. Perhaps this is of tangential interest to @drdrew42 with #3043 in that the displayed course name could be the actual internal course name, not the file name with `.tar.gz` truncated off.