### PR TITLE
Fix Caliper::Entity calling nonexistent prHintsAfter() method

### DIFF
--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -261,7 +261,7 @@ sub problem_user {
 			'counts_parent_grade'  => $problem_user->counts_parent_grade(),
 			'showMeAnother'        => $problem_user->showMeAnother(),
 			'showMeAnotherCount'   => $problem_user->showMeAnotherCount(),
-			'showHintsAfter'       => $problem_user->prHintsAfter(),
+			'showHintsAfter'       => $problem_user->showHintsAfter(),
 			'prPeriod'             => $problem_user->prPeriod(),
 			'prCount'              => $problem_user->prCount(),
 			'flags'                => $problem_user->flags(),


### PR DESCRIPTION
## Summary

`Caliper::Entity::problem_user()` called `$problem_user->prHintsAfter()` to
populate the `showHintsAfter` event field, but the `UserProblem` record has
no `prHintsAfter` accessor — the field is `showHintsAfter` (used correctly
in `problem()` for the global problem). Generating a Caliper event for a
problem attempt would die with `Can't locate object method prHintsAfter`.
Call `showHintsAfter()` instead.

## Notes

Rebased onto `WeBWorK-2.21` and retargeted per review; the
`Caliper::ResourceIri` spelling commit was dropped in favor of #3044.