### PR TITLE
Fix duplicated word in default exception template

### DIFF
--- a/templates/exception_default.html.ep
+++ b/templates/exception_default.html.ep
@@ -19,7 +19,7 @@
 			<% if ($ENV{WEBWORK_SERVER_ADMIN}) { =%>
 				<%= link_to $ENV{WEBWORK_SERVER_ADMIN} => "mailto:$ENV{WEBWORK_SERVER_ADMIN}" %>\
 			<% } =%>\
-			, including all of the following information as well as what what you were doing when the error occurred.
+			, including all of the following information as well as what you were doing when the error occurred.
 		</p>
 		<h2>Error record identifier</h2>
 		<p style="margin-left:2em;color:#dc2a2a"><code><%= $uuid =%></code></p>


### PR DESCRIPTION
## Summary

Fixes a duplicated word in `templates/exception_default.html.ep`. The paragraph asking users to report errors to the site's webmaster currently reads:

> ... including all of the following information as well as what **what** you were doing when the error occurred.

This removes the duplicated "what" so the sentence reads correctly. No functional or markup changes — a one-word text fix in the default exception page shown to end users when an unhandled error occurs.

## Testing

- Verified the duplicated word is present in the current `WeBWorK-2.21` branch (and `develop`) and that the diff is limited to removing the single extra "what" on that line (one line changed, nothing else).
- Confirmed the file is a Mojolicious `.html.ep` template, which is not covered by the repository's perltidy (`*.pl`/`*.pm`/`*.t`/`*.at`) or prettier (`htdocs/**/*.{js,css,scss,html}`) format checks, so no formatting tooling applies.

Dependencies: none
