### PR TITLE
Build the library browser alert toast with DOM methods to avoid DOM XSS

### DIFF
--- a/htdocs/js/SetMaker/setmaker.js
+++ b/htdocs/js/SetMaker/setmaker.js
@@ -19,16 +19,37 @@
 			'p-3'
 		);
 		toastContainer.style.zIndex = 20;
-		toastContainer.innerHTML =
-			'<div class="toast bg-white" role="alert" aria-live="assertive" aria-atomic="true">' +
-			'<div class="toast-header">' +
-			`<strong class="me-auto">${title}</strong>` +
-			'<button type="button" class="btn-close" data-bs-dismiss="toast" aria-label="close"></button>' +
-			'</div>' +
-			`<div class="toast-body alert ${good ? 'alert-success' : 'alert-danger'} mb-0 text-center">${msg}</div>` +
-			'</div>';
+
+		const toast = document.createElement('div');
+		toast.classList.add('toast', 'bg-white');
+		toast.setAttribute('role', 'alert');
+		toast.setAttribute('aria-live', 'assertive');
+		toast.setAttribute('aria-atomic', 'true');
+		toastContainer.append(toast);
+
+		const toastHeader = document.createElement('div');
+		toastHeader.classList.add('toast-header');
+		toast.append(toastHeader);
+
+		const toastTitle = document.createElement('strong');
+		toastTitle.classList.add('me-auto');
+		toastTitle.textContent = title;
+
+		const closeButton = document.createElement('button');
+		closeButton.classList.add('btn-close');
+		closeButton.type = 'button';
+		closeButton.dataset.bsDismiss = 'toast';
+		closeButton.setAttribute('aria-label', 'close');
+
+		toastHeader.append(toastTitle, closeButton);
+
+		const toastBody = document.createElement('div');
+		toastBody.classList.add('toast-body', 'alert', good ? 'alert-success' : 'alert-danger', 'mb-0', 'text-center');
+		toastBody.textContent = msg;
+		toast.append(toastBody);
+
 		document.body.prepend(toastContainer);
-		const bsToast = new bootstrap.Toast(toastContainer.firstElementChild);
+		const bsToast = new bootstrap.Toast(toast);
 		toastContainer.addEventListener('hidden.bs.toast', () => {
 			bsToast.dispose();
 			toastContainer.remove();


### PR DESCRIPTION
## Summary

The `alertToast` helper in `htdocs/js/SetMaker/setmaker.js` (the library browser) interpolated its `title` and `msg` arguments directly into an `innerHTML` template. All current callers pass plain text, but several of those strings incorporate server-provided content (e.g. RPC error messages), and interpolating DOM text into `innerHTML` lets it be reinterpreted as HTML. CodeQL flags this pattern as a `js/xss-through-dom` alert.

Per review, this now removes the `innerHTML` usage entirely: the toast is built with `document.createElement` and the title and message are assigned with `textContent`, so caller-supplied strings are always treated as text and can never be parsed as markup. The construction mirrors the toast already built this way in `htdocs/js/TagWidget/tagwidget.js`.

The separate `alertToast` in `htdocs/js/GatewayQuiz/gateway.js` is intentionally left alone — it renders HTML from server-controlled data attributes by design.

## Testing

- `node --check htdocs/js/SetMaker/setmaker.js` passes (Node 20).
- `prettier --check` on the modified file passes (matches the check-formats CI workflow).
- Behavior is unchanged for all existing callers: the rendered toast markup is identical (same elements, classes, and attributes as the previous template); a title or message containing markup characters displays literally instead of being parsed as HTML.