### PR TITLE
Save the useMathView user setting on the User Settings page

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Options.pm
+++ b/lib/WeBWorK/ContentGenerator/Options.pm
@@ -149,11 +149,14 @@ sub initialize ($c) {
 				&& $c->{effectiveUser}->showOldAnswers() ne $c->param('showOldAnswers'))
 			|| (defined($c->param('useMathQuill'))
 				&& $c->{effectiveUser}->useMathQuill() ne $c->param('useMathQuill'))
+			|| (defined($c->param('useMathView'))
+				&& $c->{effectiveUser}->useMathView() ne $c->param('useMathView'))
 			)
 		{
 			$c->{effectiveUser}->displayMode($c->param('displayMode'));
 			$c->{effectiveUser}->showOldAnswers($c->param('showOldAnswers'));
 			$c->{effectiveUser}->useMathQuill($c->param('useMathQuill'));
+			$c->{effectiveUser}->useMathView($c->param('useMathView'));
 
 			eval { $db->putUser($c->{effectiveUser}) };
 			if ($@) {


### PR DESCRIPTION
## Summary

When `$pg{specialPGEnvironmentVars}{entryAssist}` is set to `'MathView'`, the User Settings page (`templates/ContentGenerator/Options.html.ep`) shows a "Use Equation Editor?" radio group named `useMathView`. However, `WeBWorK::ContentGenerator::Options::initialize` never reads that parameter when saving display settings — the change-detection condition only checks `displayMode`, `showOldAnswers`, and `useMathQuill`, and the save block only writes those three fields. As a result the submitted `useMathView` value is silently discarded and the setting reverts to the course default (`$pg{options}{useMathView}`) on every page load.

This adds `useMathView` to the change-detection condition and saves it on the effective user record alongside the other display settings, exactly matching the existing handling of `displayMode`, `showOldAnswers`, and `useMathQuill`.

## Testing

- With `entryAssist => 'MathView'` set in `specialPGEnvironmentVars` for a course, toggle "Use Equation Editor?" on the User Settings page and save: the `user.useMathView` field is updated and the selection persists after a reload (previously it always fell back to the course default).
- The MathQuill flow (`entryAssist => 'MathQuill'`) is unaffected: the added disjunct is guarded by `defined($c->param('useMathView'))` and is inert when the MathView radios are not rendered, and `useMathView($c->param('useMathView'))` then stores undef/NULL exactly as the existing code already does for the unrendered `useMathQuill` parameter in the MathView flow.
- `perltidy` (Perl::Tidy 20260204, as pinned in `.github/workflows/check-formats.yml`) produces no changes on the modified file.
