### PR TITLE
Fix stale comment in site.conf.dist referencing removed database.conf

### DIFF
--- a/conf/site.conf.dist
+++ b/conf/site.conf.dist
@@ -131,8 +131,7 @@ $externalPrograms{mysqldump} ="/usr/bin/mysqldump";
 # where webworkWrite and passwordRW must match the corresponding variables in the next section.
 
 ################################################################################
-# these variables are used by database.conf. we define them here so that editing
-# database.conf isn't necessary.
+# These variables define the database connection.
 
 # You must initialize the database and set the password for webworkWrite.
 # Edit the $database_password line and replace 'passwordRW' by the actual password used in the GRANT command above


### PR DESCRIPTION
## Summary

Comment-only fix in `conf/site.conf.dist`: the header above the
`$database_*` variables still says they "are used by database.conf", but
`conf/database.conf` no longer ships. Replace it with a simple statement
of what the variables are for — "These variables define the database
connection." — so admins reading `site.conf.dist` aren't sent looking for
a file that no longer exists.

No behavior is affected.

## Testing

- Verified `conf/database.conf`/`.dist` is absent on current `WeBWorK-2.21` (and `develop`).
- Diff is comment lines only; no Perl code touched.