### PR TITLE
Allow overriding the OPL metadata release API URL via an environment variable

### DIFF
--- a/bin/download-OPL-metadata-release.pl
+++ b/bin/download-OPL-metadata-release.pl
@@ -32,8 +32,10 @@ my $ce = WeBWorK::CourseEnvironment->new({ webwork_dir => $ENV{WEBWORK_ROOT} });
 die "The WeBWorK temporary directory $ce->{webworkDirs}{tmp} does not exist or is not writable."
 	if (!-d $ce->{webworkDirs}{tmp} || !-w $ce->{webworkDirs}{tmp});
 
-my $releaseDataFF =
-	File::Fetch->new(uri => 'https://api.github.com/repos/openwebwork/webwork-open-problem-library/releases/latest');
+# Set the OPL_METADATA_RELEASE_API_URL environment variable to override the release API URL,
+# for example, for sites that use a fork of the OPL.
+my $releaseDataFF = File::Fetch->new(uri => $ENV{OPL_METADATA_RELEASE_API_URL}
+		// 'https://api.github.com/repos/openwebwork/webwork-open-problem-library/releases/latest');
 my $file        = $releaseDataFF->fetch(to => $ce->{webworkDirs}{tmp}) or die $releaseDataFF->error;
 my $path        = Mojo::File->new($file);
 my $releaseData = decode_json($path->slurp);


### PR DESCRIPTION
## Summary

`bin/download-OPL-metadata-release.pl` hardcodes the GitHub API URL used to locate the latest OPL metadata release (`https://api.github.com/repos/openwebwork/webwork-open-problem-library/releases/latest`). Sites that maintain a fork of the webwork-open-problem-library (for example, to carry local problems and publish their own metadata releases) cannot use the script against their fork without patching it.

This change allows the release API URL to be overridden by setting the `OPL_METADATA_RELEASE_API_URL` environment variable:

```
OPL_METADATA_RELEASE_API_URL=https://api.github.com/repos/<org>/webwork-open-problem-library/releases/latest \
    ./bin/download-OPL-metadata-release.pl
```

When the variable is not set, the script behaves exactly as before, using the openwebwork URL. The rest of the fetch/decode/restore logic is untouched, and a brief comment documents the override at the point of use.

## Testing

- Ran `perltidy` v20260204 (the version pinned in `.github/workflows/check-formats.yml`) with the repository `.perltidyrc`; the committed file is idempotent under it.
- `perl -c` passes on the full script (checked with the script's WeBWorK/Helper module dependencies stubbed, since compiling those requires a full runtime environment).
- Verified the default (variable unset) resolves to the same openwebwork URL string as before the change, so existing installations see no behavior change.

Dependencies: none.
