### PR TITLE
Prevent Caliper events from dying on problem-group pseudo source files

### DIFF
--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -193,13 +193,20 @@ sub problem {
 
 	my $problem = $db->getGlobalProblem($set_id, $problem_id);
 
-	my $templateDir = $ce->{courseDirs}->{templates};
-	my $tags        = WeBWorK::Utils::Tags->new($templateDir . '/' . $problem->source_file());
-	my $keywords    = $tags->{'keywords'};
-	$_ =~ s/(^[\s"']+)|([\s"']+$)//g for @$keywords;
+	my $keywords = [];
+	my $unblessed_tags;
 
-	my %tags_ref       = %$tags;
-	my $unblessed_tags = \%tags_ref;
+	# Problem groups use a "group:problemGroupName" pseudo source file (see
+	# WeBWorK::Utils::Instructor::assignProblemToUserSetVersion) which is not a real file, so attempting to read tags
+	# from it would die.
+	if ($problem->source_file() !~ /^group:/) {
+		my $templateDir = $ce->{courseDirs}->{templates};
+		my $tags        = WeBWorK::Utils::Tags->new($templateDir . '/' . $problem->source_file());
+		$keywords = $tags->{'keywords'};
+		$_ =~ s/(^[\s"']+)|([\s"']+$)//g for @$keywords;
+
+		$unblessed_tags = {%$tags};
+	}
 
 	return {
 		'id'         => $resource_iri->problem($set_id, $problem_id),


### PR DESCRIPTION
## Summary

Prevent Caliper events from dying on problem-group pseudo source files.

Problems selected from a problem group carry the pseudo source file `group:problemGroupName` (see `WeBWorK::Utils::Instructor::assignProblemToUserSetVersion`), which is not a real file under the course templates directory. `Caliper::Entity::problem` unconditionally passed that path to `WeBWorK::Utils::Tags->new`, whose `open ... or die` kills the request. As a result, any Caliper event that embeds the problem entity — for example an answer-submission event in a gateway quiz built from problem groups — crashed server side whenever Caliper is enabled.

This change guards the tag-parsing block in `sub problem` so it is skipped for `group:` pseudo source files. For those problems the entity payload now reports `keywords => []` and `tags => undef`. Real problem files are unaffected: `WeBWorK::Utils::Tags` initializes `{keywords}` to `[]` for every real `.pg` file it parses, so `keywords` is always an arrayref, and the keyword trimming and unblessed tag hash are built exactly as before.

Note that `sub problem_user` intentionally keeps the unguarded tag parsing: user problems for versioned (gateway) sets are assigned a concrete source file selected out of the group at set-version creation time, so a merged user problem never carries the `group:` pseudo path.

## Testing

- Exercised `Caliper::Entity::problem` with the dependency surface stubbed (`WeBWorK::DB`, `Caliper::ResourceIri`, and a `WeBWorK::Utils::Tags` stub reproducing the real `open ... or die` behavior):
  - Before this change, a problem with source file `group:myGroup` dies with `cannot open .../group:myGroup: No such file or directory`; after this change it returns a payload with `keywords => []`, `extensions.tags => undef`, and `extensions.source_file` passed through.
  - A real `.pg` source file produces an identical payload before and after the change (keywords trimmed of quotes/whitespace, unblessed tags hash populated).
  - A missing real (non-`group:`) source file still dies as before; this change does not swallow genuine errors.
- `perl -c lib/Caliper/Entity.pm` passes (with dependency stubs, since a full course environment is not available in the check environment).
- `perltidy` (Perl::Tidy 20260204, matching `check-formats.yml`) with the repo `.perltidyrc` produces no changes.

## Dependencies

Depends on #3050 (this branch is based on it, since #3050 already touches the same region of `lib/Caliper/Entity.pm` with the `Caliper::ResourceIri` package rename and the `showHintsAfter()` fix).
