### PR TITLE
Suggestion from #3043.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1200,14 +1200,15 @@ sub do_unarchive_course ($c) {
 
 	my $unarchive_courseID = $c->param('unarchive_courseID') || '';
 
-	unarchiveCourse(
-		newCourseID => $new_courseID,
-		archivePath => "$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives/$unarchive_courseID",
-		ce          => $ce,
-	);
+	eval {
+		unarchiveCourse(
+			newCourseID => $new_courseID,
+			archivePath => "$ce->{webworkDirs}{courses}/$ce->{admin_course_id}/archives/$unarchive_courseID",
+			ce          => $ce,
+		);
+	};
 
 	if ($@) {
-		my $error = $@;
 		return $c->tag(
 			'div',
 			class => 'alert alert-danger p-1 mb-2',
@@ -1215,7 +1216,7 @@ sub do_unarchive_course ($c) {
 				$c->tag(
 					'p', $c->maketext('An error occurred while unarchiving the course [_1]:', $unarchive_courseID)
 				),
-				$c->tag('div', class => 'font-monospace', $error)
+				$c->tag('div', class => 'font-monospace', ref $@ ? $@->message : $@)
 			)->join('')
 		);
 	} else {


### PR DESCRIPTION
Wrap the `unarchiveCourse` call in the `do_unarchive_course` method of the `WeBWorK::ContentGenerator::CourseAdmin` package in an `eval`, so that exceptions are caught.  The exceptions are already checked for on the next line, but deal with the exception message better.  Instead of displaying `$@` which might include a backtrace, show `$@->message` in the case that `$@` is an object.

This is built on top of #3043 (and rebased onto the current `WeBWorK-2.21` branch).  I am making a new pull request so that we can merge this (and #3043) and move on.