### PR TITLE
Make the color scheme chooser active theme check work.

### DIFF
--- a/htdocs/js/System/color-scheme.js
+++ b/htdocs/js/System/color-scheme.js
@@ -33,10 +33,12 @@
 		for (const element of document.querySelectorAll('[data-bs-theme-value]')) {
 			element.classList.remove('active');
 			element.setAttribute('aria-pressed', 'false');
+			element.querySelector('.fa-check')?.classList.add('d-none');
 		}
 
 		btnToActive.classList.add('active');
 		btnToActive.setAttribute('aria-pressed', 'true');
+		btnToActive.querySelector('.fa-check')?.classList.remove('d-none');
 		activeThemeIcon.classList.remove('fa-sun', 'fa-moon', 'fa-circle-half-stroke');
 		activeThemeIcon.classList.add(
 			theme === 'light' ? 'fa-sun' : theme === 'dark' ? 'fa-moon' : 'fa-circle-half-stroke'


### PR DESCRIPTION
In the HTML markup for the color scheme chooser in `templates/layouts/system.html.ep` each of the theme buttons in the dropdown have a check icon.  However, that check icon has `d-none` set, and it is always that way.  So the checks are never shown. The javascript is supposed to make the check for the active theme visible, but does not. So make that happen.

This is a result of copying the HTML that Bootstrap actually uses for the theme chooser on their documentation page, and using the JavScript they demonstrate on their documentation page, but their implementation and their demonstration do not quite match.