### PR TITLE
Update npm dependencies once more.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -7,7 +7,7 @@
 			"name": "webwork.javascript_package_manager",
 			"license": "GPL-2.0+",
 			"dependencies": {
-				"@fortawesome/fontawesome-free": "^7.2.0",
+				"@fortawesome/fontawesome-free": "^7.3.1",
 				"@openwebwork/pg-codemirror-editor": "^0.0.10",
 				"bootstrap": "^5.3.8",
 				"flatpickr": "^4.6.13",
@@ -21,21 +21,21 @@
 				"sortablejs": "^1.15.7"
 			},
 			"devDependencies": {
-				"autoprefixer": "^10.5.0",
+				"autoprefixer": "^10.5.4",
 				"chokidar": "^5.0.0",
-				"cssnano": "^8.0.1",
-				"postcss": "^8.5.15",
-				"prettier": "^3.8.3",
+				"cssnano": "^8.0.2",
+				"postcss": "^8.5.21",
+				"prettier": "^3.9.6",
 				"rtlcss": "^4.3.0",
-				"sass": "^1.100.0",
-				"terser": "^5.48.0",
+				"sass": "^1.101.3",
+				"terser": "^5.49.0",
 				"yargs": "^18.0.0"
 			}
 		},
 		"node_modules/@codemirror/autocomplete": {
-			"version": "6.20.2",
-			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.2.tgz",
-			"integrity": "sha512-G5FPkgIiLjOgZMjqVjvuKQ1rGPtHogLldJr33eFJdVLtmwY+giGrlv/ewljLz6b9BSQLkjxuwBc6g6omDM+YxQ==",
+			"version": "6.20.3",
+			"resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+			"integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
@@ -45,13 +45,13 @@
 			}
 		},
 		"node_modules/@codemirror/commands": {
-			"version": "6.10.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.3.tgz",
-			"integrity": "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==",
+			"version": "6.10.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+			"integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/language": "^6.0.0",
-				"@codemirror/state": "^6.6.0",
+				"@codemirror/state": "^6.7.0",
 				"@codemirror/view": "^6.27.0",
 				"@lezer/common": "^1.1.0"
 			}
@@ -116,9 +116,9 @@
 			}
 		},
 		"node_modules/@codemirror/language": {
-			"version": "6.12.3",
-			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.3.tgz",
-			"integrity": "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==",
+			"version": "6.12.4",
+			"resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+			"integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -130,9 +130,9 @@
 			}
 		},
 		"node_modules/@codemirror/lint": {
-			"version": "6.9.6",
-			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.6.tgz",
-			"integrity": "sha512-6Kp7r6XfCi/D/5sdXieMfg9pJU1bUEx96WITuLU6ESaKizCz0QHFMjY/TaFSbigDdEAIgi93itLBIUETP4oK+A==",
+			"version": "6.9.7",
+			"resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+			"integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -141,9 +141,9 @@
 			}
 		},
 		"node_modules/@codemirror/search": {
-			"version": "6.7.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.0.tgz",
-			"integrity": "sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+			"integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
 			"license": "MIT",
 			"dependencies": {
 				"@codemirror/state": "^6.0.0",
@@ -152,9 +152,9 @@
 			}
 		},
 		"node_modules/@codemirror/state": {
-			"version": "6.6.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.6.0.tgz",
-			"integrity": "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==",
+			"version": "6.7.1",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.1.tgz",
+			"integrity": "sha512-9QzNDgE4EYDnAHfrTlR2lwiPciiOymLtwKK+8yHQzCc7GXhAP9xdEbEJFy2IWB1j9UGUl9BsgMmTo/ImA02T7A==",
 			"license": "MIT",
 			"dependencies": {
 				"@marijn/find-cluster-break": "^1.0.0"
@@ -173,28 +173,28 @@
 			}
 		},
 		"node_modules/@codemirror/view": {
-			"version": "6.43.0",
-			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.0.tgz",
-			"integrity": "sha512-V7ZCLQO3Jus9hzh2jVCCPW3mO4IBMr43O37PqSUYautJSnnJF41YlgLw21x0fLJTYvJ+Vkm6Gp+qKGH9pltgXA==",
+			"version": "6.43.6",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.6.tgz",
+			"integrity": "sha512-EVunGSYN1wz1p75WY1s3Xg7t3i8Yol0kGZGizNdX9BUFgMFILYVe8/u6EVpo7Ff5PwbZuILb4QAq7IZoKzIEQA==",
 			"license": "MIT",
 			"dependencies": {
-				"@codemirror/state": "^6.6.0",
+				"@codemirror/state": "^6.7.0",
 				"crelt": "^1.0.6",
 				"style-mod": "^4.1.0",
 				"w3c-keyname": "^2.2.4"
 			}
 		},
 		"node_modules/@colordx/core": {
-			"version": "5.4.3",
-			"resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.4.3.tgz",
-			"integrity": "sha512-kIxYSfA5T8HXjav55UaaH/o/cKivF6jCCGIb8eqtcsfI46wsvlSiT8jMDyrl779qLec3c2c2oHBZo4oAhvbjrQ==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/@colordx/core/-/core-5.5.0.tgz",
+			"integrity": "sha512-3PxTH8itZzltK0U9jTwVVnjLXvnDYuq3m+QXsHkENxWiPRh4WaoLcs1SQjqgZ55kS+QyirpH5BVwzP2gMVG6EQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@fortawesome/fontawesome-free": {
-			"version": "7.2.0",
-			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.2.0.tgz",
-			"integrity": "sha512-3DguDv/oUE+7vjMeTSOjCSG+KeawgVQOHrKRnvUuqYh1mfArrh7s+s8hXW3e4RerBA1+Wh+hBqf8sJNpqNrBWg==",
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-free/-/fontawesome-free-7.3.1.tgz",
+			"integrity": "sha512-wmglKKPDIkgV3aWlZzWECCPoGIkYCulzBwxG9+w7rc5BGapZ6cPMpoPOT8k36J0Ni7PPX6c/rsoMWfS4d1MUMg==",
 			"license": "(CC-BY-4.0 AND OFL-1.1 AND MIT)",
 			"engines": {
 				"node": ">=6"
@@ -257,9 +257,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@lezer/css": {
-			"version": "1.3.3",
-			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.3.tgz",
-			"integrity": "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==",
+			"version": "1.3.4",
+			"resolved": "https://registry.npmjs.org/@lezer/css/-/css-1.3.4.tgz",
+			"integrity": "sha512-N+tn9tej2hPvyKgHEApMOQfHczDJCwxrRFS3SPn9QjYN+uwHvEDnCgKRrb3mxDYxRS8sKMM8fhC3+lc04Abz5Q==",
 			"license": "MIT",
 			"dependencies": {
 				"@lezer/common": "^1.2.0",
@@ -319,9 +319,9 @@
 			}
 		},
 		"node_modules/@marijn/find-cluster-break": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
-			"integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+			"integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
 			"license": "MIT"
 		},
 		"node_modules/@mathjax/mathjax-newcm-font": {
@@ -369,9 +369,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.6.tgz",
-			"integrity": "sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.6.0.tgz",
+			"integrity": "sha512-7FNeNl8NCE7aINx7WXiKQrPYZWC/hvrTsmk6zmxbI7LTXE7hVek/n8AfVgpe2y82zl3w0HvCHN0bVKMBoJcC0w==",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -380,7 +380,7 @@
 				"detect-libc": "^2.0.3",
 				"is-glob": "^4.0.3",
 				"node-addon-api": "^7.0.0",
-				"picomatch": "^4.0.3"
+				"picomatch": "^4.0.4"
 			},
 			"engines": {
 				"node": ">= 10.0.0"
@@ -390,25 +390,24 @@
 				"url": "https://opencollective.com/parcel"
 			},
 			"optionalDependencies": {
-				"@parcel/watcher-android-arm64": "2.5.6",
-				"@parcel/watcher-darwin-arm64": "2.5.6",
-				"@parcel/watcher-darwin-x64": "2.5.6",
-				"@parcel/watcher-freebsd-x64": "2.5.6",
-				"@parcel/watcher-linux-arm-glibc": "2.5.6",
-				"@parcel/watcher-linux-arm-musl": "2.5.6",
-				"@parcel/watcher-linux-arm64-glibc": "2.5.6",
-				"@parcel/watcher-linux-arm64-musl": "2.5.6",
-				"@parcel/watcher-linux-x64-glibc": "2.5.6",
-				"@parcel/watcher-linux-x64-musl": "2.5.6",
-				"@parcel/watcher-win32-arm64": "2.5.6",
-				"@parcel/watcher-win32-ia32": "2.5.6",
-				"@parcel/watcher-win32-x64": "2.5.6"
+				"@parcel/watcher-android-arm64": "2.6.0",
+				"@parcel/watcher-darwin-arm64": "2.6.0",
+				"@parcel/watcher-darwin-x64": "2.6.0",
+				"@parcel/watcher-freebsd-x64": "2.6.0",
+				"@parcel/watcher-linux-arm-glibc": "2.6.0",
+				"@parcel/watcher-linux-arm-musl": "2.6.0",
+				"@parcel/watcher-linux-arm64-glibc": "2.6.0",
+				"@parcel/watcher-linux-arm64-musl": "2.6.0",
+				"@parcel/watcher-linux-x64-glibc": "2.6.0",
+				"@parcel/watcher-linux-x64-musl": "2.6.0",
+				"@parcel/watcher-win32-arm64": "2.6.0",
+				"@parcel/watcher-win32-x64": "2.6.0"
 			}
 		},
 		"node_modules/@parcel/watcher-android-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.5.6.tgz",
-			"integrity": "sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-android-arm64/-/watcher-android-arm64-2.6.0.tgz",
+			"integrity": "sha512-trgpLSCKRC/huFjXX/Smh+0sWe4+YtKfktIToiMl59ghz7z+qkH6kMvNnUbLyRs9N11t8l4svSCs1+5B3rOAhA==",
 			"cpu": [
 				"arm64"
 			],
@@ -427,9 +426,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.5.6.tgz",
-			"integrity": "sha512-Z2ZdrnwyXvvvdtRHLmM4knydIdU9adO3D4n/0cVipF3rRiwP+3/sfzpAwA/qKFL6i1ModaabkU7IbpeMBgiVEA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-arm64/-/watcher-darwin-arm64-2.6.0.tgz",
+			"integrity": "sha512-Y3QV0gl7Q1zbfueunkWIERICbEojQFCgpyG7YqOGNFLsckXyI1xu9mAIUpKY9QBYzBtSkN8dBPwd3yiAO9ovMw==",
 			"cpu": [
 				"arm64"
 			],
@@ -448,9 +447,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-darwin-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.6.tgz",
-			"integrity": "sha512-HgvOf3W9dhithcwOWX9uDZyn1lW9R+7tPZ4sug+NGrGIo4Rk1hAXLEbcH1TQSqxts0NYXXlOWqVpvS1SFS4fRg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.6.0.tgz",
+			"integrity": "sha512-Ohv6OpzhUfKYD7Beb8kDvG0jbIxORCYY1JRdZnaBtnjjkJxgD7ZVL0nw2sCYd0yTMKTvz3nnTnOF3cDifK+kvw==",
 			"cpu": [
 				"x64"
 			],
@@ -469,9 +468,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-freebsd-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.5.6.tgz",
-			"integrity": "sha512-vJVi8yd/qzJxEKHkeemh7w3YAn6RJCtYlE4HPMoVnCpIXEzSrxErBW5SJBgKLbXU3WdIpkjBTeUNtyBVn8TRng==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-freebsd-x64/-/watcher-freebsd-x64-2.6.0.tgz",
+			"integrity": "sha512-5HmXvDgs8VK+74jF9y9/2FE3/OnlcKmc56tjmSrEuZjpSZOGL+fvAu+HKJBdPs9uwoP2hE6TlSUpXZ/C5jUFmQ==",
 			"cpu": [
 				"x64"
 			],
@@ -490,9 +489,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-glibc": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.5.6.tgz",
-			"integrity": "sha512-9JiYfB6h6BgV50CCfasfLf/uvOcJskMSwcdH1PHH9rvS1IrNy8zad6IUVPVUfmXr+u+Km9IxcfMLzgdOudz9EQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-glibc/-/watcher-linux-arm-glibc-2.6.0.tgz",
+			"integrity": "sha512-Ps/hui3A+vMbjdqlqAowK2ZL8+BO8dBjxeWXj6npTBs3jx4wWmbPpaLuqwrQrSqIVMCnpWo238bJ1U37GhQOYg==",
 			"cpu": [
 				"arm"
 			],
@@ -514,9 +513,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.5.6.tgz",
-			"integrity": "sha512-Ve3gUCG57nuUUSyjBq/MAM0CzArtuIOxsBdQ+ftz6ho8n7s1i9E1Nmk/xmP323r2YL0SONs1EuwqBp2u1k5fxg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm-musl/-/watcher-linux-arm-musl-2.6.0.tgz",
+			"integrity": "sha512-9c6AUHgHoG+IY88MRIHupztQiQnrbqHYQjkM2btA+Bf/wQnQMuiD0Wfk1EVv3TlNT3x41uU71rn6E4xh/+zvkw==",
 			"cpu": [
 				"arm"
 			],
@@ -538,9 +537,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-glibc": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.5.6.tgz",
-			"integrity": "sha512-f2g/DT3NhGPdBmMWYoxixqYr3v/UXcmLOYy16Bx0TM20Tchduwr4EaCbmxh1321TABqPGDpS8D/ggOTaljijOA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-glibc/-/watcher-linux-arm64-glibc-2.6.0.tgz",
+			"integrity": "sha512-yHRqS2owEXe6Hic9z6Mh1ECsCd+ODVOGvZDyciqRd21+v+o+DnXMOrw50DSpIG2sb8GPEaPPmfeCAWKPJdq46g==",
 			"cpu": [
 				"arm64"
 			],
@@ -562,9 +561,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-arm64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.5.6.tgz",
-			"integrity": "sha512-qb6naMDGlbCwdhLj6hgoVKJl2odL34z2sqkC7Z6kzir8b5W65WYDpLB6R06KabvZdgoHI/zxke4b3zR0wAbDTA==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-arm64-musl/-/watcher-linux-arm64-musl-2.6.0.tgz",
+			"integrity": "sha512-WhB2e/V7rqdHHWZusBSPuy5Ei8S6lSz6FE5TKKQz5h3a0O+C+mhY7vxU9b/stqvMb8beLnPY82ZrFTLKs+SrKA==",
 			"cpu": [
 				"arm64"
 			],
@@ -586,9 +585,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-glibc": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.5.6.tgz",
-			"integrity": "sha512-kbT5wvNQlx7NaGjzPFu8nVIW1rWqV780O7ZtkjuWaPUgpv2NMFpjYERVi0UYj1msZNyCzGlaCWEtzc+exjMGbQ==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-glibc/-/watcher-linux-x64-glibc-2.6.0.tgz",
+			"integrity": "sha512-ulGE6x6Oz6iAwg75T8YQSoguBWasniIbX+QWpaYPcCnDOpdWX3k+4xbEYPZVLxOuoJI+svJJPD3sEj8G7lrQ3A==",
 			"cpu": [
 				"x64"
 			],
@@ -610,9 +609,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-linux-x64-musl": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.5.6.tgz",
-			"integrity": "sha512-1JRFeC+h7RdXwldHzTsmdtYR/Ku8SylLgTU/reMuqdVD7CtLwf0VR1FqeprZ0eHQkO0vqsbvFLXUmYm/uNKJBg==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-linux-x64-musl/-/watcher-linux-x64-musl-2.6.0.tgz",
+			"integrity": "sha512-tkBYKt7YQrjIJWYDnto2YgO8MRkjlMTSNoRHzsXinBqbLdeOM3L32wPZJvIZxqaLMfSlS/4sUjH/6STVP/XDLw==",
 			"cpu": [
 				"x64"
 			],
@@ -634,9 +633,9 @@
 			}
 		},
 		"node_modules/@parcel/watcher-win32-arm64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.5.6.tgz",
-			"integrity": "sha512-3ukyebjc6eGlw9yRt678DxVF7rjXatWiHvTXqphZLvo7aC5NdEgFufVwjFfY51ijYEWpXbqF5jtrK275z52D4Q==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-arm64/-/watcher-win32-arm64-2.6.0.tgz",
+			"integrity": "sha512-gIZAP23jaHjGWasY/TY6yL7NHFClf0Ga7FN+iINvk+KN94rhm94lYZhFsbYFNcA04/onvGD9kKmiJLJB2HbNwQ==",
 			"cpu": [
 				"arm64"
 			],
@@ -654,31 +653,10 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/@parcel/watcher-win32-ia32": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-ia32/-/watcher-win32-ia32-2.5.6.tgz",
-			"integrity": "sha512-k35yLp1ZMwwee3Ez/pxBi5cf4AoBKYXj00CZ80jUz5h8prpiaQsiRPKQMxoLstNuqe2vR4RNPEAEcjEFzhEz/g==",
-			"cpu": [
-				"ia32"
-			],
-			"dev": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"win32"
-			],
-			"engines": {
-				"node": ">= 10.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/parcel"
-			}
-		},
 		"node_modules/@parcel/watcher-win32-x64": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.5.6.tgz",
-			"integrity": "sha512-hbQlYcCq5dlAX9Qx+kFb0FHue6vbjlf0FrNzSKdYK2APUf7tGfGxQCk2ihEREmbR6ZMc0MVAD5RIX/41gpUzTw==",
+			"version": "2.6.0",
+			"resolved": "https://registry.npmjs.org/@parcel/watcher-win32-x64/-/watcher-win32-x64-2.6.0.tgz",
+			"integrity": "sha512-cA+/pXV2YkfxlIcXOQ5fSWqAzzPyD78/x5qbK/I0vUkrlYHA8TIz+MXjAbGouguKVSI4bOmkTSJ1/poVSsgt+A==",
 			"cpu": [
 				"x64"
 			],
@@ -734,9 +712,9 @@
 			}
 		},
 		"node_modules/acorn": {
-			"version": "8.16.0",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
-			"integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+			"version": "8.17.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
+			"integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -773,9 +751,9 @@
 			}
 		},
 		"node_modules/autoprefixer": {
-			"version": "10.5.0",
-			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
-			"integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
+			"version": "10.5.4",
+			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.4.tgz",
+			"integrity": "sha512-MaU0U/za7N3r6brxD4YB/l4NSrFzLPlANv6wEuQVaIPlD3L4W9rFcQPbL/EilY9BHhHvhfcz3gInDLrEtWT4EA==",
 			"dev": true,
 			"funding": [
 				{
@@ -793,8 +771,8 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"browserslist": "^4.28.2",
-				"caniuse-lite": "^1.0.30001787",
+				"browserslist": "^4.28.6",
+				"caniuse-lite": "^1.0.30001806",
 				"fraction.js": "^5.3.4",
 				"picocolors": "^1.1.1",
 				"postcss-value-parser": "^4.2.0"
@@ -810,9 +788,9 @@
 			}
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.32",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.32.tgz",
-			"integrity": "sha512-wbPvpyjJPC0zdfdKXxqEL3Ea+bOMD/87X4lftiJkkaBiuG6ALQy1SLmEd7BSmVCuwCQsBrCamgBoLyfFDD1EPg==",
+			"version": "2.11.0",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.0.tgz",
+			"integrity": "sha512-oCu2wfipvX3AePSgmOuKkIywOu+8n9psz7hXYmk56ghpu3+7KzNIBopaOs4c9BrtdnTtW30unG9GTfHo7EwERQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -849,9 +827,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -869,10 +847,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
 				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
@@ -890,22 +868,20 @@
 			"license": "MIT"
 		},
 		"node_modules/caniuse-api": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-3.0.0.tgz",
-			"integrity": "sha512-bsTwuIg/BZZK/vreVTYYbSWoe2F+71P7K5QGEX+pT250DZbfU1MQ5prOKpPR+LL6uWKK3KMwMCAS74QB3Um1uw==",
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/caniuse-api/-/caniuse-api-4.0.0.tgz",
+			"integrity": "sha512-B0hQ1OLyJuHTQSOWXvwibWqM6DCoqJdvBA6X1S/53bd4XU7LJ1yurIPlrsouol3mw1jh9pGI4ivubSpmJeIqCA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.0.0",
-				"caniuse-lite": "^1.0.0",
-				"lodash.memoize": "^4.1.2",
-				"lodash.uniq": "^4.5.0"
+				"caniuse-lite": "^1.0.0"
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001793",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001793.tgz",
-			"integrity": "sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==",
+			"version": "1.0.30001806",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 			"dev": true,
 			"funding": [
 				{
@@ -1101,9 +1077,9 @@
 			}
 		},
 		"node_modules/crelt": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.6.tgz",
-			"integrity": "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==",
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+			"integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
 			"license": "MIT"
 		},
 		"node_modules/css-select": {
@@ -1164,13 +1140,13 @@
 			}
 		},
 		"node_modules/cssnano": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.1.tgz",
-			"integrity": "sha512-oSiOnPQNNYjusTUlYJiE6xvFQG4don3N0QavaoV1BxIsC1zjvxOwikXlR7lG1EVmZNDDaJkHbQx1VRB8kaoMHA==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/cssnano/-/cssnano-8.0.2.tgz",
+			"integrity": "sha512-K+a76gA1v0/CsYgcsE95HGGyIuPKxpQSetwSwz4nHEM8fFXqSkzq2JzEXFL8v5+CCjxzVVVhPcTK3Oo8SaF/xA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cssnano-preset-default": "^8.0.1",
+				"cssnano-preset-default": "^8.0.2",
 				"lilconfig": "^3.1.3"
 			},
 			"engines": {
@@ -1181,64 +1157,64 @@
 				"url": "https://opencollective.com/cssnano"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/cssnano-preset-default": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.1.tgz",
-			"integrity": "sha512-OTdKeYMlvQ8KBgyej5ysktnWJoeyo7rGrVnm+bdpIHGvxhbTGPsOkB+7T1EdTuX00dGlQQb2UEbSPB1OpMXULw==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/cssnano-preset-default/-/cssnano-preset-default-8.0.2.tgz",
+			"integrity": "sha512-+jQAqIKCqMmBjZs7741XkilU93ITZ/EW8gjAkMmujdCzfDkfjrDBv2VqkSu29Fzeig/0rZ3S9IAwfPLlmXEUfQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
-				"cssnano-utils": "^6.0.0",
+				"cssnano-utils": "^6.0.1",
 				"postcss-calc": "^10.1.1",
-				"postcss-colormin": "^8.0.0",
-				"postcss-convert-values": "^8.0.0",
-				"postcss-discard-comments": "^8.0.0",
-				"postcss-discard-duplicates": "^8.0.0",
-				"postcss-discard-empty": "^8.0.0",
-				"postcss-discard-overridden": "^8.0.0",
-				"postcss-merge-longhand": "^8.0.0",
-				"postcss-merge-rules": "^8.0.0",
-				"postcss-minify-font-values": "^8.0.0",
-				"postcss-minify-gradients": "^8.0.0",
-				"postcss-minify-params": "^8.0.0",
-				"postcss-minify-selectors": "^8.0.1",
-				"postcss-normalize-charset": "^8.0.0",
-				"postcss-normalize-display-values": "^8.0.0",
-				"postcss-normalize-positions": "^8.0.0",
-				"postcss-normalize-repeat-style": "^8.0.0",
-				"postcss-normalize-string": "^8.0.0",
-				"postcss-normalize-timing-functions": "^8.0.0",
-				"postcss-normalize-unicode": "^8.0.0",
-				"postcss-normalize-url": "^8.0.0",
-				"postcss-normalize-whitespace": "^8.0.0",
-				"postcss-ordered-values": "^8.0.0",
-				"postcss-reduce-initial": "^8.0.0",
-				"postcss-reduce-transforms": "^8.0.0",
-				"postcss-svgo": "^8.0.0",
-				"postcss-unique-selectors": "^8.0.0"
+				"postcss-colormin": "^8.0.1",
+				"postcss-convert-values": "^8.0.1",
+				"postcss-discard-comments": "^8.0.1",
+				"postcss-discard-duplicates": "^8.0.1",
+				"postcss-discard-empty": "^8.0.1",
+				"postcss-discard-overridden": "^8.0.1",
+				"postcss-merge-longhand": "^8.0.1",
+				"postcss-merge-rules": "^8.0.1",
+				"postcss-minify-font-values": "^8.0.1",
+				"postcss-minify-gradients": "^8.0.1",
+				"postcss-minify-params": "^8.0.1",
+				"postcss-minify-selectors": "^8.0.2",
+				"postcss-normalize-charset": "^8.0.1",
+				"postcss-normalize-display-values": "^8.0.1",
+				"postcss-normalize-positions": "^8.0.1",
+				"postcss-normalize-repeat-style": "^8.0.1",
+				"postcss-normalize-string": "^8.0.1",
+				"postcss-normalize-timing-functions": "^8.0.1",
+				"postcss-normalize-unicode": "^8.0.1",
+				"postcss-normalize-url": "^8.0.1",
+				"postcss-normalize-whitespace": "^8.0.1",
+				"postcss-ordered-values": "^8.0.1",
+				"postcss-reduce-initial": "^8.0.1",
+				"postcss-reduce-transforms": "^8.0.1",
+				"postcss-svgo": "^8.0.1",
+				"postcss-unique-selectors": "^8.0.1"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/cssnano-utils": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-6.0.0.tgz",
-			"integrity": "sha512-ztS9W/+uaDn+bkYmDhs+GdMveHJ3CL8IPNHpRqDUQXv5GJOTQAJjV1XUOInr9esLXSabQV1pLRZlJpyUwEqDyQ==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/cssnano-utils/-/cssnano-utils-6.0.1.tgz",
+			"integrity": "sha512-zk65GIxA8tCjqVk7nTm1mE+ZKxtnxAvU5JSUaBLXbAr3ZF7IOvz3fbPOnEDvZKhnS7GOIitXTS5BgehLzNoc8Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/csso": {
@@ -1348,9 +1324,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.361",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.361.tgz",
-			"integrity": "sha512-Q6Hts7N9FnJc5LeGRINFvLhCI9xZmNtTDe5ZbcVezQz7cU4a8Aua3GH1b8J2XY8Al9PF+OCwYqhgsOOheMdvkA==",
+			"version": "1.5.395",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.395.tgz",
+			"integrity": "sha512-7zt9Aw+SrmxLWLN0zhaTWZQiCdryLVrYTq5R7iZakLvi2UQPYMMsROYV/2qVCzMeCiSXHwKOU+sZ4zOVVlrtKA==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -1428,11 +1404,11 @@
 			}
 		},
 		"node_modules/iframe-resizer": {
-			"version": "4.4.2",
-			"resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.2.tgz",
-			"integrity": "sha512-2SupFCq9V9osWac4q+PodF0E9QdWY5A9VdCpKrrE7HlDrcIsaTp7D6k14mkGXWoWMS9jCavYusik25wTc0YB2Q==",
+			"version": "4.4.5",
+			"resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
+			"integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
 			"hasInstallScript": true,
-			"license": "GPL-3.0",
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
 			},
@@ -1442,9 +1418,9 @@
 			}
 		},
 		"node_modules/immutable": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -1507,20 +1483,6 @@
 				"url": "https://github.com/sponsors/antonk52"
 			}
 		},
-		"node_modules/lodash.memoize": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
-			"integrity": "sha512-t7j+NzmgnQzTAYXcsHYLgimltOV1MXHtlOWf6GjL9Kj8GK5FInw5JotxvbOs+IvV1/Dzo04/fCGfLVs7aXb4Ag==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/lodash.uniq": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
-			"integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/luxon": {
 			"version": "3.7.2",
 			"resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
@@ -1553,9 +1515,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.12",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-			"integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -1580,9 +1542,9 @@
 			"optional": true
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.46",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.46.tgz",
-			"integrity": "sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1610,9 +1572,9 @@
 			"license": "ISC"
 		},
 		"node_modules/picomatch": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.5.tgz",
+			"integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1624,9 +1586,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.15",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-			"integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+			"version": "8.5.21",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.21.tgz",
+			"integrity": "sha512-v4sDNP3fdNiWMfabO7OwOQdOX8TiQSztKyT1Wj0w+j7LDallJThJRBBBmzVGyYj0crMh7jlV4zepPkiNu9UwDQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -1644,7 +1606,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.12",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -1670,28 +1632,28 @@
 			}
 		},
 		"node_modules/postcss-colormin": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.0.tgz",
-			"integrity": "sha512-KKwMmsSgsmdYXqrjQeqL3tnuIFtctiR1GEMHdjNpDpz/TCRkkkok2mMcreK2zVV3l7POWOmAkR2xYHUpRUK1DA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-colormin/-/postcss-colormin-8.0.1.tgz",
+			"integrity": "sha512-qBY4ABQ6d8/mk5RRZHwMllrZMxeMey3azVY2dZUEk+RgiUC4ARdPR3/AITzNqqKTbvW/3y/MJKinDrzwqn8RDQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@colordx/core": "^5.4.3",
 				"browserslist": "^4.28.2",
-				"caniuse-api": "^3.0.0",
+				"caniuse-api": "^4.0.0",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-convert-values": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-8.0.0.tgz",
-			"integrity": "sha512-Ohtj3rNZWawTRePv5NCHTy8VJSdJ/G/uKuxcxJreOMichuqcT6uEl2TAnopVeJCJ/c13jaSqg7m63yFLM5zBsA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-convert-values/-/postcss-convert-values-8.0.1.tgz",
+			"integrity": "sha512-IdOSIX3BzfMvCc1TAHIha2gfy17xnb5vfML8e2BIKARnFOghksESfaSAB/3CXgyLfMozZAbTRPVQF5dbuKOidw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1702,104 +1664,104 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-discard-comments": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.0.tgz",
-			"integrity": "sha512-zGpvVLj2sbagEp+BTVETvAfkZdGVA6rALNujDK/WTIjdf1/rQOxOG8BBzkI8UQgnw8SkL6xffAfbtGMHFypadw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-comments/-/postcss-discard-comments-8.0.1.tgz",
+			"integrity": "sha512-FDvzm3tXlEsQBO2XQgnta5ugsAqwBrgWH+j5QgXpegEIDYA0VPnZg2aP7LtmWtC49POskeIhXesFiU/k3NyFHA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^7.1.1"
+				"postcss-selector-parser": "^7.1.2"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-discard-duplicates": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.0.tgz",
-			"integrity": "sha512-zjRyYmNGI3PTipKBBtCgExlmZXQn49KvKoaiNnR2g+iXxeNk7GY5Js2ULtZXPrCYeqjPagrzKIBNcBocvXCR7g==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-duplicates/-/postcss-discard-duplicates-8.0.1.tgz",
+			"integrity": "sha512-stTDXkI8YkCUfADurQhp03oq5ynsgSx6Qrw5B1swds6oTHtAeOZ9I0SHGK8cY/VpWUsIYFDWMs3IWf9jIEfFvA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-discard-empty": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.0.tgz",
-			"integrity": "sha512-kxPJg6EqahbBvm+l7hpYYCtpsv8dlz7Tv6wJXUXZaeuY0WGS61DxfGdZR4uVB/Cx+yi3iOHQVSqpSHKMFaBg6Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-8.0.1.tgz",
+			"integrity": "sha512-Zv4fM1Yfhk71tbt6gfiptbL6jDHi+7apSnaMeaO9n1uET+1embrXQw5m93Zp5x28UyQSuv+AVkFY193jdwZ33w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-discard-overridden": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-8.0.0.tgz",
-			"integrity": "sha512-sW2OWH3l9p0FmBSVr228uztFseqroZxwgD7SGF0Ks0dRPDttSo3P8FK5ZBLtWBH2A5+chpB0J2fB/T8heKHLBw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-discard-overridden/-/postcss-discard-overridden-8.0.1.tgz",
+			"integrity": "sha512-ykt4fvrC7yYGzbxKyqBVjDCbsjF/11JgWK8enrdkobRyqqEtb/uDUCbKOGdvrK8X7BrShW8Lv5cCRNbdkNHGkQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-merge-longhand": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-8.0.0.tgz",
-			"integrity": "sha512-YDmAmQ8H+ljfomVpSXvr9NA0GP01fraQJqjWBYoMVGg6rOT+PJLwPyeVo2ekn4WB4ZVSH5ddtK3DTRxbz6CFzg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-longhand/-/postcss-merge-longhand-8.0.1.tgz",
+			"integrity": "sha512-huTfSYgQ13O81SFvAuOi7GWnO48vvybjj3xF+X3qUoPjzvvaLpJH5DcUqqXcwOEulZUcvaV4s0V9WtWs+IAQPA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"postcss-value-parser": "^4.2.0",
-				"stylehacks": "^8.0.0"
+				"stylehacks": "^8.0.1"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-merge-rules": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.0.tgz",
-			"integrity": "sha512-bgstL5mpi41dDpnYGDUcI3M814NWkCMcIWpwDqEHXkHg3BT7b4XRAfNEuwJncZOVn/67kVKvWzhfv/7xyrp2uQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-merge-rules/-/postcss-merge-rules-8.0.1.tgz",
+			"integrity": "sha512-o3rk4UpnPNg469tklYwbR/NtvKc/f/wJiVDTnNQ/EFPw/LeiPOHUCvV1GIBQIZHGrBAYdPjToK6a+ojYprsrxQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
-				"caniuse-api": "^3.0.0",
-				"cssnano-utils": "^6.0.0",
-				"postcss-selector-parser": "^7.1.1"
+				"caniuse-api": "^4.0.0",
+				"cssnano-utils": "^6.0.1",
+				"postcss-selector-parser": "^7.1.2"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-minify-font-values": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-8.0.0.tgz",
-			"integrity": "sha512-EnOHQEnSt6oH5NrL1DMFAQuwB2IOimFXTCzc9bKfUeH1jREbqIF5MAK4gQJQOC4mPUwJt4sWifAmNZ1qLu6j3Q==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-font-values/-/postcss-minify-font-values-8.0.1.tgz",
+			"integrity": "sha512-L8Nzs/PRlBSPrLdY/7rAiU5ZN5800+2J/4LRbfyG8SJnPljmgMaXVmQiCklvRS+yObfVRNtvmk/Ean/eoYcSeg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1809,81 +1771,81 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-minify-gradients": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.0.tgz",
-			"integrity": "sha512-43iAnYIGk0ZjNx5X/rkIcHi6dhmu/vEjY0kqfUfxPuJRO+V7jx8uKIdcnL0dpfNoC5J9TSh3EtzLWbq0gpqnWA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-gradients/-/postcss-minify-gradients-8.0.1.tgz",
+			"integrity": "sha512-qf+4s/hZMqTwpWN2teqf6+1yvR/SZK5HgHqXYuACeJXV7ABe7AXtBEomgxagUzcN4bSnmqBh5vnIml0dYqykYg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@colordx/core": "^5.4.3",
-				"cssnano-utils": "^6.0.0",
+				"cssnano-utils": "^6.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-minify-params": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-8.0.0.tgz",
-			"integrity": "sha512-z7w4QO7G55l4vMUK1Lmx03GW7iyRLgf2V5Dz/7ioSPLnXRjeD+b7m0XfAXUGrbBYYrJ6bXPk+3LoX5u4JfAcSg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-minify-params/-/postcss-minify-params-8.0.1.tgz",
+			"integrity": "sha512-L0h3H59deFfFg0wQN1NVaS/8E/LfGvaMuZKGO7siwlG995zo3OshtQyRkqKdVqcBwAORBvZ1nDZrKPLRapYkQw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
-				"cssnano-utils": "^6.0.0",
+				"cssnano-utils": "^6.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-minify-selectors": {
-			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-8.0.1.tgz",
-			"integrity": "sha512-c31D46811kTkQDxV1KTTow79axX6gj/01AY5G7cGZg3s31KvAwP13jEFXGAzQbJ7NvOFV1pRqEia6nrAdHU7qg==",
+			"version": "8.0.2",
+			"resolved": "https://registry.npmjs.org/postcss-minify-selectors/-/postcss-minify-selectors-8.0.2.tgz",
+			"integrity": "sha512-3icdxc/zght5UAizdwqZBDE2KOWHf1jMQCxET6iLACeNlRxfTPyXS0/COpGk8CQ2cECyaEKTRUd/i/k8Gxmz4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.1",
-				"caniuse-api": "^3.0.0",
+				"caniuse-api": "^4.0.0",
 				"cssesc": "^3.0.0",
-				"postcss-selector-parser": "^7.1.1"
+				"postcss-selector-parser": "^7.1.2"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-charset": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.0.tgz",
-			"integrity": "sha512-s88FUNDSUD8m0wBYvTQQcubVts6zhXwBU8zCD4vkRKiecd0v8cOjHVIF9r/i+5xzS/WG3f98qq4XsOM0JqvfLA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-charset/-/postcss-normalize-charset-8.0.1.tgz",
+			"integrity": "sha512-xzqr36F8UeIZOvOHsf3aul+RVJCADvSwuwpMLgizqKjisHZpBfztgW0XFLBfJvz9pJgaStaOXAtGb0zLqT6B0w==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-display-values": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.0.tgz",
-			"integrity": "sha512-gG2nBxD27fiw6Luinb1QYKdM/Co5GornRJgSD+JTwNH4PGKxImP0qyruDDav49aHUPLY3qrL3qN3LvybO7IzxQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-8.0.1.tgz",
+			"integrity": "sha512-ZDWOijOK1FFMlpgiQCUO9fCNKd7HJ9L7z9HWEq4iyubnUFWzdTSwm/LcrMbNW6iZ1oAtqeLYA0WA3xHszOI08g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1893,13 +1855,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-positions": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-8.0.0.tgz",
-			"integrity": "sha512-t/wGqpehS20Ke7kc4QAsWpH+AJjUdMK/V5qV2RhrXkj8hO/fT1t1MJ8NL7sedWYk7ZqC7eISEJQonW5j0tU1MQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-positions/-/postcss-normalize-positions-8.0.1.tgz",
+			"integrity": "sha512-uuivan2poSqbE48ST4do20dGaFUeXey9/H8rhHzoyVHB2I6BmkoVLZ/C9+BRjUlpaAFYVOoDY7epkiidzaYbvA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1909,13 +1871,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-repeat-style": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.0.tgz",
-			"integrity": "sha512-3ebOmGdCYKrBYyGKc1xhj0unEnW7beZpVU7JohVeGl7mTxR+7T6egpaawTWAVsB0pEIhcsbJVOjPKCJSoRO6Zg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-repeat-style/-/postcss-normalize-repeat-style-8.0.1.tgz",
+			"integrity": "sha512-q2hq5fmKxk29K6DjKA3nZ17Q2dtjhLYFNmFweKALmooUqx6UWAHF1bBoWTu/EqlJ88josb82A/J0Atj9LJUmpQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1925,13 +1887,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-string": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-8.0.0.tgz",
-			"integrity": "sha512-TvWCGZ/e04Tv31uJvOUtbexkfgUnqmQ3M2P5DkAaVzvOj+BvTkG2QjpA5Y71SL1SPxJcj4M23fNh+RDVCmG8kA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-string/-/postcss-normalize-string-8.0.1.tgz",
+			"integrity": "sha512-+Wf+kQJhm1WgSGEAuUaswE9rdpR9QbrKRVemcVHs6rhOoOTVIdAbgaicftfYA6vLM346P8onRzkEVbFN29ktKQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1941,13 +1903,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-timing-functions": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.0.tgz",
-			"integrity": "sha512-uEfaXst5Xgqxv7geYUuz6vs9mn88K2NPY2RoIzM3BMmSjsdTSeppV9x2qIgrxsisdbSqF6IVhzI2occcte3hTA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-timing-functions/-/postcss-normalize-timing-functions-8.0.1.tgz",
+			"integrity": "sha512-W8/tvwRlm3T+yjGkg0IRTF4bvHj0vILYr/LOogCrJKHz2ey2HFRwfsAA8Bk9N4BGR7z7WmmDu/KzzwhJ6FoGPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1957,13 +1919,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-unicode": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.0.tgz",
-			"integrity": "sha512-+WYngZaChEeTHZmWhmKtnJ4gTzWdINEaFcgWBnu6WdVu8Ftim8OBTcw768DuCC/3Aax9bZ9WkwrLGHym2Lzf+A==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-unicode/-/postcss-normalize-unicode-8.0.1.tgz",
+			"integrity": "sha512-Ad0YHNRBp4WHEOYUM/4wL/8MoL2fimEF8se/0q+Rt/owMzYpbxsypC1P8fN/oluwoRmRKdNVX7X2oycEobPWcQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1974,13 +1936,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-url": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-8.0.0.tgz",
-			"integrity": "sha512-4Mz9hZHn/QIB+YtFqTXrDmE2193GYxGb3F8uMfLvMicaEXCCUlDIJ658gFFJbqEGl9FYzwPtRiuNgbwlO9kkBg==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-url/-/postcss-normalize-url-8.0.1.tgz",
+			"integrity": "sha512-tkYcip6pCDY806xuxpJYqMW2M3/623jzGFJmz3m5Us47q8P28+gbRZxaea3Rr/CmwwLUiVlh+BTGYwQ6gvaP8A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1990,13 +1952,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-normalize-whitespace": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.0.tgz",
-			"integrity": "sha512-V1f8tYnwIP5tscOXQFTKK8Y5EJ+R2GMpFJ6FjzwoKoQnhbqQy3IeSrDjJJb8JjVos8ut6Osi80Zybpayv/XjIQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-normalize-whitespace/-/postcss-normalize-whitespace-8.0.1.tgz",
+			"integrity": "sha512-XzORadNfSrKWDZZpgAEHPKINKx8r9r9RIfE9c70g/HThdpbmPHhDYCodHSVESDxmKeySAYw1p4liuBCf7j6LyA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2006,47 +1968,47 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-ordered-values": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.0.tgz",
-			"integrity": "sha512-Dg9+itb6lmD0bxqhQyHCtXAwYRh0wUrx6Mp4/BNXgkLoJmdYMmWi+V+Pypw79Q6iQhxA8KFMHqLBITQJV2gKMA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-ordered-values/-/postcss-ordered-values-8.0.1.tgz",
+			"integrity": "sha512-OLXq5lR1yk3KWQ1FPK6aWjFFdktHE9f9kb8cnt4LmIw7w30DnzgD9+sOVYJc5HenkWCX8i1MJhhFwmqc/GYqLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"cssnano-utils": "^6.0.0",
+				"cssnano-utils": "^6.0.1",
 				"postcss-value-parser": "^4.2.0"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-reduce-initial": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.0.tgz",
-			"integrity": "sha512-DChcE9d528AKrlpCTHjhsAiOsWCk4H9ApHPS1QqRT3praObWTiWyn6W1UddGpc46K9LQnHwUu4YwaPUukGtXVA==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-8.0.1.tgz",
+			"integrity": "sha512-+aQsR6+61KRoIfcFNLP3v9RM7+0iYOTtPnjl1wr6JqMW1zx6S+t2ktHRefXwacFdHIDj5+ETG0KY7K3+SGQ4Nw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
-				"caniuse-api": "^3.0.0"
+				"caniuse-api": "^4.0.0"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-reduce-transforms": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.0.tgz",
-			"integrity": "sha512-cLZT0som7vvumQT9XQCnSKOSnRinNQZd1Hm+J723Ney13E8CIydDhw6JwzsjPtgnYThTqn9Q45906gz6wxaAsw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-reduce-transforms/-/postcss-reduce-transforms-8.0.1.tgz",
+			"integrity": "sha512-x71slHVykiFi5RuKEXM0wgYpY2PngC78x6R8TnZhHF3lhqt+u/w3MGwYLX+2t5O87ssRiMfEAhQH+3J4QwVzCw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2056,13 +2018,13 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-selector-parser": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
-			"integrity": "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==",
+			"version": "7.1.4",
+			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.4.tgz",
+			"integrity": "sha512-HeP7D2wyhkR+XaK6v4W8oRF62Dsz4flyuczALJp61GckGm42u1saSSJ/0auvcBqxs3jMRFEcPK34At/0JBKdOg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2074,9 +2036,9 @@
 			}
 		},
 		"node_modules/postcss-svgo": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.0.tgz",
-			"integrity": "sha512-Q2fMSYEiNE1ioDc/3sxvI24NdgA/MJno2XLNpOxgv8aCcJbym8mZY10/lDY5+AWCIc3Aiqzy2Wcp9/zaIXBZgQ==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-svgo/-/postcss-svgo-8.0.1.tgz",
+			"integrity": "sha512-HpnvWii7W0/FPrsejJa6ZTi0kNtTJP/Iba7CUMPX0xPV6QpnndOp+SDP74tFtgjA2cYKYNWJPOlmLXMsvi/9yA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2087,23 +2049,23 @@
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-unique-selectors": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-8.0.0.tgz",
-			"integrity": "sha512-iObuolUX+ITJfMU2QQFQdh31JgSjNLPNjVs6YGAqBHvOvAWXMMNget6donQl83aQaeS32i5XeKZURUW/WBxIUw==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-unique-selectors/-/postcss-unique-selectors-8.0.1.tgz",
+			"integrity": "sha512-+xvKI5+/Cl8yYQwxDV39Uhuc4WV951xngFvPPjiPj2NIbIfm6vbbRTXblyw0FioLkIoGlw+7qUcY1h2YhaZYgw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"postcss-selector-parser": "^7.1.1"
+				"postcss-selector-parser": "^7.1.2"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/postcss-value-parser": {
@@ -2114,9 +2076,9 @@
 			"license": "MIT"
 		},
 		"node_modules/prettier": {
-			"version": "3.8.3",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
-			"integrity": "sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==",
+			"version": "3.9.6",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.9.6.tgz",
+			"integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -2163,9 +2125,9 @@
 			}
 		},
 		"node_modules/sass": {
-			"version": "1.100.0",
-			"resolved": "https://registry.npmjs.org/sass/-/sass-1.100.0.tgz",
-			"integrity": "sha512-B5j0rYMlinhhOo9tjQebMVVn0TfyXAF+wB3b2ggZUuJ/is/Y+7+JGjirAMxHZ9Z3hIP98NPfamlAkBHa1lAaXQ==",
+			"version": "1.101.3",
+			"resolved": "https://registry.npmjs.org/sass/-/sass-1.101.3.tgz",
+			"integrity": "sha512-Z1lLHhtAII+dyLNIQB6JQTZMy7sDxk3f5NzbINRc9ks1P0HCGvSuKev0wUhULFpLSaHBIMZrcTs9WDQUZerrgA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2290,26 +2252,26 @@
 			"license": "MIT"
 		},
 		"node_modules/stylehacks": {
-			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-8.0.0.tgz",
-			"integrity": "sha512-sWyjaJvBqHoVKYPbQ8JRvrGSPaYWtWrJsU+fGVtwKB1GE1rRPu3rC7T6UCuXLoL00Dwb+tsHe2T904r8Vnsx8w==",
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/stylehacks/-/stylehacks-8.0.1.tgz",
+			"integrity": "sha512-Gv095oTD0N+BdJALNFDsxZpETHZLTxbOl5RyIO7y6VAE6sR3z0MnV3Nix7N0IATNldNTrkvSASp2KR1Yt526HA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"browserslist": "^4.28.2",
-				"postcss-selector-parser": "^7.1.1"
+				"postcss-selector-parser": "^7.1.2"
 			},
 			"engines": {
 				"node": "^22.11.0 || ^24.11.0 || >=26.0"
 			},
 			"peerDependencies": {
-				"postcss": "^8.5.14"
+				"postcss": "^8.5.15"
 			}
 		},
 		"node_modules/svgo": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.1.tgz",
-			"integrity": "sha512-XDpWUOPC6FEibaLzjfe0ucaV0YrOjYotGJO1WpF0Zd+n6ZGEQUsSugaoLq9QkEZtAfQIxT42UChcssDVPP3+/w==",
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-4.0.2.tgz",
+			"integrity": "sha512-ekx94z1rRc5LDi6oSUaeRnYhd0UOJxdtQCL2rF8xpWxD3TPAsISWOrxezqGovqS38GRZOdpDfvQe3ts6F7nsng==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2333,9 +2295,9 @@
 			}
 		},
 		"node_modules/terser": {
-			"version": "5.48.0",
-			"resolved": "https://registry.npmjs.org/terser/-/terser-5.48.0.tgz",
-			"integrity": "sha512-J/9An6vs9Us6wKRriSFXBWdRZapREHqFzdNUKk0pmu804EMR6dr6winwo7e5JDxN4xahxQsuysyYFwlwj4XN/Q==",
+			"version": "5.49.0",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.49.0.tgz",
+			"integrity": "sha512-SNiDnXyHSrxVcIOtVbULzcTmniUiwcV7Nwdyj1twVubeTmbjoa8p69KKDpfkdoOavuM4/GRm1+ykI8qqnavHoA==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -13,7 +13,7 @@
 		"url": "https://github.com/openwebwork/webwork2"
 	},
 	"dependencies": {
-		"@fortawesome/fontawesome-free": "^7.2.0",
+		"@fortawesome/fontawesome-free": "^7.3.1",
 		"@openwebwork/pg-codemirror-editor": "^0.0.10",
 		"bootstrap": "^5.3.8",
 		"flatpickr": "^4.6.13",
@@ -27,14 +27,14 @@
 		"sortablejs": "^1.15.7"
 	},
 	"devDependencies": {
-		"autoprefixer": "^10.5.0",
+		"autoprefixer": "^10.5.4",
 		"chokidar": "^5.0.0",
-		"cssnano": "^8.0.1",
-		"postcss": "^8.5.15",
-		"prettier": "^3.8.3",
+		"cssnano": "^8.0.2",
+		"postcss": "^8.5.21",
+		"prettier": "^3.9.6",
 		"rtlcss": "^4.3.0",
-		"sass": "^1.100.0",
-		"terser": "^5.48.0",
+		"sass": "^1.101.3",
+		"terser": "^5.49.0",
 		"yargs": "^18.0.0"
 	},
 	"browserslist": [


### PR DESCRIPTION
The only dependency that is updated that is not for the `generate-assets.js` script is `@fortawesome/fontawesome-free` and there do not seem to be any issues from that.  From their changelog the only changes are new icons and some improvements to animations.

The `generate-assets.js` script still seems to be working fine, so the development updates should be fine also.

The security vulnerabilities that just showed up were fixed with the upgrade.