### PR TITLE
Fix a cut and paste error in the reset password template.

### DIFF
--- a/templates/ContentGenerator/ResetPassword.html.ep
+++ b/templates/ContentGenerator/ResetPassword.html.ep
@@ -32,7 +32,7 @@
 					% if ($ce->two_factor_authentication_enabled
 						% && $authz->hasPermissions($userID, 'use_two_factor_auth')) {
 						<div class="row mb-2">
-							<%= label_for confirmPassword =>
+							<%= label_for otp_code =>
 									maketext("One-time code from authenticator app"),
 								class => 'col-form-label col-sm-6' =%>
 							<div class="col-sm-6">


### PR DESCRIPTION
The label should be for the `otp_code` input, and not be for the `confirmPassword` input above which already has a label.