### PR TITLE
move the test navigation table into a nav element

### DIFF
--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -516,12 +516,12 @@
 			% end
 		% }
 		% my $jumpLinks = begin
-			<div class="table-responsive">
-				<table class="gwNavigation" role="navigation" aria-label="problem navigation">
+			<nav class="table-responsive" aria-label="<%= maketext('problem navigation') %>">
+				<table class="gwNavigation">
 					<%= content 'gw-navigation-cols' =%>
 					<%= content 'gw-navigation-table-rows' =%>
 				</table>
-			</div>
+			</nav>
 			<%= content 'gw-previous-next-buttons' =%>
 		% end
 		<%= $jumpLinks->() =%>


### PR DESCRIPTION
A medium level accessibility issue that Claude flagged is that the table here had role="navigation". This addresses that, by removing the aria labeling from the table and enclosing it all in a nav.