### PR TITLE
buttons for reordering problems in a set details page

### DIFF
--- a/htdocs/js/ProblemSetDetail/problemsetdetail.js
+++ b/htdocs/js/ProblemSetDetail/problemsetdetail.js
@@ -42,10 +42,189 @@
 		}
 	};
 
+	const getSourceFilePath = (id) =>
+		document.getElementById(`problem.${id}.source_file_id`)?.value ||
+		document.getElementById(`problem_${id}_default_source_file`)?.value ||
+		'';
+
+	// Compute the "same source file" alerts for every problem based on the current order of the list.
+	const updateRepeatFileAlerts = () => {
+		if (!container) return;
+		const repeatFileText = container.dataset.repeatFileText;
+		if (!repeatFileText) return;
+
+		const shownYet = new Map();
+		for (const item of container.querySelectorAll('.psd_list_item')) {
+			const row = item.querySelector(':scope > .problem_detail_row');
+			const alertContainer = row?.querySelector('.pdr_repeat_file_alert');
+			if (!alertContainer) return;
+
+			alertContainer.innerHTML = '';
+
+			const problemID = item.id.replace('psd_list_item_', '');
+			const sourceFile = getSourceFilePath(problemID).replace(/^\//, '').replace(/\.\./g, '');
+			if (!sourceFile || sourceFile.startsWith('group:')) return;
+
+			if (shownYet.has(sourceFile)) {
+				const alert = document.createElement('div');
+				alert.className = 'alert alert-danger p-1 mb-2 fw-bold';
+				alert.textContent = repeatFileText.replace('[_1]', shownYet.get(sourceFile));
+				alertContainer.append(alert);
+			} else {
+				shownYet.set(sourceFile, row.querySelector('.pdr_problem_number')?.textContent ?? '');
+			}
+		}
+	};
+
 	const setProblemNumberFields = () => {
 		container.querySelectorAll('.psd_list_item .pdr_problem_number').forEach((num) => (num.textContent = ''));
 		recursiveRenumber(Sortable.get(container).toArray());
+		updateRepeatFileAlerts();
 	};
+
+	// Buttons to rearrange problems. Either up/down for rearranging order, or buttons for nestin/de-nesting JITAR
+	// problems. Buttons are disabled when the corresponding action isn't possible.
+	const updateReorderButtonStates = () => {
+		if (!container) return;
+		for (const list of [container, ...container.querySelectorAll('.sortable-branch')]) {
+			const items = list.querySelectorAll(':scope > .psd_list_item');
+			for (const [index, item] of items.entries()) {
+				const upButton = item.querySelector(':scope > .problem_detail_row .psd_move_up');
+				const downButton = item.querySelector(':scope > .problem_detail_row .psd_move_down');
+				if (upButton) upButton.disabled = index === 0;
+				if (downButton) downButton.disabled = index === items.length - 1;
+
+				// Nesting nests the item under its previous sibling, so it needs a previous sibling to nest under.
+				// Denesting moves the item up to its parent's list, so it isn't possible at the top level.
+				const nestButton = item.querySelector(':scope > .problem_detail_row .psd_nest');
+				const denestButton = item.querySelector(':scope > .problem_detail_row .psd_denest');
+				if (nestButton) nestButton.disabled = index === 0;
+				if (denestButton) denestButton.disabled = list === container;
+			}
+		}
+	};
+
+	// Recompute the nestDepth property (used by the drag-and-drop "put" rule) for a sub-list and all of its
+	// descendant sub-lists after the sub-list has moved to a new position in the tree.
+	const recomputeNestDepth = (list) => {
+		if (!list) return;
+		list.nestDepth = list.parentNode.closest('.sortable-branch').nestDepth + 1;
+		list.querySelectorAll(':scope > .psd_list_item > .sortable-branch').forEach(recomputeNestDepth);
+	};
+
+	// Show or hide each row's expand/collapse button depending on whether its sub-list currently has any children.
+	const updateCollapseButtonVisibility = () => {
+		if (!container) return;
+		for (const list of container.querySelectorAll('.sortable-branch')) {
+			if (list.firstElementChild) list.parentNode.collapseButton?.classList.remove('d-none');
+			else list.parentNode.collapseButton?.classList.add('d-none');
+		}
+	};
+
+	// Bookkeeping after any keyboard-driven reorder/nest/denest: update the hidden problem number/parent fields,
+	// re-enable/disable fields whose relevance depends on tree position, update this row's button states, and
+	// manage focus.
+	const finishReorder = (item, button, fallbackSelectors) => {
+		setProblemNumberFields();
+		disableFields();
+		updateReorderButtonStates();
+		updateCollapseButtonVisibility();
+
+		if (!button.disabled) {
+			button.focus();
+			return;
+		}
+		for (const selector of fallbackSelectors) {
+			const fallback = item.querySelector(selector);
+			if (fallback && !fallback.disabled) {
+				fallback.focus();
+				return;
+			}
+		}
+	};
+
+	const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+	// Animate elements that just moved from where they used to be to where they ended up (the "FLIP" technique),
+	// so a move up/down reads as the two rows swapping places instead of an unexplained instant jump. Only the
+	// vertical position can change here, since these are stacked list items.
+	const animateReorder = (elementsAndFirstRects) => {
+		if (prefersReducedMotion) return;
+		for (const [el, firstRect] of elementsAndFirstRects) {
+			const deltaY = firstRect.top - el.getBoundingClientRect().top;
+			if (!deltaY) continue;
+			el.style.transition = 'none';
+			el.style.transform = `translateY(${deltaY}px)`;
+			el.getBoundingClientRect(); // Force a reflow so the starting position above is rendered before animating.
+			requestAnimationFrame(() => {
+				el.style.transition = 'transform 150ms ease-in-out';
+				el.style.transform = '';
+			});
+			el.addEventListener('transitionend', () => (el.style.transition = ''), { once: true });
+		}
+	};
+
+	const moveItem = (button, direction) => {
+		const item = button.closest('.psd_list_item');
+		const sibling = direction === 'up' ? item.previousElementSibling : item.nextElementSibling;
+		if (!sibling?.classList.contains('psd_list_item')) return;
+
+		const firstRects = [item, sibling].map((el) => [el, el.getBoundingClientRect()]);
+
+		if (direction === 'up') item.parentNode.insertBefore(item, sibling);
+		else item.parentNode.insertBefore(sibling, item);
+
+		animateReorder(firstRects);
+
+		finishReorder(item, button, [
+			direction === 'up' ? '.psd_move_down' : '.psd_move_up',
+			'.psd_denest',
+			'.psd_nest'
+		]);
+	};
+
+	const nestItem = (button) => {
+		const item = button.closest('.psd_list_item');
+		const prevSibling = item.previousElementSibling;
+		if (!prevSibling?.classList.contains('psd_list_item')) return;
+
+		const targetList = prevSibling.querySelector(':scope > .sortable-branch');
+		if (!targetList) return;
+
+		targetList.append(item);
+		recomputeNestDepth(item.querySelector(':scope > .sortable-branch'));
+
+		// Make sure the item's new position is actually visible, in case its new parent's children were collapsed.
+		bootstrap.Collapse.getInstance(targetList)?.show();
+
+		finishReorder(item, button, ['.psd_denest', '.psd_move_up', '.psd_move_down']);
+	};
+
+	const denestItem = (button) => {
+		const item = button.closest('.psd_list_item');
+		const currentList = item.parentNode;
+		if (currentList === container) return;
+
+		const parentItem = currentList.closest('.psd_list_item');
+		const grandParentList = parentItem.parentNode;
+
+		grandParentList.insertBefore(item, parentItem.nextSibling);
+		recomputeNestDepth(item.querySelector(':scope > .sortable-branch'));
+
+		finishReorder(item, button, ['.psd_nest', '.psd_move_up', '.psd_move_down']);
+	};
+
+	for (const button of document.querySelectorAll('.psd_move_up, .psd_move_down, .psd_nest, .psd_denest')) {
+		button.addEventListener('click', () => {
+			// Since focus stays on (or moves to another) reorder button after the click is handled below, the
+			// tooltip's own focus/hover triggers won't naturally hide it. Hide it explicitly so it doesn't get stuck.
+			bootstrap.Tooltip.getInstance(button)?.hide();
+			if (button.classList.contains('psd_move_up')) moveItem(button, 'up');
+			else if (button.classList.contains('psd_move_down')) moveItem(button, 'down');
+			else if (button.classList.contains('psd_nest')) nestItem(button);
+			else denestItem(button);
+		});
+	}
 
 	const setSortable = (list) => {
 		// Set up the bootstrap collapses.  Note that if a list is empty, then the collapse is shown.  Since it is empty
@@ -112,6 +291,7 @@
 			onSort() {
 				setProblemNumberFields();
 				disableFields();
+				updateReorderButtonStates();
 			},
 			onRemove() {
 				if (hiddenCollapse?._isTransitioning)
@@ -121,10 +301,7 @@
 				else hiddenCollapse?.show();
 			},
 			onChange(evt) {
-				container.querySelectorAll('.sortable-branch').forEach((list) => {
-					if (list.firstElementChild) list.parentNode.collapseButton?.classList.remove('d-none');
-					else list.parentNode.collapseButton?.classList.add('d-none');
-				});
+				updateCollapseButtonVisibility();
 				if (evt.from.querySelectorAll('.psd_list_item').length < 2)
 					evt.from.parentNode.collapseButton?.classList.add('d-none');
 			}
@@ -182,6 +359,8 @@
 
 	if (container) setSortable(container);
 	container?.querySelectorAll('.sortable-branch').forEach(setSortable);
+	updateReorderButtonStates();
+	updateRepeatFileAlerts();
 
 	// Recursively convert the sortable list to a tree.  Each entry of the tree has the problem id, the parent id if it
 	// has a parent, and a list of the child problems (each of which is again an entry of the tree).
@@ -211,7 +390,10 @@
 
 	// Initialize tooltips.
 	document
-		.querySelectorAll('.psd_view,.psd_edit,.pdr_render,.pdr_grader,.pdr_handle > i')
+		.querySelectorAll(
+			'.psd_view,.psd_edit,.pdr_render,.pdr_grader,.pdr_handle > i,' +
+				'.psd_move_up,.psd_move_down,.psd_nest,.psd_denest'
+		)
 		.forEach((el) => new bootstrap.Tooltip(el));
 
 	// If editing for user(s), then disable drag and drop re-ordering of problems.
@@ -345,9 +527,7 @@
 
 			const ro = {
 				problemSeed: document.getElementById(`problem.${id}.problem_seed_id`)?.value ?? 1,
-				sourceFilePath:
-					document.getElementById(`problem.${id}.source_file_id`)?.value ||
-					document.getElementById(`problem_${id}_default_source_file`)?.value
+				sourceFilePath: getSourceFilePath(id)
 			};
 
 			if (ro.sourceFilePath.startsWith('group')) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -668,8 +668,8 @@ sub fieldTable ($c, $userID, $setID, $problemID, $globalRecord, $userRecord = un
 						colspan => 2,
 						$problemID ? '' : $c->maketext('General Parameters')
 					),
-					$c->tag('th', class => 'p-2', scope => 'col', $c->maketext('User Overrides')),
-					$c->tag('th', class => 'p-2', scope => 'col', $c->maketext('Set Values'))
+					$c->tag('th', class => 'p-2',             scope => 'col', $c->maketext('User Overrides')),
+					$c->tag('th', class => 'p-2 text-nowrap', scope => 'col', $c->maketext('Set Values'))
 				)->join('')
 			)
 		);
@@ -760,6 +760,8 @@ sub fieldTable ($c, $userID, $setID, $problemID, $globalRecord, $userRecord = un
 			)
 		);
 	}
+
+	unshift @$rows, $c->tag('col') x 2, $c->tag('col', class => 'w-75'), $forOneUser ? $c->tag('col') : '';
 
 	return $c->tag(
 		'table',

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -16,8 +16,8 @@
 		<%= javascript getAssetURL(
 			$ce,
 			'node_modules/flatpickr/dist/l10n/'
-		   	. ($ce->{language} =~ /^el/ ? 'gr' : ($ce->{language} =~ s/^(..).*/$1/gr))
-		   	. '.js'
+			. ($ce->{language} =~ /^el/ ? 'gr' : ($ce->{language} =~ s/^(..).*/$1/gr))
+			. '.js'
 		), defer => undef =%>
 	% }
 	<%= javascript getAssetURL($ce, 'node_modules/flatpickr/dist/plugins/confirmDate/confirmDate.js'),
@@ -204,7 +204,7 @@
 			<div class="card-title fw-bold"><%= maketext('Set Parameters') %></div>
 			<div class="card-text">
 				<%= $c->fieldTable($userToShow, $setID, undef, $setRecord,
-				   	$editingSetVersion
+					$editingSetVersion
 					? $db->getSetVersion($userToShow, $setID, $editingSetVersion)
 					: $db->getUserSet($userToShow, $setID)) =%>
 			</div>
@@ -393,8 +393,6 @@
 		</div>
 		%
 		<div id="problemset_detail_list" class="container-fluid p-0">
-			% my %shownYet;
-			% my $repeatFile;
 			% my @problemRows;
 			%
 			% for my $problemID (@$problemIDList) {
@@ -414,16 +412,6 @@
 				% my $problemFile =
 					% ((param("problem.$problemID.source_file") || $sourceFile) =~ s|^/||r) =~ s|\.\.||gr;
 				%
-				% # Warn of repeat problems
-				% if (defined $shownYet{$problemFile}) {
-					% my $prettyID = $shownYet{$problemFile};
-					% $prettyID   = join('.', jitar_id_to_seq($prettyID)) if $isJitarSet;
-					% $repeatFile = maketext('This problem uses the same source file as number [_1].', $prettyID);
-				% } else {
-					% $shownYet{$problemFile} = $problemID unless $problemFile =~ /^group:/;
-					% $repeatFile = '';
-				% }
-				%
 				% my $error = $c->checkFile($problemFile, undef);
 				%
 				% my $problemNumber     = $problemID;
@@ -436,7 +424,7 @@
 					% $lastProblemNumber = pop @seq;
 					% $parentID          = seq_to_jitar_id(@seq) if @seq;
 					% my $button = begin
-						<button class="pdr_collapse me-2 collapsed btn btn-sm p-0"
+						<button class="pdr_collapse me-1 collapsed btn btn-sm p-0"
 							data-expand-text="<%= maketext('Expand Nested Problems') %>"
 							data-collapse-text="<%= maketext('Collapse Nested Problems') %>"
 							data-bs-toggle="collapse"
@@ -458,8 +446,9 @@
 				% my $problemRow = begin
 					<div class="problem_detail_row card d-flex flex-column p-2 mb-3 g-0">
 						<div class="pdr_block_1 row align-items-center">
-							<div class="col-md-4 col-10 order-1 d-flex align-items-center">
-								<div class="pdr_handle me-2 text-nowrap" id="pdr_handle_<%= $problemID %>">
+							<div class="d-flex align-items-center
+								<%= @editForUser ? 'col-12 col-lg-3 col-xl-2' : 'col col-lg-6 col-xl-4 col-xxl-3' %>">
+								<div class="pdr_handle me-1 text-nowrap" id="pdr_handle_<%= $problemID %>">
 									<span class="pdr_problem_number"><%= $problemNumber %></span>
 									% if (!@editForUser) {
 										<i class="<%= $isJitarSet ? 'fas fa-arrows-alt' : 'fas fa-arrows-alt-v' %>"
@@ -467,123 +456,171 @@
 										</i>
 									% }
 								</div>
-								<%= $collapseButton =%>
-								<%= hidden_field "prob_num_$problemID" => $lastProblemNumber,
-									id => "prob_num_$problemID" =%>
-								<%= hidden_field "prob_parent_id_$problemID" => $parentID,
-									id => "prob_parent_id_$problemID" =%>
-								%
-								% # Show the "Render Problem", "Edit Problem", and "Open in New Window" links if there
-								% # is a well defined problem to view. This is when editing a homework set, editing a
-								% # gateway set version, or editing a gateway set and the problem is not drawing from
-								% # grouping set.  Really the only case needed here is that of a group problem.
-								% if (!$isGatewaySet || $editingSetVersion || $problemFile !~ /^group/) {
-									<button id="pdr_render_<%= $problemID %>"
-										class="pdr_render btn btn-secondary btn-sm"
-										data-bs-toggle="tooltip" data-bs-placement="top"
-										data-bs-title="<%= maketext('Render Problem') %>"
-										type="button">
-										<i class="icon far fa-image" aria-hidden="true"></i>
-										<span class="visually-hidden"><%= maketext('Render') %></span>
-									</button>
-									<%= link_to $c->systemLink(url_for(
-											'instructor_problem_editor_withset_withproblem',
-											setID => $setID, problemID => $problemID
-										)),
-										class  => 'psd_edit btn btn-secondary btn-sm',
-										target => 'WW_Editor',
-										data   => {
-											bs_toggle    => 'tooltip',
-										   	bs_placement => 'top',
-										   	bs_title     => maketext('Edit Problem')
-										},
-										begin =%>
-										<i class="icon fas fa-pencil-alt" aria-hidden="true"></i>
-										<span class="visually-hidden"><%= maketext('Edit') =%></span>
-									<% end =%>
-									% my $problemLink;
-									% if ($isGatewaySet) {
-										% # If editing a set version, then open the actual set version.
-										% # Otherwise, the best that can be done is to use an undefined set.
-										% if ($editingSetVersion) {
-											% my ($problemNumber, $pageNumber) =
-												% get_test_problem_position($db, $problemToShow);
-											% $problemLink = $c->systemLink(url_for('gateway_quiz',
-													% setID => $problemToShow->set_id
-														% . ',v' . $problemToShow->version_id,
-													% problemID => $problemToShow->problem_id
-												%),
-												% params => {
-													% effectiveUser => $editForUser[0],
-													% currentPage   => $pageNumber
-												% }
-											% )->fragment("prob$problemNumber");
+								<div class="d-flex align-items-center">
+									% if (!@editForUser) {
+										<div class="pdr_move_buttons btn-group btn-group-sm me-1" role="group"
+											aria-label="<%= maketext('Reorder problem') %>">
+											<button type="button" class="psd_move_up btn btn-secondary px-1 px-sm-2"
+												id="psd_move_up_<%= $problemID %>"
+												aria-label="<%= maketext('Move problem up') %>"
+												data-bs-title="<%= maketext('Move problem up') %>"
+												data-bs-toggle="tooltip">
+												<i class="fas fa-chevron-up" aria-hidden="true"></i>
+											</button>
+											<button type="button" class="psd_move_down btn btn-secondary px-1 px-sm-2"
+												id="psd_move_down_<%= $problemID %>"
+												aria-label="<%= maketext('Move problem down') %>"
+												data-bs-title="<%= maketext('Move problem down') %>"
+												data-bs-toggle="tooltip">
+												<i class="fas fa-chevron-down" aria-hidden="true"></i>
+											</button>
+										</div>
+										% if ($isJitarSet) {
+											<div class="pdr_nest_buttons btn-group btn-group-sm me-1" role="group"
+												aria-label="<%= maketext('Change nesting level') %>">
+												<button type="button" class="psd_denest btn btn-secondary px-1 px-sm-2"
+													id="psd_denest_<%= $problemID %>"
+													aria-label="<%= maketext('De-nest problem to parent level') %>"
+													data-bs-title="<%= maketext('De-nest problem') %>"
+													data-bs-toggle="tooltip">
+													<i class="fas fa-outdent" aria-hidden="true"></i>
+												</button>
+												<button type="button" class="psd_nest btn btn-secondary px-1 px-sm-2"
+													id="psd_nest_<%= $problemID %>"
+													aria-label="<%= maketext('Nest problem under previous problem') %>"
+													data-bs-title="<%= maketext('Nest problem') %>"
+													data-bs-toggle="tooltip">
+													<i class="fas fa-indent" aria-hidden="true"></i>
+												</button>
+											</div>
+										% }
+										<%= $collapseButton =%>
+									% }
+									<%= hidden_field "prob_num_$problemID" => $lastProblemNumber,
+										id => "prob_num_$problemID" =%>
+									<%= hidden_field "prob_parent_id_$problemID" => $parentID,
+										id => "prob_parent_id_$problemID" =%>
+									%
+									% # Show the "Render Problem", "Edit Problem", and "Open in New Window" links if
+									% # there is a well defined problem to view. This is when editing a homework set,
+									% # editing a gateway set version, or editing a gateway set and the problem is not
+									% # drawing from a grouping set.  Really the only case needed here is that of a
+									% # group problem.
+									% if (!$isGatewaySet || $editingSetVersion || $problemFile !~ /^group/) {
+										<button id="pdr_render_<%= $problemID %>"
+											class="pdr_render btn btn-secondary btn-sm
+												<%= @editForUser ? '' : 'px-1 px-sm-2' %>"
+											data-bs-toggle="tooltip" data-bs-placement="top"
+											data-bs-title="<%= maketext('Render Problem') %>"
+											type="button">
+											<i class="icon far fa-image" aria-hidden="true"></i>
+											<span class="visually-hidden"><%= maketext('Render') %></span>
+										</button>
+										<%= link_to $c->systemLink(url_for(
+												'instructor_problem_editor_withset_withproblem',
+												setID => $setID, problemID => $problemID
+											)),
+											class  => 'psd_edit btn btn-secondary btn-sm'
+												. (@editForUser ? '' : ' px-1 px-sm-2'),
+											target => 'WW_Editor',
+											data   => {
+												bs_toggle    => 'tooltip',
+												bs_placement => 'top',
+												bs_title     => maketext('Edit Problem')
+											},
+											begin =%>
+											<i class="icon fas fa-pencil-alt" aria-hidden="true"></i>
+											<span class="visually-hidden"><%= maketext('Edit') =%></span>
+										<% end =%>
+										% my $problemLink;
+										% if ($isGatewaySet) {
+											% # If editing a set version, then open the actual set version.
+											% # Otherwise, the best that can be done is to use an undefined set.
+											% if ($editingSetVersion) {
+												% my ($problemNumber, $pageNumber) =
+													% get_test_problem_position($db, $problemToShow);
+												% $problemLink = $c->systemLink(url_for('gateway_quiz',
+														% setID => $problemToShow->set_id
+															% . ',v' . $problemToShow->version_id,
+														% problemID => $problemToShow->problem_id
+													%),
+													% params => {
+														% effectiveUser => $editForUser[0],
+														% currentPage   => $pageNumber
+													% }
+												% )->fragment("prob$problemNumber");
+											% } else {
+												% $problemLink = $c->systemLink(
+													% url_for('gateway_quiz', setID => 'Undefined_Set', problemID => '1'),
+													% params => {
+														% effectiveUser  =>
+															% @editForUser == 1 ? $editForUser[0] : param('user'),
+														% problemSeed =>
+															% $problemToShow ? $problemToShow->problem_seed : '',
+														% sourceFilePath => $problemToShow && $problemToShow->source_file
+															% ? $problemToShow->source_file
+															% : $globalProblems->{$problemID}->source_file
+													% }
+												% )
+											% }
 										% } else {
 											% $problemLink = $c->systemLink(
-												% url_for('gateway_quiz', setID => 'Undefined_Set', problemID => '1'),
+												% url_for('problem_detail', setID => $setID, problemID => $problemID),
 												% params => {
-													% effectiveUser  =>
-														% @editForUser == 1 ? $editForUser[0] : param('user'),
-													% problemSeed => $problemToShow ? $problemToShow->problem_seed : '',
-													% sourceFilePath => $problemToShow && $problemToShow->source_file
-														% ? $problemToShow->source_file
-														% : $globalProblems->{$problemID}->source_file
+													% effectiveUser => @editForUser == 1 ? $editForUser[0] : param('user')
 												% }
 											% )
 										% }
-									% } else {
-										% $problemLink = $c->systemLink(
-											% url_for('problem_detail', setID => $setID, problemID => $problemID),
-											% params => {
-												% effectiveUser => @editForUser == 1 ? $editForUser[0] : param('user')
-											% }
-										% )
+										<%= link_to $problemLink,
+											class  => 'psd_view btn btn-secondary btn-sm'
+												. (@editForUser ? '' : ' px-1 px-sm-2'),
+											target => 'WW_View',
+											data   => {
+												bs_toggle    => 'tooltip',
+												bs_placement => 'top',
+												bs_title     => maketext('Open in New Window')
+											},
+											begin =%>
+											<i class="icon far fa-eye" aria-hidden="true"></i>
+											<span class="visually-hidden"><%= maketext('View') =%></span>
+										<% end =%>
 									% }
-									<%= link_to $problemLink,
-										class  => 'psd_view btn btn-secondary btn-sm',
-										target => 'WW_View',
-										data   => {
-											bs_toggle    => 'tooltip',
-											bs_placement => 'top',
-											bs_title     => maketext('Open in New Window')
-										},
-										begin =%>
-										<i class="icon far fa-eye" aria-hidden="true"></i>
-										<span class="visually-hidden"><%= maketext('View') =%></span>
-									<% end =%>
-								% }
-								% if ($authz->hasPermissions(param('user'), 'problem_grader')) {
-									<%= link_to $c->systemLink(url_for(
-											'instructor_problem_grader',
-										   	setID     => $setID,
-										   	problemID => $problemID
-										)),
-										class => "pdr_grader btn btn-secondary btn-sm",
-										data  => {
-											bs_toggle    => "tooltip",
-											bs_placement => "top",
-											bs_title     => maketext("Grade Problem")
-										},
-										begin =%>
-										<i class="icon fas fa-edit" aria-hidden="true"></i>
-										<span class="visually-hidden"><%= maketext('Grade') =%></span>
-									<% end =%>
-								% }
+									% if ($authz->hasPermissions(param('user'), 'problem_grader')) {
+										<%= link_to $c->systemLink(url_for(
+												'instructor_problem_grader',
+												setID     => $setID,
+												problemID => $problemID
+											)),
+											class => 'pdr_grader btn btn-secondary btn-sm'
+												. (@editForUser ? '' : ' px-1 px-sm-2'),
+											data  => {
+												bs_toggle    => "tooltip",
+												bs_placement => "top",
+												bs_title     => maketext("Grade Problem")
+											},
+											begin =%>
+											<i class="icon fas fa-edit" aria-hidden="true"></i>
+											<span class="visually-hidden"><%= maketext('Grade') =%></span>
+										<% end =%>
+									% }
+								</div>
 							</div>
-							<div class="col-md-2 col-3 col-form-label col-form-label-sm order-md-2 order-3 text-nowrap">
-								<%= $source_file_parts[0] =%>
-							</div>
-							<div class="<%= @editForUser ? 'col-md-6' : 'col-md-5' %> col-9 order-md-3 order-4">
-								<%= $source_file_parts[2] =%>
-								<%= hidden_field "problem_${problemID}_default_source_file" =>
-									$globalProblems->{$problemID}->source_file,
-									id => "problem_${problemID}_default_source_file" =%>
+							<div class="row col-12 <%= @editForUser ? 'col-lg-9 col-xl-10' : 'col-lg order-last' %>">
+								<div class="<%= @editForUser ? 'col-2 col-xxl-1' : 'col-3' %> col-form-label
+									col-form-label-sm text-nowrap text-lg-end">
+									<%= $source_file_parts[0] =%>
+								</div>
+								<div class="<%= @editForUser ? 'col-10 col-xxl-11' : 'col col-lg-9' %>">
+									<%= $source_file_parts[2] =%>
+									<%= hidden_field "problem_${problemID}_default_source_file" =>
+										$globalProblems->{$problemID}->source_file,
+										id => "problem_${problemID}_default_source_file" =%>
+								</div>
 							</div>
 							% if (!@editForUser) {
-								<div class="accordion col-md-1 col-2 d-flex align-items-center justify-content-end
-									order-md-last order-2">
-									<button class="accordion-button pdr_detail_collapse ps-0 w-auto"
-										type="button" aria-expanded="true" aria-controls="pdr_details_<%= $problemID %>"
+								<div class="accordion col-auto order-lg-last d-flex align-items-center justify-content-end">
+									<button class="accordion-button pdr_detail_collapse ps-0 w-auto" type="button"
+										aria-expanded="true" aria-controls="pdr_details_<%= $problemID %>"
 										aria-label="<%= maketext('Collapse Problem Details') %>"
 										data-bs-toggle="collapse" data-bs-target="#pdr_details_<%= $problemID %>"
 										data-expand-text="<%= maketext('Expand Problem Details') %>"
@@ -594,16 +631,17 @@
 						</div>
 						<div id="pdr_details_<%= $problemID %>" class="collapse show mt-1">
 							<div class="row">
-								<div class="col-md-6 d-flex flex-row order-md-first order-last">
-									% if (!@editForUser) {
-										<div class="form-check form-check-inline form-control-sm">
-											<%= check_box deleteProblem => $problemID, id =>
-												"delete-problem-$problemID", class => 'form-check-input' =%>
-											<%= label_for "delete-problem-$problemID" => maketext('Delete it?'),
-												class => 'form-check-label' =%>
-										</div>
-									% }
+								<div class="<%= @editForUser ? 'col-2 col-lg-3 col-xl-2'
+									: 'col-12 col-lg-6 col-xl-4 col-xxl-3' %> d-flex flex-row align-items-center">
 									% if (@editForUser != 1) {
+										% if (!@editForUser) {
+											<div class="form-check form-check-inline form-control-sm">
+												<%= check_box deleteProblem => $problemID, id =>
+													"delete-problem-$problemID", class => 'form-check-input' =%>
+												<%= label_for "delete-problem-$problemID" => maketext('Delete it?'),
+													class => 'form-check-label' =%>
+											</div>
+										% }
 										<div class="form-check form-check-inline form-control-sm">
 											<%= check_box markCorrect => $problemID,
 												id    => "problem.${problemID}.mark_correct",
@@ -614,15 +652,16 @@
 										</div>
 									% }
 								</div>
-								% if (@editForUser) {
-									<div class="<%= @editForUser ? 'col-md-6' : 'col-md-5'
-										%> offset-md-0 col-9 offset-3 font-sm order-md-last order-first">
-										<%= $source_file_parts[3] =%>
-									</div>
-								% }
+								<div class="<%= @editForUser ? 'col' : 'col-12 col-lg-6 col-xl-8 col-xxl-9' %> row">
+									% if (@editForUser) {
+										<div class="col-12 col-lg-10 col-xxl-11 offset-lg-2 offset-xxl-1 font-sm">
+											<%= $source_file_parts[3] =%>
+										</div>
+									% }
+								</div>
 							</div>
 							<div class="row">
-								<div class="col-lg-5">
+								<div class="col-12 col-lg-8">
 									<%= $c->fieldTable(
 										$userToShow, $setID, $problemID,
 										$globalProblems->{$problemID},
@@ -630,10 +669,8 @@
 										$setRecord->assignment_type
 									) =%>
 								</div>
-								<div class="font-sm col-lg-7">
-									% if ($repeatFile) {
-										<div class="alert alert-danger p-1 mb-2 fw-bold"><%= $repeatFile %></div>
-									% }
+								<div class="font-sm col-lg-4">
+									<div class="pdr_repeat_file_alert"></div>
 									<div class="rpc_render_area" id="psr_render_area_<%= $problemID %>">\
 										<% if ($error) { =%>\
 											<div class="alert alert-danger p-1 mb-0 fw-bold"><%= $error %></div>
@@ -647,7 +684,8 @@
 				% push @problemRows, $problemRow->();
 			% }
 			%
-			<ol id="psd_list" class="sortable-branch <%= @editForUser ? 'disable_renumber' : '' %>">
+			<ol id="psd_list" class="sortable-branch <%= @editForUser ? 'disable_renumber' : '' %>"
+				data-repeat-file-text="<%= maketext('This problem uses the same source file as number ~[_1~].') %>">
 				% if ($isJitarSet) {
 					% # If this is a jitar set then print nested lists.
 					% my $nestedIDHash = {};


### PR DESCRIPTION
When in the Set Details page, there will now be buttons on each problem to move a problem up/down in sequence. The mouse click-and-drag tool is still there, but these buttons give a keyboard accessible way to rearrange the problems.

If the set is a JITAR set, there are also buttons for indenting/outdenting problems.

Buttons are disabled when appropriate (like you can't move problem #1 up in the list).