### PR TITLE
announce remaining time for test at certain times

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.js
+++ b/htdocs/js/GatewayQuiz/gateway.js
@@ -10,6 +10,7 @@
 
 	// Gateway timer
 	const timerDiv = document.getElementById('gwTimer'); // The timer div element
+	const timerAnnounceDiv = document.getElementById('gwTimerAnnounce'); // Hidden live region for time announcements
 	let actuallySubmit = false; // This needs to be set to true to allow an actual submission.
 	// The 'Grade Test' submit button.
 	const submitAnswers =
@@ -58,8 +59,30 @@
 		bsToast.show();
 	};
 
+	// Only announce the remaining time via the hidden live region at these checkpoints (seconds remaining).
+	// Announcing every second would be overwhelming, so this only fires at the last few seconds (when the test is
+	// about to auto-submit) and at a handful of longer-interval checkpoints on the way down from 30 minutes.
+	const shouldAnnounceRemainingTime = (t) =>
+		(t >= 1 && t <= 5) ||
+		t === 15 ||
+		t === 30 ||
+		t === 60 ||
+		t === 300 ||
+		t === 900 ||
+		(t >= 1800 && t % 1800 === 0);
+
+	// Update the hidden live region with the current remaining time, either because it just hit one of the
+	// checkpoints above, or because force is true (used to always announce the initial remaining time on page load).
+	const announceRemainingTime = (remainingTime, force = false) => {
+		if (!timerAnnounceDiv || (!force && !shouldAnnounceRemainingTime(remainingTime))) return;
+		timerAnnounceDiv.textContent =
+			remainingTime >= 0
+				? `${remainingTimeString}${formatTime(remainingTime)}`
+				: `${remainingTimeString}00:00:00`;
+	};
+
 	// Update the timer
-	const updateTimer = () => {
+	const updateTimer = (forceAnnounce = false) => {
 		const dateNow = new Date();
 		const browserTime = Math.round(dateNow.getTime() / 1000);
 		const remainingTime = serverDueTime - browserTime + timeDelta;
@@ -72,6 +95,7 @@
 		}
 
 		if (!timerDiv.dataset.acting) {
+			announceRemainingTime(remainingTime, forceAnnounce);
 			// Check to see if we should put up a low time alert, or submit the test if
 			// the time is near the end of the grace period.
 			const alertStatus = sessionStorage.getItem('gatewayAlertStatus');
@@ -167,8 +191,9 @@
 				submitAnswers.click();
 			}
 		} else {
-			// Set the timer text and check alerts at page load.
-			updateTimer();
+			// Set the timer text and check alerts at page load. Force the initial remaining time to be announced
+			// via the live region, regardless of whether it happens to land on a normal announcement checkpoint.
+			updateTimer(true);
 
 			// Start the timer.
 			setInterval(updateTimer, 1000);

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -251,6 +251,7 @@
 			# '00:00:00' is a placeholder that is replaced by the actual time remaining via javascript.
 			maketext('Remaining time: [_1]', '00:00:00')
 		) =%>
+		<div id="gwTimerAnnounce" class="visually-hidden" role="status" aria-live="polite" aria-atomic="true"></div>
 	% }
 	%
 	% if ($timeLeft < 60 && $timeLeft > 0 && !$c->{can}{gradeUnsubmittedTest}


### PR DESCRIPTION
Even moreso than other recent PRs, this one could wait until after 2.21 is released and I'll retarget to develop. (That's true for all of these recent PRs, but this one seems like extra testing is warranted.)

An accessibility flag raised by Claude is that the countdown timer for a test is not announced. But of course we don't want it constantly announcing every tick of the clock. This makes it announce the timer at certain times. Those times are just what I came up with off the top of my head: at 1 second, 2 seconds, 3 seconds, 4 seconds, 5 seconds, 15 seconds, 30 seconds, 1 minute, 5 minutes, 15 minutes,  30 minutes, and every multiple of 30 minutes. Different times could be used.his 

Also, this probably clashes with the existing thing where there is a dialog that pops up to warn you that you only have 45 seconds left, etc. So more thought should be put into something like this working well with that feature (which is a better feature for sighted users).

This should be tested with a screen reader, and I've never had much success trying that myself.