### PR TITLE
put aria-sort attributes on tables in Instructor Tools

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -1261,6 +1261,33 @@ sub read_scoring_file ($c, $fileName) {
 	return parse_scoring_file($c->ce->{courseDirs}{scoring} . "/$fileName");
 }
 
+=item ariaSortAttr($c, $field)
+
+Returns the C<aria-sort> attribute (as C<< aria-sort="..." >>) to use on the
+C<< <th> >> for the sortable column C<$field> of a table, based on the
+C<primarySortField>/C<primarySortOrder>, C<secondarySortField>, and
+C<ternarySortField> values for the content generator C<$c>.  Returns an
+empty string if C<$field> is not currently a sort field for the table.
+
+Some content generators store these values directly on C<$c>, and others
+store them in the stash, so both locations are checked.
+
+=cut
+
+sub ariaSortAttr ($c, $field) {
+	my $primarySortField   = $c->{primarySortField}   // $c->stash->{primarySortField}   // '';
+	my $primarySortOrder   = $c->{primarySortOrder}   // $c->stash->{primarySortOrder}   // '';
+	my $secondarySortField = $c->{secondarySortField} // $c->stash->{secondarySortField} // '';
+	my $ternarySortField   = $c->{ternarySortField}   // $c->stash->{ternarySortField}   // '';
+
+	if ($primarySortField eq $field) {
+		return $primarySortOrder eq 'ASC' ? 'aria-sort="ascending"' : 'aria-sort="descending"';
+	} elsif ($secondarySortField eq $field || $ternarySortField eq $field) {
+		return 'aria-sort="other"';
+	}
+	return '';
+}
+
 =back
 
 =cut

--- a/templates/ContentGenerator/Instructor/JobManager.html.ep
+++ b/templates/ContentGenerator/Instructor/JobManager.html.ep
@@ -87,7 +87,7 @@
 							<i class="fa-solid fa-check-double" aria-hidden="true"></i>
 						<% end =%>
 					</th>
-					<th>
+					<th <%== $c->ariaSortAttr('id') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('Id') => '#', class => 'sort-header',
 								data => { sort_field => 'id' } =%>
@@ -95,44 +95,44 @@
 						</div>
 					</th>
 					% if ($courseID eq $ce->{admin_course_id}) {
-						<th>
+						<th <%== $c->ariaSortAttr('courseID') %>>
 							<div class="d-flex justify-content-between align-items-end gap-1">
 								<%= link_to maketext('Course Id') => '#', class => 'sort-header',
 									data => { sort_field => 'courseID' } =%>
 								<%= include 'ContentGenerator/Instructor/JobManager/sort_button',
-									field => 'course_id' =%>
+									field => 'courseID' =%>
 							</div>
 						</th>
 					% }
-					<th>
+					<th <%== $c->ariaSortAttr('task') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('Task') => '#', class => 'sort-header',
 								data => { sort_field => 'task' } =%>
 							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'task' =%>
 						</div>
 					</th>
-					<th>
+					<th <%== $c->ariaSortAttr('created') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('Created') => '#', class => 'sort-header',
 								data => { sort_field => 'created' } =%>
 							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'created' =%>
 						</div>
 					</th>
-					<th>
+					<th <%== $c->ariaSortAttr('started') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('Started') => '#', class => 'sort-header',
 								data => { sort_field => 'started' } =%>
 							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'started' =%>
 						</div>
 					</th>
-					<th>
+					<th <%== $c->ariaSortAttr('finished') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('Finished') => '#', class => 'sort-header',
 								data => { sort_field => 'finished' } =%>
 							<%= include 'ContentGenerator/Instructor/JobManager/sort_button', field => 'finished' =%>
 						</div>
 					</th>
-					<th>
+					<th <%== $c->ariaSortAttr('state') %>>
 						<div class="d-flex justify-content-between align-items-end gap-1">
 							<%= link_to maketext('State') => '#', class => 'sort-header',
 								data => { sort_field => 'state' } =%>

--- a/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList/set_list_table.html.ep
@@ -80,7 +80,8 @@
 						<% end =%>
 				</th>
 				% for (@$fieldNames) {
-					<th id="<%= $_ %>_header">
+					<th id="<%= $_ %>_header"
+						<%== !$c->{editMode} && $sortableFields->{$_} ? $c->ariaSortAttr($_) : '' %>>
 						% if (!$c->{editMode} && $sortableFields->{$_}) {
 							<div class="d-flex justify-content-between align-items-end gap-1">
 								<%= link_to $fieldHeaders{$_} => '#', class => 'sort-header',

--- a/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
+++ b/templates/ContentGenerator/Instructor/UserList/user_list.html.ep
@@ -14,7 +14,7 @@
 					<i class="fa-solid fa-check-double" aria-hidden="true"></i>
 				<% end =%>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('user_id') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Login Name') => '#', class => 'sort-header',
 						data => { sort_field => 'user_id' } =%>
@@ -23,14 +23,14 @@
 		</th>
 		<th><%= maketext('Login Status') %></th>
 		<th><%= maketext('Assigned Sets') %></th>
-		<th>
+		<th <%== $c->ariaSortAttr('first_name') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('First Name') => '#', class => 'sort-header',
 					data => { sort_field => 'first_name' } %>
 				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'first_name' =%>
 			</div>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('last_name') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Last Name') => '#', class => 'sort-header',
 					data => { sort_field => 'last_name' } =%>
@@ -38,14 +38,14 @@
 			</div>
 		</th>
 		<th><%= maketext('Email Link') %></th>
-		<th>
+		<th <%== $c->ariaSortAttr('student_id') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Student ID') => '#', class => 'sort-header',
 					data => { sort_field => 'student_id' } =%>
 				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'student_id' =%>
 			</div>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('status') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Status') => '#', class => 'sort-header',
 					data => { sort_field => 'status' } =%>
@@ -53,28 +53,28 @@
 			</div>
 		</th>
 		<th><%= maketext('Accommodation Time Factor') %></th>
-		<th>
+		<th <%== $c->ariaSortAttr('section') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Section') => '#', class => 'sort-header',
 					data => { sort_field => 'section' } =%>
 				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'section' =%>
 			</div>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('recitation') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Recitation') => '#', class => 'sort-header',
 					data => { sort_field => 'recitation' } =%>
 				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'recitation' =%>
 			</div>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('comment') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Comment') => '#', class => 'sort-header',
 					data => { sort_field => 'comment' } =%>
 				<%= include 'ContentGenerator/Instructor/UserList/sort_button', field => 'comment' =%>
 			</div>
 		</th>
-		<th>
+		<th <%== $c->ariaSortAttr('permission') %>>
 			<div class="d-flex justify-content-between align-items-end gap-1">
 				<%= link_to maketext('Permission Level') => '#', class => 'sort-header',
 					data => { sort_field => 'permission' } =%>


### PR DESCRIPTION
The set list and user list tables now put `aria-sort="ascending"/"descending"` on the `<th>` of the primary sort column. And `aria-sort="other"` on any other (seondary or ternary) currently-sorted column's `<th>`, since `aria-sort` can only represent one column as strictly ascending/descending at a time.