### PR TITLE
show links to sets even when you are not assigned to those sets

### DIFF
--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -486,6 +486,7 @@ sub links ($c) {
 	my $setID         = $c->stash('setID');
 	my $problemID     = $c->stash('problemID');
 	my $achievementID = $c->stash('achievementID');
+	my $globalSetID   = defined $setID ? $setID =~ s/,v\d+$//r : undef;
 
 	# Determine if navigation is restricted for this user.
 	my $restricted_navigation = $authen->was_verified && !$authz->hasPermissions($userID, 'navigation_allowed');
@@ -500,9 +501,13 @@ sub links ($c) {
 	if ($authen->was_verified) {
 		if (defined $setID && $db->existsUserSet($eUserID, $setID)) {
 			$problemID = undef unless (defined $problemID && $db->existsUserProblem($eUserID, $setID, $problemID));
-		} else {
+		} elsif (defined $globalSetID && $db->existsGlobalSet($globalSetID)) {
 			$setID     = undef;
-			$problemID = undef;
+			$problemID = undef unless (defined $problemID && $db->existsGlobalProblem($globalSetID, $problemID));
+		} else {
+			$setID       = undef;
+			$globalSetID = undef;
+			$problemID   = undef;
 		}
 	}
 
@@ -543,7 +548,8 @@ sub links ($c) {
 		eUserID               => $eUserID,
 		urlUserID             => $c->stash('userID'),
 		setID                 => $setID,
-		prettySetID           => format_set_name_display($setID // ''),
+		globalSetID           => $globalSetID,
+		prettySetID           => format_set_name_display($setID // $globalSetID // ''),
 		problemID             => $problemID,
 		prettyProblemID       => $prettyProblemID,
 		achievementID         => $achievementID,

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -125,14 +125,14 @@
 			% # Sets Manager
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_list') %></li>
 			% # Editor link.  Only shown for non-versioned sets
-			% if (defined $setID && $setID !~ /,v\d+$/) {
+			% if (defined $globalSetID || defined $setID && $setID !~ /,v\d+$/) {
 				<li class="list-group-item nav-item">
 					<ul class="nav flex-column">
 						<li class="nav-item">
 							<%= $makelink->(
 								'instructor_set_detail',
 								text       => $prettySetID,
-								captures   => { setID => $setID },
+								captures   => { setID => $globalSetID // $setID },
 								link_attrs => { dir => 'ltr' }
 							); %>
 						</li>
@@ -162,7 +162,7 @@
 									$c->tag('span', dir => 'ltr', $prettySetID),
 									$prettyProblemID
 								)),
-								captures => { setID => $setID, problemID => $problemID },
+								captures => { setID => $setID // $globalSetID, problemID => $problemID },
 								target   => 'WW_Editor'
 							) %>
 						</li>
@@ -177,7 +177,7 @@
 								text => param('file_type') eq 'set_header'
 									? b(maketext('[_1]: Set Header',      $c->tag('span', dir => 'ltr', $prettySetID)))
 									: b(maketext('[_1]: Hardcopy Header', $c->tag('span', dir => 'ltr', $prettySetID))),
-								captures          => { setID => $setID, problemID => 0 },
+								captures          => { setID => $setID // $globalSetID, problemID => 0 },
 								systemlink_params => { file_type => param('file_type') },
 								target            => 'WW_Editor'
 							) %>
@@ -221,14 +221,14 @@
 			% # Statistics
 			<li class="list-group-item nav-item">
 				<%= $makelink->('instructor_statistics') %>
-				% if (defined $setID) {
+				% if (defined $setID || defined $globalSetID) {
 					<ul class="nav flex-column">
 						<li class="nav-item" dir="ltr">
 							<%= $makelink->(
 								'instructor_set_statistics',
 								# Make sure a versioned set id is not used for the statistics link.
 								text     => $prettySetID =~ s/,v\d+$//r,
-								captures => { setID => $setID =~ s/,v\d+$//r }
+								captures => { setID => $globalSetID // $setID =~ s/,v\d+$//r }
 							) %>
 						</li>
 						% if (defined $problemID) {
@@ -239,7 +239,7 @@
 											'instructor_problem_statistics',
 											text     => maketext('Problem [_1]', $prettyProblemID),
 											captures => {
-												setID     => $setID =~ s/,v\d+$//r,
+												setID     => $globalSetID // $setID =~ s/,v\d+$//r,
 												problemID => $problemID
 											}
 										) =%>
@@ -252,7 +252,7 @@
 			</li>
 			% # Student Progress
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_progress') %>
-				% if ($userID ne $eUserID || defined $setID || defined $urlUserID) {
+				% if ($userID ne $eUserID || defined $setID || defined $globalSetID || defined $urlUserID) {
 					<ul class="nav flex-column">
 						% if (defined $urlUserID) {
 							<li class="nav-item">
@@ -276,13 +276,13 @@
 								) %>
 							</li>
 						% }
-						% if (defined $setID) {
+						% if (defined $setID || defined $globalSetID) {
 							<li class="nav-item" dir="ltr">
 								<%= $makelink->(
 									'instructor_set_progress',
 									# Make sure a versioned set id is not used for the progress link.
 									text     => $prettySetID =~ s/,v\d+$//r,
-									captures => { setID => $setID =~ s/,v\d+$//r },
+									captures => { setID => $globalSetID // $setID =~ s/,v\d+$//r },
 								) %>
 							</li>
 						% }


### PR DESCRIPTION
Suppose you are an instructor and there is a set that is not assigned to you. If you go to the Sets Manager, and go to the Set Details page for that set, you won't see links to that set in the side navigation (under Sets Manager, Statistics, and Student Progress). This changes it so that you do. For example, it facilitates going to the Statistics page for that set even though it's not assigned to you as a user.