### PR TITLE
Updates to the PG problem editor PGML conversion for corresponding changes to PG.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -272,15 +272,12 @@
 			.then((data) => {
 				if (data.error) throw new Error(data.error);
 				if (!data.result_data) throw new Error('An invalid response was received.');
-				if (data.result_data.errors) {
+				if (data.result_data.error) {
 					renderArea.innerHTML =
 						'<div class="alert alert-danger p-1 m-2">' +
-						'<p class="fw-bold">PGML conversion errors:</p>' +
-						'<pre><code>' +
-						data.result_data.errors
-							.replace(/^[\s\S]*Begin Error Output Stream\n\n/, '')
-							.replace(/\n\d*: To save a full \.LOG file rerun with -g/, '') +
-						'</code></pre>';
+						'<p class="fw-bold">PGML conversion error:</p>' +
+						data.result_data.error +
+						'</div>';
 
 					showMessage('Errors occurred when converting code to PGML.', false);
 					return;

--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -272,6 +272,19 @@
 			.then((data) => {
 				if (data.error) throw new Error(data.error);
 				if (!data.result_data) throw new Error('An invalid response was received.');
+				if (data.result_data.errors) {
+					renderArea.innerHTML =
+						'<div class="alert alert-danger p-1 m-2">' +
+						'<p class="fw-bold">PGML conversion errors:</p>' +
+						'<pre><code>' +
+						data.result_data.errors
+							.replace(/^[\s\S]*Begin Error Output Stream\n\n/, '')
+							.replace(/\n\d*: To save a full \.LOG file rerun with -g/, '') +
+						'</code></pre>';
+
+					showMessage('Errors occurred when converting code to PGML.', false);
+					return;
+				}
 				if (request_object.pgCode === data.result_data.pgmlCode) {
 					showMessage('There were no changes to the code.', true);
 				} else {
@@ -279,6 +292,7 @@
 					else document.getElementById('problemContents').value = data.result_data.pgmlCode;
 					saveTempFile();
 					showMessage('Successfully converted code to PGML', true);
+					if (!(renderArea.firstChild instanceof HTMLIFrameElement)) render();
 				}
 			})
 			.catch((err) => showMessage(`Error: ${err?.message ?? err}`));

--- a/lib/WebworkWebservice/ProblemActions.pm
+++ b/lib/WebworkWebservice/ProblemActions.pm
@@ -159,13 +159,11 @@ sub tidyPGCode {
 
 sub convertCodeToPGML {
 	my ($invocant, $self, $params) = @_;
-	my $code = $params->{pgCode};
 
 	return {
-		ra_out => { pgmlCode => convertToPGML($code) },
+		ra_out => convertToPGML($params->{pgCode}),
 		text   => 'Converted to PGML'
 	};
-
 }
 
 sub runPGCritic {


### PR DESCRIPTION
This is built on top of #3046 which basically sets up the PG problem editor for the initial changes on the PG side.

The plurality of the `error` key in the response was removed as was done on the PG side since there is only ever one error.
    
Also, remove the `<pre><code>` wrapper.  That is not right for this type of message.

