### PR TITLE
Workaround for issue with MathJax 4 in RTL contexts

### DIFF
--- a/htdocs/js/MathJaxConfig/mathjax-config.js
+++ b/htdocs/js/MathJaxConfig/mathjax-config.js
@@ -5,7 +5,33 @@ if (!window.MathJax) {
 		tex: { packages: { '[+]': webworkConfig?.showMathJaxErrors ? [] : ['noerrors'] } },
 		loader: {
 			load: ['input/asciimath', '[tex]/noerrors', '[bs-color-scheme]'],
-			paths: { 'bs-color-scheme': webworkConfig?.mathJaxBSColorSchemeUrl ?? './bs-color-scheme.js' }
+			paths: { 'bs-color-scheme': webworkConfig?.mathJaxBSColorSchemeUrl ?? './bs-color-scheme.js' },
+			'output/chtml': {
+				ready() {
+					const { CHTML } = MathJax._.output.chtml_ts;
+					Object.assign(CHTML.prototype, {
+						_createNode_: CHTML.prototype.createNode,
+						createNode() {
+							const node = this._createNode_();
+							this.adaptor.setAttribute(node, 'dir', 'ltr');
+							return node;
+						}
+					});
+				}
+			},
+			'output/svg': {
+				ready() {
+					const { SVG } = MathJax._.output.svg_ts;
+					Object.assign(SVG.prototype, {
+						_createNode_: SVG.prototype.createNode,
+						createNode() {
+							const node = this._createNode_();
+							this.adaptor.setAttribute(node, 'dir', 'ltr');
+							return node;
+						}
+					});
+				}
+			}
 		},
 		startup: {
 			ready() {


### PR DESCRIPTION
MathJax 4.1.3 does not display math properly when inside an RTL setting, and that version will be in WeBWorK 2.21 (unless MathJax 4.2 is released and a transition is made before the release of 2.21).

The problem occurs in both SVG an CHTML output.

Things were fine with MathJax 3.

@dpvc provided the workaround added here in https://github.com/mathjax/MathJax/issues/3589 .

For the future, MathJax 4.2 will fix the issue by adding a `dir="ltr"` attribute to the `mjx-container` element. That is in https://github.com/mathjax/MathJax-src/pull/1526
so this change can be removed WeBWorK transitions to MathJax 4.2.

The issue can be seen using the following sample problem. Pay attention to how the inline math renders in the Hebrew portion which is in a DIV set to `rtl`.

---

```
DOCUMENT();

loadMacros( 'PGstandard.pl', 'PGML.pl');

BEGIN_PGML

When [` a \ne 0 `], there are two solutions to [` ax^2 + bx + c = 0 `] and they are
[```
  x = {-b \pm \sqrt{b^2-4ac} \over 2a}.
```]

[@ openDiv( { 'dir' => 'rtl' } )  @]*
כאשר [` a \ne 0 `]
יש 2 פתרונות למשוואה
[` ax^2 + bx + c = 0 `]
והם
[```
  x = {-b \pm \sqrt{b^2-4ac} \over 2a}
```]

[@ closeDiv() @]*
END_PGML
ENDDOCUMENT();
```

Here is an images of the issue when this problem is rendered before the change in this PR. 
<img width="566" height="274" alt="MathJax-4-RTL-issue" src="https://github.com/user-attachments/assets/03995202-b094-4382-9035-732df0cb1dec" />

Once the patch is applied, the two portions of inline math will display properly.
