### PR TITLE
Net::SAML2 0.86 security fix now requires cacert

### DIFF
--- a/lib/WeBWorK/Authen/Saml2.pm
+++ b/lib/WeBWorK/Authen/Saml2.pm
@@ -73,7 +73,8 @@ sub do_verify ($self) {
 			->handle_response($c->stash->{saml2}{samlResp});
 		my $assertion = Net::SAML2::Protocol::Assertion->new_from_xml(
 			xml      => $decodedXml,
-			key_file => $self->spKeyFile->to_string
+			key_file => $self->spKeyFile->to_string,
+			cacert   => $idpCertificateFile->to_string
 		);
 
 		# Get the database key containing the authReqId that was generated before redirecting to the identity provider.


### PR DESCRIPTION
Net::SAML2 0.86 is a security release that fixes CVE-2026-18092, CVE-2026-18089.

CVE-2026-18089 fix requires adding the (previously optional) cacert param to the Net::SAML2::Protocol::Assertion->new_from_xml call. This ensures that if there are embedded certificates in the assertions, they are verified to be trusted by the IdP before being used.