### PR TITLE
Lock the iframe-resizer version to exactly version 4.4.2.

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -11,7 +11,7 @@
 				"@openwebwork/pg-codemirror-editor": "^0.0.10",
 				"bootstrap": "^5.3.8",
 				"flatpickr": "^4.6.13",
-				"iframe-resizer": "^4.4.2",
+				"iframe-resizer": "4.4.2",
 				"jquery": "^4.0.0",
 				"jquery-ui-dist": "^1.13.3",
 				"luxon": "^3.7.2",
@@ -1436,11 +1436,11 @@
 			}
 		},
 		"node_modules/iframe-resizer": {
-			"version": "4.4.5",
-			"resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.5.tgz",
-			"integrity": "sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==",
+			"version": "4.4.2",
+			"resolved": "https://registry.npmjs.org/iframe-resizer/-/iframe-resizer-4.4.2.tgz",
+			"integrity": "sha512-2SupFCq9V9osWac4q+PodF0E9QdWY5A9VdCpKrrE7HlDrcIsaTp7D6k14mkGXWoWMS9jCavYusik25wTc0YB2Q==",
 			"hasInstallScript": true,
-			"license": "MIT",
+			"license": "GPL-3.0",
 			"engines": {
 				"node": ">=0.8.0"
 			},

--- a/htdocs/package.json
+++ b/htdocs/package.json
@@ -17,7 +17,7 @@
 		"@openwebwork/pg-codemirror-editor": "^0.0.10",
 		"bootstrap": "^5.3.8",
 		"flatpickr": "^4.6.13",
-		"iframe-resizer": "^4.4.2",
+		"iframe-resizer": "4.4.2",
 		"jquery": "^4.0.0",
 		"jquery-ui-dist": "^1.13.3",
 		"luxon": "^3.7.2",


### PR DESCRIPTION
When I updated dependencies the `package-lock.json` file switched to version 4.4.5 of `iframe-resizer` which has console warnings. This was unintentional.  So specify exactlay version 4.4.2 without the prefix of `^` to lock the version.