### PR TITLE
Show both course id and the archive file when they differ when listing course archives in the admin course.

### DIFF
--- a/lib/WeBWorK/Utils/CourseManagement.pm
+++ b/lib/WeBWorK/Utils/CourseManagement.pm
@@ -111,14 +111,15 @@ sub listCourses {
 =item listArchivedCourses($ce)
 
 Lists the courses which have been archived (end in .tar.gz). The courses found
-are returned as a hash whose keys are the course ids and the values are
-references to hashes containing the C<filename> (the basename of the file
-including the .tar.gz extension) and file C<size>. For example,
+are returned as a hash whose keys are the filenames (the basename of the file
+including the .tar.gz extension) and the values are references to hashes
+containing the C<courseID>, file C<size>, and C<lastModified> time. For example,
 
     {
-        myTestCourse => {
-            filename => 'myTestCourse.tar.gz',
-            size     => '605 KB'
+        'myTestCourse.tar.gz' => {
+            courseID     => 'myTestCourse',
+            size         => '605 KB',
+            lastModified => 1778667472
         }
     }
 
@@ -134,23 +135,19 @@ sub listArchivedCourses {
 	my $archiveDataFile = $archivesDir->child('archive-cache.json');
 	my $archiveData     = eval { decode_json($archiveDataFile->slurp) } || {};
 
-	my $archiveDataUpdated = 0;
+	my %updatedArchiveData;
 	my %return;
 	for (@$archives) {
 		my $basename     = $_->basename;
 		my $lastModified = $_->stat->mtime;
 
 		if ($archiveData->{$basename} && $archiveData->{$basename}{lastModified} >= $lastModified) {
-			$return{ $archiveData->{$basename}{courseID} } = {
-				filename => $basename,
-				size     => $archiveData->{$basename}{size}
-				}
-				if defined $archiveData->{$basename}{courseID};
+			$updatedArchiveData{$basename} = $archiveData->{$basename};
+			$return{$basename} = $updatedArchiveData{$basename} if defined $archiveData->{$basename}{courseID};
 			next;
 		}
 
-		$archiveDataUpdated = 1;
-		$archiveData->{$basename} = { lastModified => $lastModified };
+		$updatedArchiveData{$basename} = { lastModified => $lastModified };
 
 		my $archive = Archive::Tar->new($_);
 		my %top_level;
@@ -164,20 +161,12 @@ sub listArchivedCourses {
 		}
 		my ($currCourseID) = keys %top_level;
 
-		$archiveData->{$basename}{courseID} = $currCourseID;
-		$archiveData->{$basename}{size}     = getHumanReadableFileSize($_);
-		$return{$currCourseID}              = { filename => $basename, size => $archiveData->{$basename}{size} };
+		$updatedArchiveData{$basename}{courseID} = $currCourseID;
+		$updatedArchiveData{$basename}{size}     = getHumanReadableFileSize($_);
+		$return{$basename}                       = $updatedArchiveData{$basename};
 	}
 
-	my %archives = map { $_->basename => 1 } @$archives;
-	for (keys %$archiveData) {
-		unless ($archives{$_}) {
-			delete $archiveData->{$_};
-			$archiveDataUpdated = 1;
-		}
-	}
-
-	$archiveDataFile->spew(encode_json($archiveData)) if $archiveDataUpdated;
+	$archiveDataFile->spew(encode_json(\%updatedArchiveData));
 
 	return %return;
 }

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -65,7 +65,11 @@
 	<ol>
 		% my %courseArchives = listArchivedCourses($ce);
 		% for (sort { lc($a) cmp lc($b) } keys %courseArchives) {
-			<li><%= "$courseArchives{$_}{courseID} ($_, $courseArchives{$_}{size})" %></li>
+			<li>
+				<%= "$courseArchives{$_}{courseID} ("
+					. ($courseArchives{$_}{courseID} eq ($_ =~ s/\.tar\.gz$//ir) ? '' : "$_, ")
+					. "$courseArchives{$_}{size})" %>
+			</li>
 		% }
 	</ol>
 % }

--- a/templates/ContentGenerator/CourseAdmin.html.ep
+++ b/templates/ContentGenerator/CourseAdmin.html.ep
@@ -65,7 +65,7 @@
 	<ol>
 		% my %courseArchives = listArchivedCourses($ce);
 		% for (sort { lc($a) cmp lc($b) } keys %courseArchives) {
-			<li><%= "$_ ($courseArchives{$_}{size})" %></li>
+			<li><%= "$courseArchives{$_}{courseID} ($_, $courseArchives{$_}{size})" %></li>
 		% }
 	</ol>
 % }

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -20,9 +20,11 @@
 					class                => 'col-md-2 pe-0 col-form-label fw-bold' =%>
 				<div class="col-lg-9 col-md-8">
 					<%= select_field
-						unarchive_courseID =>
-						[ map { [ "$courseArchives{$_}{courseID} ($_, $courseArchives{$_}{size})" => $_ ] }
-							@archiveFiles ],
+						unarchive_courseID => [
+							map { [ "$courseArchives{$_}{courseID} ("
+								. ($courseArchives{$_}{courseID} eq ($_ =~ s/\.tar\.gz$//ir) ? '' : "$_, ")
+								. "$courseArchives{$_}{size})" => $_ ] } @archiveFiles
+						],
 						id    => 'unarchive_courseID',
 						class => 'form-select',
 						size  => 10 =%>

--- a/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/unarchive_course_form.html.ep
@@ -4,9 +4,9 @@
 %
 % # Find courses which have been archived.
 % my %courseArchives = listArchivedCourses($ce);
-% my @courseIDs      = sort { lc($a) cmp lc($b) } keys %courseArchives;
+% my @archiveFiles   = sort { lc($a) cmp lc($b) } keys %courseArchives;
 %
-% if (@courseIDs) {
+% if (@archiveFiles) {
 	<%= form_for current_route, method => 'POST', begin =%>
 		<%= $c->hidden_authen_fields =%>
 		<%= $c->hidden_fields('subDisplay') =%>
@@ -21,7 +21,8 @@
 				<div class="col-lg-9 col-md-8">
 					<%= select_field
 						unarchive_courseID =>
-						[ map { [ "$_ ($courseArchives{$_}{size})" => $courseArchives{$_}{filename} ] } @courseIDs ],
+						[ map { [ "$courseArchives{$_}{courseID} ($_, $courseArchives{$_}{size})" => $_ ] }
+							@archiveFiles ],
 						id    => 'unarchive_courseID',
 						class => 'form-select',
 						size  => 10 =%>


### PR DESCRIPTION
This is an alternate to #3114.