### PR TITLE
Add a configuration option to provide a custom logout URL for SAML2 authentication.

### DIFF
--- a/conf/authen_saml2.conf.dist
+++ b/conf/authen_saml2.conf.dist
@@ -134,4 +134,11 @@ $saml2{sp}{private_key_file} = 'docker-config/idp/certs/saml.pem';
 # session for the user with the identity provider.
 $saml2{sp}{enable_sp_initiated_logout} = 0;
 
+# The URL of the identity provider's single logout service is normally read from
+# the SingleLogoutService location in the identity provider's metadata.  If the
+# identity provider's metadata does not advertise a SingleLogoutService, then
+# this can be set to a custom logout URL to use instead. This is only used if
+# $saml2{sp}{enable_sp_initiated_logout} is set to 1.
+#$saml2{sp}{logout_url} = 'https://idp.example.edu/saml2/logout';
+
 1;

--- a/lib/WeBWorK/Authen/Saml2.pm
+++ b/lib/WeBWorK/Authen/Saml2.pm
@@ -277,8 +277,10 @@ sub logout_user ($self) {
 		return unless $idp;
 
 		my $logoutReq = $self->sp->logout_request(
-			$idp->slo_url(BINDING_HTTP_REDIRECT), $self->session->{saml2_nameid},
-			$idp->format || undef,                $self->session->{saml2_session}
+			$ce->{saml2}{sp}{logout_url} || $idp->slo_url(BINDING_HTTP_REDIRECT),
+			$self->session->{saml2_nameid},
+			$idp->format || undef,
+			$self->session->{saml2_session}
 		);
 
 		debug('Redirecting user to the identity provider for logout');


### PR DESCRIPTION
If a SAML2 identity provider does not provide a logout URL in its metadata, and yet one is available for the identity provider, then the `$saml2{sp}{logout_url}` option can be set to that logout URL, and it will be used instead of the logout URL from the metadata.

This was requested in issue #3102.