### PR TITLE
Fix an obvious issue with the LMS Date Sync form in the Sets Manager.

### DIFF
--- a/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetList.html.ep
@@ -84,7 +84,7 @@
 	%
 	% for my $actionID (@$formsToShow) {
 		% next
-			% if $actionID eq 'lms_roster_sync'
+			% if $actionID eq 'lms_date_sync'
 			% && (!$ce->{LTIVersion}
 				% || $ce->{LTIVersion} ne 'v1p3'
 				% || $ce->{LTIGradeMode} ne 'homework'


### PR DESCRIPTION
The date synchronization form id is `lms_date_sync`, not `lms_roster_sync`.  This clearly makes the LMS Date Synchronization be always shown regardless of the conditions for which it is not supposed be shown.