### PR TITLE
Do not delete a course's `html_temp` directory when archiving it.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1011,15 +1011,6 @@ sub do_archive_course ($c) {
 
 	my $ce2 = WeBWorK::CourseEnvironment->new({ courseName => $archive_courseID });
 
-	# Remove course specific temp files before archiving, but don't delete the temp directory itself.
-	remove_tree($ce2->{courseDirs}{html_temp}, { keep_root => 1 });
-
-	# Remove the original default tmp directory if it exists
-	my $orgDefaultCourseTempDir = "$ce2->{courseDirs}{html}/tmp";
-	if (-d $orgDefaultCourseTempDir) {
-		remove_tree($orgDefaultCourseTempDir);
-	}
-
 	my $message = eval { archiveCourse(courseID => $archive_courseID, ce => $ce2); };
 
 	if ($@) {


### PR DESCRIPTION
There is no reason to delete this directory when a course is archived. It cannot be inside the course directory, since the webwork2 app does not serve these files from there, and so will not be contained in the archive in any case.  So simply delete the line that does this deletion. It is not needed.

Also remove the code for deleting some old "original default tmp" directory.  If you still have such a directory in your course it is because you have restored some really old course archive file that has this directory, and it is time to upgrade the archives you are using. There is a statute of limitations on things like this. This obsolete code needs to go.

This addresses issue #3048.