### PR TITLE
Add a missing `debug` import in `lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm`.

### DIFF
--- a/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
+++ b/lib/WeBWorK/Authen/LTIAdvantage/SubmitGrade.pm
@@ -22,7 +22,7 @@ use Math::Random::Secure qw(irand);
 use Digest::SHA          qw(sha256_hex);
 use Time::HiRes;
 
-use WeBWorK::Debug;
+use WeBWorK::Debug                      qw(debug);
 use WeBWorK::Utils                      qw(wwRound);
 use WeBWorK::Utils::Sets                qw(grade_all_sets);
 use WeBWorK::Authen::LTI::GradePassback qw(getSetPassbackScore);

--- a/lib/WeBWorK/File/SetDef.pm
+++ b/lib/WeBWorK/File/SetDef.pm
@@ -9,7 +9,7 @@ WeBWorK::File::SetDef - utilities for dealing with set definition files.
 
 use Carp;
 
-use WeBWorK::Debug;
+use WeBWorK::Debug             qw(debug);
 use WeBWorK::Utils             qw(x);
 use WeBWorK::Utils::DateTime   qw(formatDateTime getDefaultSetDueDate parseDateTime timeToSec);
 use WeBWorK::Utils::Files      qw(surePathToFile);


### PR DESCRIPTION
This was missed in #3126.  The `WeBWorK::Debug` package no longer exports the `debug` method by default, and it must be explicitly imported where needed.