### PR TITLE
Remove `Class::Tiny` from the PG shared modules.

### DIFF
--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -1218,7 +1218,7 @@ ${pg}{modules} = [
 	[qw(Locale::Maketext)],
 	[qw(WeBWorK::PG::Localize)],
 	[qw(Mojo::JSON)],
-	[qw(Rserve Class::Tiny IO::Handle)],
+	[qw(Rserve IO::Handle)],
 	[qw(DragNDrop)],
 	[qw(Types::Serialiser)],
 	[qw(strict)],


### PR DESCRIPTION
This used to be needed for R serve, but is not anymore.  When the R serve code was rewritten, I removed this dependency and removed it from the `pg_config.dist.yml` file for PG, but this was not removed here.