### PR TITLE
Fix a new npm security vulnerability. (hotfix of #3139)

### DIFF
--- a/htdocs/package-lock.json
+++ b/htdocs/package-lock.json
@@ -1533,9 +1533,9 @@
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.17",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-			"integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+			"version": "3.3.18",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+			"integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
 			"dev": true,
 			"funding": [
 				{


### PR DESCRIPTION
This is simply the result of executing `npm audit fix`.  It just updated `nanoid` to version 3.3.18 from 3.3.17.