### PR TITLE
Fix bug in chipping_away achievement. (Hotfix of #3137)

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/chipping_away.at
+++ b/courses.dist/modelCourse/templates/achievements/chipping_away.at
@@ -3,9 +3,9 @@
 #
 # See [templates]/achievements/achievement_readme.txt for details.
 
-# If the set id doest equal the id of the last set then set
+# If the set id doesn't equal the id of the last set then set
 # *this* set as the last set, and set the start time.
-if ($problem->set_id ne $localData->{last_set}) {
+if (!$localData->{last_set} || $problem->set_id ne $localData->{last_set}) {
 	$localData->{last_set}   = $problem->set_id;
 	$localData->{start_time} = time;
 	return 0;


### PR DESCRIPTION
`$localData->{last_set}` is used in a `ne` comparison but could be undefined. Ensure it is defined before testing it.