### PR TITLE
Improve the width of the field table on the set detail page. (hotfix of #3142)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -761,7 +761,7 @@ sub fieldTable ($c, $userID, $setID, $problemID, $globalRecord, $userRecord = un
 		);
 	}
 
-	unshift @$rows, $c->tag('col') x 2, $c->tag('col', class => 'w-75'), $forOneUser ? $c->tag('col') : '';
+	unshift @$rows, $c->tag('col') x ($forOneUser ? 4 : 3);
 
 	return $c->tag(
 		'table',

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -661,7 +661,11 @@
 								</div>
 							</div>
 							<div class="row">
-								<div class="col-12 col-lg-8">
+								<div
+									class="col-12<%=
+										@editForUser ? ' col-lg-7 col-xxl-6' : ' col-lg-6 col-xl-5 col-xxl-4'
+									%>"
+								>
 									<%= $c->fieldTable(
 										$userToShow, $setID, $problemID,
 										$globalProblems->{$problemID},
@@ -669,7 +673,11 @@
 										$setRecord->assignment_type
 									) =%>
 								</div>
-								<div class="font-sm col-lg-4">
+								<div
+									class="font-sm col-12<%=
+										@editForUser ? ' col-lg-5 col-xxl-6' : ' col-lg-6 col-xl-7 col-xxl-8'
+									%>"
+								>
 									<div class="pdr_repeat_file_alert"></div>
 									<div class="rpc_render_area" id="psr_render_area_<%= $problemID %>">\
 										<% if ($error) { =%>\


### PR DESCRIPTION
Remove the `w-75` class from the third column in that table.  That width specifier is not right for a column in this table, and results in the column being to wide.  The width of the column is good on its own.

Also, for the problem field tables switch to using `col-lg-6 col-xl-5 col-xxl-4` for the field table and `col-lg-6 col-xl-7 col-xxl-8` the problem rendering area when editing a set for all users, and use `col-lg-7 col-xxl-6`` for the field table and `col-lg-5 col-xxl6` for the problem rendering area when editing the set for users.  This was always `col-lg-5` and `col-lg-7` prior to WeBWorK 2.21, and was switched to always `col-lg-8` and `col-lg-4` in #3090 for WeBWorK 2.21. The pre 2.21 setting often made the field table to narrow, but the 2.21 setting went to far makes it too wide and leaves to small of a width for problem rendering.