### PR TITLE
Update `WWSafe.pm`.

### DIFF
--- a/lib/WeBWorK/WWSafe.pm
+++ b/lib/WeBWorK/WWSafe.pm
@@ -3,9 +3,9 @@ package WeBWorK::WWSafe;
 
 #use 5.003_11;
 use 5.12.0;
-use strict;
-use utf8;
-$WeBWorK::WWSafe::VERSION = "2.16";
+use Scalar::Util qw(reftype refaddr blessed);
+
+$WeBWorK::WWSafe::VERSION = "2.47";
 
 # *** Don't declare any lexicals above this point ***
 #
@@ -23,16 +23,30 @@ sub lexless_anon_sub {
 	# Uses a closure (on $__ExPr__) to pass in the code to be executed.
 	# (eval on one line to keep line numbers as expected by caller)
 	eval sprintf
-		'package %s; %s strict; sub { @_=(); eval q[my $__ExPr__;] . $__ExPr__; }',
-		$_[0], $_[1] ? 'use' : 'no';
+		'package %s; %s sub { @_=(); local *SIG; eval q[my $__ExPr__;] . $__ExPr__; }',
+		$_[0], $_[1] ? 'use strict;' : 'no strict;';
 }
 
+use strict;
 use Carp;
 
 BEGIN {
 	eval q{
     use Carp::Heavy;
 };
+}
+
+use B ();
+
+BEGIN {
+	no strict 'refs';
+	if (defined &B::sub_generation) {
+		*sub_generation = \&B::sub_generation;
+	} else {
+		# fake sub generation changing for perls < 5.8.9
+		my $sg;
+		*sub_generation = sub { ++$sg };
+	}
 }
 
 use Opcode 1.01, qw(
@@ -42,6 +56,25 @@ use Opcode 1.01, qw(
 );
 
 *ops_to_opset = \&opset;    # Temporary alias for old Penguins
+
+# Regular expressions and other unicode-aware code may need to call
+# utf8->SWASHNEW (via perl's utf8.c).  That will fail unless we share the
+# SWASHNEW method.
+# Sadly we can't just add utf8::SWASHNEW to $default_share because perl's
+# utf8.c code does a fetchmethod on SWASHNEW to check if utf8.pm is loaded,
+# and sharing makes it look like the method exists.
+# The simplest and most robust fix is to ensure the utf8 module is loaded when
+# Safe is loaded. Then we can add utf8::SWASHNEW to $default_share.
+require utf8;
+# we must ensure that utf8_heavy.pl, where SWASHNEW is defined, is loaded
+# but without depending on too much knowledge of that implementation detail.
+# This code (//i on a unicode string) should ensure utf8 is fully loaded
+# and also loads the ToFold SWASH, unless things change so that these
+# particular code points don't cause it to load.
+# (Swashes are cached internally by perl in PL_utf8_* variables
+# independent of being inside/outside of Safe. So once loaded they can be)
+do { my $a = pack('U', 0x100); $a =~ m/\x{1234}/; $a =~ tr/\x{1234}//; };
+# now we can safely include utf8::SWASHNEW in $default_share defined below.
 
 my $default_root = 0;
 # share *_ and functions defined in universal.c
@@ -62,7 +95,26 @@ my $default_share = [
 		&utf8::downgrade
 		&utf8::native_to_unicode
 		&utf8::unicode_to_native
+		&utf8::SWASHNEW
+		$version::VERSION
+		$version::CLASS
+		$version::STRICT
+		$version::LAX
+		@version::ISA
 	],
+	(
+		$] >= 5.04000
+			&& qw[
+			&UNIVERSAL::import
+			&UNIVERSAL::unimport
+			]
+	),
+	(
+		$] < 5.010
+			&& qw[
+			&utf8::SWASHGET
+			]
+	),
 	(
 		$] >= 5.008001
 			&& qw[
@@ -76,15 +128,6 @@ my $default_share = [
 			&re::regname
 			&re::regnames
 			&re::regnames_count
-			&Tie::Hash::NamedCapture::FETCH
-			&Tie::Hash::NamedCapture::STORE
-			&Tie::Hash::NamedCapture::DELETE
-			&Tie::Hash::NamedCapture::CLEAR
-			&Tie::Hash::NamedCapture::EXISTS
-			&Tie::Hash::NamedCapture::FIRSTKEY
-			&Tie::Hash::NamedCapture::NEXTKEY
-			&Tie::Hash::NamedCapture::SCALAR
-			&Tie::Hash::NamedCapture::flags
 			&UNIVERSAL::DOES
 			&version::()
 			&version::new
@@ -102,6 +145,13 @@ my $default_share = [
 			&version::noop
 			&version::is_alpha
 			&version::qv
+			&version::vxs::declare
+			&version::vxs::qv
+			&version::vxs::_VERSION
+			&version::vxs::stringify
+			&version::vxs::new
+			&version::vxs::parse
+			&version::vxs::VCMP
 			]
 	),
 	(
@@ -109,8 +159,26 @@ my $default_share = [
 			&& qw[
 			&re::regexp_pattern
 			]
+	),
+	(
+		$] >= 5.010
+			&& $] < 5.014
+			&& qw[
+			&Tie::Hash::NamedCapture::FETCH
+			&Tie::Hash::NamedCapture::STORE
+			&Tie::Hash::NamedCapture::DELETE
+			&Tie::Hash::NamedCapture::CLEAR
+			&Tie::Hash::NamedCapture::EXISTS
+			&Tie::Hash::NamedCapture::FIRSTKEY
+			&Tie::Hash::NamedCapture::NEXTKEY
+			&Tie::Hash::NamedCapture::SCALAR
+			&Tie::Hash::NamedCapture::flags
+			]
 	)
 ];
+if (defined $Devel::Cover::VERSION) {
+	push @$default_share, '&Devel::Cover::use_file';
+}
 
 sub new {
 	my ($class, $root, $mask) = @_;
@@ -139,7 +207,9 @@ sub new {
 	# the whole glob *_ rather than $_ and @_ separately, otherwise
 	# @_ in non default packages within the compartment don't work.
 	$obj->share_from('main', $default_share);
+
 	Opcode::_safe_pkg_prep($obj->{Root}) if ($Opcode::VERSION > 1.04);
+
 	return $obj;
 }
 
@@ -254,14 +324,16 @@ sub share_from {
 		my ($var, $type);
 		$type = $1 if ($var = $arg) =~ s/^(\W)//;
 		# warn "share_from $pkg $type $var";
-		*{ $root . "::$var" } =
-			(!$type)         ? \&{ $pkg . "::$var" }
-			: ($type eq '&') ? \&{ $pkg . "::$var" }
-			: ($type eq '$') ? \${ $pkg . "::$var" }
-			: ($type eq '@') ? \@{ $pkg . "::$var" }
-			: ($type eq '%') ? \%{ $pkg . "::$var" }
-			: ($type eq '*') ? *{ $pkg . "::$var" }
-			:                  croak(qq(Can't share "$type$var" of unknown type));
+		for (1 .. 2) {    # assign twice to avoid any 'used once' warnings
+			*{ $root . "::$var" } =
+				(!$type)         ? \&{ $pkg . "::$var" }
+				: ($type eq '&') ? \&{ $pkg . "::$var" }
+				: ($type eq '$') ? \${ $pkg . "::$var" }
+				: ($type eq '@') ? \@{ $pkg . "::$var" }
+				: ($type eq '%') ? \%{ $pkg . "::$var" }
+				: ($type eq '*') ? *{ $pkg . "::$var" }
+				:                  croak(qq(Can't share "$type$var" of unknown type));
+		}
 	}
 	$obj->share_record($pkg, $vars) unless $no_record or !$vars;
 }
@@ -295,20 +367,167 @@ sub varglob {
 	return *{ $obj->root() . "::$var" };
 }
 
+sub _clean_stash {
+	my ($root, $saved_refs, $orig_root) = @_;
+	$saved_refs ||= [];
+	$orig_root = $root unless defined $orig_root;
+	no strict 'refs';
+
+	# share_from can alias a whole external package's stash into the compartment. Stripping its
+	# DESTROY/AUTOLOAD/overload hooks here would corrupt the shared package. So leave stashes like this alone.
+	if ($root ne $orig_root) {
+		(my $local_name = $root) =~ s/^\Q$orig_root\E//;
+		return if \%{$root} eq \%{$local_name};
+	}
+
+	foreach my $hook (qw(DESTROY AUTOLOAD), grep /^\(/, keys %$root) {
+		push @$saved_refs, \*{ $root . $hook };
+		delete ${$root}{$hook};
+	}
+
+	for (grep /::$/, keys %$root) {
+		next if \%{ $root . $_ } eq \%$root;
+		_clean_stash($root . $_, $saved_refs, $orig_root);
+	}
+}
+
+# Tracks, per compartment root, whether a reval/rdo/wrap_code_ref call for that root is currently executing further
+# down the call stack. See the comment in reval() for why this matters.
+my %IN_PROGRESS;
+
 sub reval {
 	my ($obj, $expr, $strict) = @_;
+	die "Bad Safe object" unless $obj->isa('WeBWorK::WWSafe');
+
 	my $root = $obj->{Root};
 
 	my $evalsub = lexless_anon_sub($root, $strict, $expr);
-	return Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub);
+	# propagate context
+	my $sg = sub_generation();
+	my @subret;
+	if ($IN_PROGRESS{$root}) {
+		# This is already executing inside this safe compartment (this reval was called, directly or indirectly, from
+		# code that is itself running via a _safe_call_sv for this root). The package and opcode mask are already 'in
+		# effect' from that outer call, so just run the compiled sub directly. Entering Opcode::_safe_call_sv again here
+		# breaks eval/$@ propagation for the code that is already running.
+		@subret = (wantarray) ? $evalsub->() : scalar $evalsub->();
+	} else {
+		local $IN_PROGRESS{$root} = 1;
+		if (defined wantarray) {
+			@subret =
+				(wantarray)
+				? Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub)
+				: scalar Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub);
+		} else {
+			Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub);
+		}
+	}
+	_clean_stash($root . '::') if $sg != sub_generation();
+	$obj->wrap_code_refs_within(@subret);
+	return (wantarray) ? @subret : $subret[0];
+}
+
+my %OID;
+
+sub wrap_code_refs_within {
+	my $obj = shift;
+
+	%OID = ();
+	$obj->_find_code_refs('wrap_code_ref', @_);
+}
+
+sub _find_code_refs {
+	my $obj     = shift;
+	my $visitor = shift;
+
+	for my $item (@_) {
+		my $reftype = defined $item && reftype $item
+			or next;
+
+		# skip references already seen
+		next if ++$OID{ refaddr $item } > 1;
+
+		if ($reftype eq 'ARRAY') {
+			$obj->_find_code_refs($visitor, @$item);
+		} elsif ($reftype eq 'HASH') {
+			$obj->_find_code_refs($visitor, values %$item);
+		}
+		# XXX GLOBs?
+		elsif ($reftype eq 'CODE') {
+			$item = $obj->$visitor($item);
+		}
+	}
+}
+
+sub wrap_code_ref {
+	my ($obj, $sub) = @_;
+	die "Bad safe object" unless $obj->isa('WeBWorK::WWSafe');
+
+	# wrap code ref $sub with _safe_call_sv so that, when called, the
+	# execution will happen with the compartment fully 'in effect'.
+
+	croak "Not a CODE reference"
+		if reftype $sub ne 'CODE';
+
+	my $ret = sub {
+		my @args          = @_;                      # lexical to close over
+		my $sub_with_args = sub { $sub->(@args) };
+		my $root          = $obj->{Root};
+
+		# If a call for this root is already active further down the stack (e.g. this wrapped closure was called by code
+		# that is itself already running via _safe_call_sv), the package and mask are already 'in effect'. So just call
+		# through directly.
+		return $sub_with_args->() if $IN_PROGRESS{$root};
+
+		my @subret;
+		my $error;
+		do {
+			local $@;    # needed due to perl_call_sv(sv, G_EVAL|G_KEEPERR)
+			local $IN_PROGRESS{$root} = 1;
+			my $sg = sub_generation();
+			@subret =
+				(wantarray)
+				? Opcode::_safe_call_sv($root, $obj->{Mask}, $sub_with_args)
+				: scalar Opcode::_safe_call_sv($root, $obj->{Mask}, $sub_with_args);
+			$error = $@;
+			_clean_stash($root . '::') if $sg != sub_generation();
+		};
+		if ($error) {    # rethrow exception
+			$error =~ s/\t\(in cleanup\) //;    # prefix added by G_KEEPERR
+			die $error;
+		}
+		return (wantarray) ? @subret : $subret[0];
+	};
+
+	# Preserve a blessed object. Replacing the wrapped reference with an unblessed value would break method resolution.
+	# So give the return value the same class.
+	my $class = blessed($sub);
+	bless $ret, $class if defined $class;
+
+	return $ret;
 }
 
 sub rdo {
 	my ($obj, $file) = @_;
+	die "Bad Safe object" unless $obj->isa('WeBWorK::WWSafe');
+
 	my $root = $obj->{Root};
 
+	my $sg      = sub_generation();
 	my $evalsub = eval sprintf('package %s; sub { @_ = (); do $file }', $root);
-	return Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub);
+	my @subret;
+	if ($IN_PROGRESS{$root}) {    # see the comment in reval()
+		@subret = (wantarray) ? $evalsub->() : scalar $evalsub->();
+	} else {
+		local $IN_PROGRESS{$root} = 1;
+		@subret =
+			(wantarray)
+			? Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub)
+			: scalar Opcode::_safe_call_sv($root, $obj->{Mask}, $evalsub);
+	}
+	_clean_stash($root . '::') if $sg != sub_generation();
+	$obj->wrap_code_refs_within(@subret);
+	return (wantarray) ? @subret : $subret[0];
 }
 
 1;
@@ -380,7 +599,7 @@ outside the compartment) placed into the compartment. For example,
 
     $cpt = new Safe;
     sub wrapper {
-        # vet arguments and perform potentially unsafe operations
+      # vet arguments and perform potentially unsafe operations
     }
     $cpt->share('&wrapper');
 
@@ -388,6 +607,13 @@ outside the compartment) placed into the compartment. For example,
 
 
 =head1 WARNING
+
+The Safe module does not implement an effective sandbox for
+evaluating untrusted code with the perl interpreter.
+
+Bugs in the perl interpreter that could be abused to bypass
+Safe restrictions are not treated as vulnerabilities. See
+L<perlsecpolicy> for additional information.
 
 The authors make B<no warranty>, implied or otherwise, about the
 suitability of this software for safety or security purposes.
@@ -399,15 +625,7 @@ of this software.
 Your mileage will vary. If in any doubt B<do not use it>.
 
 
-=head2 RECENT CHANGES
-
-The interface to the Safe module has changed quite dramatically since
-version 1 (as supplied with Perl5.002). Study these pages carefully if
-you have code written to use Safe version 1 because you will need to
-makes changes.
-
-
-=head2 Methods in class Safe
+=head1 METHODS
 
 To create a new compartment, use
 
@@ -426,9 +644,7 @@ object returned by the above constructor. The object argument
 is implicit in each case.
 
 
-=over 8
-
-=item permit (OP, ...)
+=head2 permit (OP, ...)
 
 Permit the listed operators to be used when compiling code in the
 compartment (in I<addition> to any operators already permitted).
@@ -436,29 +652,28 @@ compartment (in I<addition> to any operators already permitted).
 You can list opcodes by names, or use a tag name; see
 L<Opcode/"Predefined Opcode Tags">.
 
-=item permit_only (OP, ...)
+=head2 permit_only (OP, ...)
 
 Permit I<only> the listed operators to be used when compiling code in
 the compartment (I<no> other operators are permitted).
 
-=item deny (OP, ...)
+=head2 deny (OP, ...)
 
 Deny the listed operators from being used when compiling code in the
 compartment (other operators may still be permitted).
 
-=item deny_only (OP, ...)
+=head2 deny_only (OP, ...)
 
 Deny I<only> the listed operators from being used when compiling code
-in the compartment (I<all> other operators will be permitted).
+in the compartment (I<all> other operators will be permitted, so you probably
+don't want to use this method).
 
-=item trap (OP, ...)
-
-=item untrap (OP, ...)
+=head2 trap (OP, ...), untrap (OP, ...)
 
 The trap and untrap methods are synonyms for deny and permit
 respectfully.
 
-=item share (NAME, ...)
+=head2 share (NAME, ...)
 
 This shares the variable(s) in the argument list with the compartment.
 This is almost identical to exporting variables using the L<Exporter>
@@ -474,9 +689,9 @@ for a glob (i.e.  all symbol table entries associated with "foo",
 including scalar, array, hash, sub and filehandle).
 
 Each NAME is assumed to be in the calling package. See share_from
-for an alternative method (which share uses).
+for an alternative method (which C<share> uses).
 
-=item share_from (PACKAGE, ARRAYREF)
+=head2 share_from (PACKAGE, ARRAYREF)
 
 This method is similar to share() but allows you to explicitly name the
 package that symbols should be shared from. The symbol names (including
@@ -484,20 +699,29 @@ type characters) are supplied as an array reference.
 
     $safe->share_from('main', [ '$foo', '%bar', 'func' ]);
 
+Names can include package names, which are relative to the specified PACKAGE.
+So these two calls have the same effect:
 
-=item varglob (VARNAME)
+    $safe->share_from('Scalar::Util', [ 'reftype' ]);
+    $safe->share_from('main', [ 'Scalar::Util::reftype' ]);
+
+=head2 varglob (VARNAME)
 
 This returns a glob reference for the symbol table entry of VARNAME in
 the package of the compartment. VARNAME must be the B<name> of a
-variable without any leading type marker. For example,
+variable without any leading type marker. For example:
+
+    ${$cpt->varglob('foo')} = "Hello world";
+
+has the same effect as:
 
     $cpt = new Safe 'Root';
     $Root::foo = "Hello world";
-    # Equivalent version which doesn't need to know $cpt's package name:
-    ${$cpt->varglob('foo')} = "Hello world";
+
+but avoids the need to know $cpt's package name.
 
 
-=item reval (STRING)
+=head2 reval (STRING, STRICT)
 
 This evaluates STRING as perl code inside the compartment.
 
@@ -520,9 +744,13 @@ expression evaluated, or a return statement may be used, just as with
 subroutines and B<eval()>. The context (list or scalar) is determined
 by the caller as usual.
 
-This behaviour differs from the beta distribution of the Safe extension
-where earlier versions of perl made it hard to mimic the return
-behaviour of the eval() command and the context was always scalar.
+If the return value of reval() is (or contains) any code reference,
+those code references are wrapped to be themselves executed always
+in the compartment. See L</wrap_code_refs_within>.
+
+The formerly undocumented STRICT argument sets strictness: if true
+'use strict;' is used, otherwise it uses 'no strict;'. B<Note>: if
+STRICT is omitted 'no strict;' is the default.
 
 Some points to note:
 
@@ -558,14 +786,15 @@ the code in the compartment.
 A similar effect applies to I<all> runtime symbol lookups in code
 called from a compartment but not compiled within it.
 
-
-
-=item rdo (FILENAME)
+=head2 rdo (FILENAME)
 
 This evaluates the contents of file FILENAME inside the compartment.
+It uses the same rules as perl's built-in C<do> to locate the file,
+poossibly using C<@INC>.
+
 See above documentation on the B<reval> method for further details.
 
-=item root (NAMESPACE)
+=head2 root (NAMESPACE)
 
 This method returns the name of the package that is the root of the
 compartment's namespace.
@@ -574,7 +803,7 @@ Note that this behaviour differs from version 1.00 of the Safe module
 where the root module could be used to change the namespace. That
 functionality has been withdrawn pending deeper consideration.
 
-=item mask (MASK)
+=head2 mask (MASK)
 
 This is a get-or-set method for the compartment's operator mask.
 
@@ -584,14 +813,34 @@ the compartment.
 With the MASK argument present, it sets the operator mask for the
 compartment (equivalent to calling the deny_only method).
 
-=back
+=head2 wrap_code_ref (CODEREF)
 
+Returns a reference to an anonymous subroutine that, when executed, will call
+CODEREF with the Safe compartment 'in effect'.  In other words, with the
+package namespace adjusted and the opmask enabled.
 
-=head2 Some Safety Issues
+Note that the opmask doesn't affect the already compiled code, it only affects
+any I<further> compilation that the already compiled code may try to perform.
 
-This section is currently just an outline of some of the things code in
-a compartment might do (intentionally or unintentionally) which can
-have an effect outside the compartment.
+This is particularly useful when applied to code references returned from reval().
+
+(It also provides a kind of workaround for RT#60374: "Safe.pm sort {} bug with
+-Dusethreads". See L<https://rt.perl.org/rt3//Public/Bug/Display.html?id=60374>
+for I<much> more detail.)
+
+=head2 wrap_code_refs_within (...)
+
+Wraps any CODE references found within the arguments by replacing each with the
+result of calling L</wrap_code_ref> on the CODE reference. Any ARRAY or HASH
+references in the arguments are inspected recursively.
+
+Returns nothing.
+
+=head1 RISKS
+
+This section is just an outline of some of the things code in a compartment
+might do (intentionally or unintentionally) which can have an effect outside
+the compartment.
 
 =over 8
 
@@ -629,7 +878,7 @@ but more subtle effect.
 
 =back
 
-=head2 AUTHOR
+=head1 AUTHOR
 
 Originally designed and implemented by Malcolm Beattie.
 


### PR DESCRIPTION
The updated `WWSafe.pm` is based on version 2.47 of the upstream `Safe.pm` module. It is essentially the upstream module except that some reentrancy issues with `reval` and `rdo`, and an issue with sharing an entire package to the safe compartment are fixed.

These are basically the same changes as to the WWSafe.pm module for PG.

Note that webwork2 uses this for three things:

- to evaluate the configuration files and construct the course environment.
- to evaluate achievement evaluators
- to generate achievement notification email text from the template set for the achievement notificaiton

So clearly those are the things to test.