### PR TITLE
Fix make sure key is defined before comparing it.

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/still_not_right.at
+++ b/courses.dist/modelCourse/templates/achievements/still_not_right.at
@@ -6,6 +6,7 @@
 
 # Initialize $localData.
 $localData->{incorrect_streak} //= 0;
+$localData->{set_id}           //= '';
 
 # If the problem is correct, reset counter and move on.
 if ($problem->status == 1) {


### PR DESCRIPTION
Make sure `$localData->{set_id}` is defined before comparing it in a `ne` comparison in still_no_right achievement.

Found another achievement that compared a value that could be undefined.