### PR TITLE
Fix make sure key is defined before comparing it. (Hotfix of #3161)

### DIFF
--- a/courses.dist/modelCourse/templates/achievements/still_not_right.at
+++ b/courses.dist/modelCourse/templates/achievements/still_not_right.at
@@ -6,6 +6,7 @@
 
 # Initialize $localData.
 $localData->{incorrect_streak} //= 0;
+$localData->{set_id}           //= '';
 
 # If the problem is correct, reset counter and move on.
 if ($problem->status == 1) {


### PR DESCRIPTION
Make sure `$localData->{set_id}` is defined before comparing it in a `ne` comparision in still_no_right achievement.