### PR TITLE
Test time announce icon

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.scss
+++ b/htdocs/js/GatewayQuiz/gateway.scss
@@ -2,15 +2,15 @@
 
 #gwTimerContainer {
 	position: sticky;
-	width: 15em;
+	width: 18em;
 	top: 2.75rem;
-	left: calc(100% - 15em - 0.75rem);
+	left: calc(100% - 18em - 0.75rem);
 	right: 0.75rem;
 	z-index: 31;
 }
 
-#gwTimer {
-	text-align: center;
+#gwAnnounceTimeBtn {
+	padding: 1px 2px;
 }
 
 .gwAlert {

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -220,11 +220,13 @@
 	%
 	% # Print the timer if there is less than 24 hours left.
 	% if ($timeLeft < 86400) {
-		<div id="gwTimerContainer" class="d-flex flex-column gap-2 mb-2">
+		<div
+			id="gwTimerContainer"
+			class="alert alert-warning d-flex justify-content-center align-items-center gap-2 py-1 mb-0"
+		>
 			<%= tag(
-				'div',
+				'span',
 				id            => 'gwTimer',
-				class         => 'alert alert-warning p-1 mb-0',
 				'aria-hidden' => 'true',
 				data          => {
 					server_time     => int($submitTime),
@@ -253,10 +255,27 @@
 			) =%>
 			<%= tag(
 				'button',
-				id    => 'gwAnnounceTimeBtn',
-				type  => 'button',
-				class => 'btn btn-sm btn-secondary',
-				maketext('Announce time remaining')
+				id           => 'gwAnnounceTimeBtn',
+				type         => 'button',
+				class        => 'btn btn-sm btn-secondary',
+				'aria-label' => maketext('Announce time remaining'),
+				tag(
+					'svg',
+					width   => 20,
+					height  => 20,
+					viewBox => '0.5 0 16 16',
+					fill    => 'currentColor',
+					xmlns   => 'http://www.w3.org/2000/svg',
+					tag(
+						'path',
+						'fill-rule' => 'evenodd',
+						d => 'M8.5 2a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-1 0v-11a.5.5 0 0 1 .5-.5m-2 2a.5.5 0 0 1 '
+							. '.5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5m4 0a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 '
+							. '0 0 1 .5-.5m-6 1.5A.5.5 0 0 1 5 6v4a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m8 0a.5.5 0 0 1 '
+							. '.5.5v4a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m-10 1A.5.5 0 0 1 3 7v2a.5.5 0 0 1-1 0V7a.5.5 '
+							. '0 0 1 .5-.5m12 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0V7a.5.5 0 0 1 .5-.5'
+					)
+				)
 			) =%>
 		</div>
 	% }


### PR DESCRIPTION
Place a small button with a speaker icon next to the remaining time on tests instead of a full button on the second row. This makes the remaining time + button overlay take up less space.

I went with using a "sound wave" icon, but am open to what ever icon is preferred. Here is what the remaining time overlay looks like with this:

<img width="320" height="63" alt="image" src="https://github.com/user-attachments/assets/6516cf3b-17ad-409e-b4bb-1f34f826eab5" />

I originally tried a megaphone, but the bootstrap one didn't look right to me (maybe a megaphone with some sound waves coming from it would be useful). Here is what the megaphone looks like.

<img width="312" height="62" alt="image" src="https://github.com/user-attachments/assets/cc785238-ebb1-4cca-ae38-3c315b5f8eb0" />

@Alex-Jordan any thoughts? Also is `aria-label` enough to make this accessible?