### PR TITLE
Use a speaker icon for the test time announce button. (Hotifx of #3165)

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.scss
+++ b/htdocs/js/GatewayQuiz/gateway.scss
@@ -2,15 +2,15 @@
 
 #gwTimerContainer {
 	position: sticky;
-	width: 15em;
+	width: 18em;
 	top: 2.75rem;
-	left: calc(100% - 15em - 0.75rem);
+	left: calc(100% - 18em - 0.75rem);
 	right: 0.75rem;
 	z-index: 31;
 }
 
-#gwTimer {
-	text-align: center;
+#gwAnnounceTimeBtn {
+	padding: 1px 2px;
 }
 
 .gwAlert {

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -224,10 +224,13 @@
 	%
 	% # Print the timer if there is less than 24 hours left.
 	% if ($timeLeft < 86400) {
-		<div id="gwTimerContainer" class="d-flex flex-column gap-2 mb-2">
-			<%= tag('div',
-				id    => 'gwTimer',
-				class => 'alert alert-warning p-1 mb-0',
+		<div
+			id="gwTimerContainer"
+			class="alert alert-warning d-flex justify-content-center align-items-center gap-2 py-1 mb-0"
+		>
+			<%= tag(
+				'span',
+				id            => 'gwTimer',
 				'aria-hidden' => 'true',
 				data  => {
 					server_time     => int($submitTime),
@@ -253,11 +256,29 @@
 				# '00:00:00' is a placeholder that is replaced by the actual time remaining via javascript.
 				maketext('Remaining time: [_1]', '00:00:00')
 			) =%>
-			<%= tag('button',
-				id    => 'gwAnnounceTimeBtn',
-				type  => 'button',
-				class => 'btn btn-sm btn-secondary',
-				maketext('Announce time remaining')
+			<%= tag(
+				'button',
+				id           => 'gwAnnounceTimeBtn',
+				type         => 'button',
+				class        => 'btn btn-sm btn-secondary',
+				'aria-label' => maketext('Announce time remaining'),
+				tag(
+					'svg',
+					width   => 20,
+					height  => 20,
+					viewBox => '0.5 0 16 16',
+					fill    => 'currentColor',
+					xmlns   => 'http://www.w3.org/2000/svg',
+					tag(
+						'path',
+						'fill-rule' => 'evenodd',
+						d => 'M8.5 2a.5.5 0 0 1 .5.5v11a.5.5 0 0 1-1 0v-11a.5.5 0 0 1 .5-.5m-2 2a.5.5 0 0 1 '
+							. '.5.5v7a.5.5 0 0 1-1 0v-7a.5.5 0 0 1 .5-.5m4 0a.5.5 0 0 1 .5.5v7a.5.5 0 0 1-1 0v-7a.5.5 '
+							. '0 0 1 .5-.5m-6 1.5A.5.5 0 0 1 5 6v4a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m8 0a.5.5 0 0 1 '
+							. '.5.5v4a.5.5 0 0 1-1 0V6a.5.5 0 0 1 .5-.5m-10 1A.5.5 0 0 1 3 7v2a.5.5 0 0 1-1 0V7a.5.5 '
+							. '0 0 1 .5-.5m12 0a.5.5 0 0 1 .5.5v2a.5.5 0 0 1-1 0V7a.5.5 0 0 1 .5-.5'
+					)
+				)
 			) =%>
 		</div>
 	% }


### PR DESCRIPTION
Place a small button with a speaker icon next to the remaining time on tests instead of a full button on the second row. This makes the remaining time + button overlay take up less space.