### PR TITLE
Make the PG problem editor resize grips properly color scheme responsive.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.scss
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.scss
@@ -126,7 +126,7 @@
 		}
 	}
 
-	@media (prefers-color-scheme: dark) {
+	[data-bs-theme='dark'] & {
 		.pgedit-resizer {
 			background-color: #000;
 			color: white;


### PR DESCRIPTION
The css should not be using the `@media (prefers-color-scheme: dark)` selector.  That will always honor the browser setting, and will not honor what the UI selector is set for.  Instead it should use the `[data-bs-theme='dark']" selector which will honor both.