### PR TITLE
Don't attempt a log write when the log's root directory is missing

### DIFF
--- a/lib/WeBWorK/Utils/Logs.pm
+++ b/lib/WeBWorK/Utils/Logs.pm
@@ -22,6 +22,17 @@ sub writeLog ($ce, $facility, $message, $time = time, $logType = 'webwork') {
 		return;
 	}
 
+	# Do not attempt to write the log if the root directory that the log file lives under does not exist.
+	# surePathToFile takes the mode for the directories it creates from that root, so a missing root makes it die
+	# inside its own eval and emit three unrelated warnings before the open below fails anyway. For course logs
+	# that root is the course directory, so this is reachable whenever a course log is written for a course that
+	# does not exist, such as a login attempt against a course that is not installed.
+	unless (-d $ce->{$dirType}{root}) {
+		warn "Not writing to the $facility $logType log: "
+			. "the log root directory $ce->{$dirType}{root} does not exist.\n";
+		return;
+	}
+
 	surePathToFile($ce->{$dirType}{root}, $ce->{$fileType}{logs}{$facility});
 
 	if (open my $LOG, '>>:encoding(UTF-8)', $ce->{$fileType}{logs}{$facility}) {
@@ -61,6 +72,11 @@ valid C<WeBWorK::CourseEnvironment> object must be specified by C<$ce>. The
 format of the message written to the log file is
 
     [formatted date & time] $message
+
+Nothing is written and a warning is issued if the root directory that the log
+file lives under does not exist. For course logs that root is the course
+directory, so writing a log will never create a directory for a course that is
+not installed.
 
 =head2 writeCourseLog
 


### PR DESCRIPTION
## Problem

`writeLog` passes `$ce->{$dirType}{root}` to `surePathToFile`, which takes the mode for the directories it creates from that root:

```perl
$path = eval { $child->dirname->make_path({ mode => $parent->stat->mode }) };
```

When that root directory does not exist, `stat` returns `undef` and `->mode` dies inside `surePathToFile`'s own `eval`. A single missing directory then produces three warnings, none of which names the actual condition:

```
Use of uninitialized value $path in concatenation (.) or string
    at lib/WeBWorK/Utils/Files.pm line 24.
Failed to create directory  with start directory /opt/webwork/courses/2022W2_GHOST_101:
    Can't call method "mode" on an undefined value at lib/WeBWorK/Utils/Files.pm line 23.
failed to open /opt/webwork/courses/2022W2_GHOST_101/logs/login.log for writing:
    No such file or directory at lib/WeBWorK/Utils/Logs.pm line 32.
```

Note the empty directory name in the second warning. The `open` fails regardless, so nothing is written either way.

This is reachable through `writeCourseLog` whenever a course log is written for a course that has no course directory — for example a login attempt against a course that is not installed. On a public server that is easy to trigger with stale or crawled URLs.

## Change

Check for the root directory up front and return with a single clear warning instead:

```
Not writing to the login_log course log: the log root directory
/opt/webwork/courses/2022W2_GHOST_101 does not exist.
```

- Course logs for courses that do exist are unaffected.
- The global `webwork` logs are unaffected, since their root always exists.

This also makes the "never create a directory for a course that is not installed" property explicit rather than incidental. It is worth pinning down: the pre-2.19 `surePathToFile` in `lib/WeBWorK/Utils.pm` read `(stat $start_directory)[2, 5]`, which returns undef for a missing directory *without* dying, and then `mkdir`'d each node starting from the course directory. That left behind stub `<course>/logs/` directories, and since a course is considered to exist when its directory exists, those stubs made uninstalled courses appear installed and every later request for them failed on missing database tables. The current implementation no longer creates them, and this guard keeps it that way.