### PR TITLE
Get the user parameter in scalar context before checking permissions

### DIFF
--- a/lib/WeBWorK/ContentGenerator/ProblemSets.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSets.pm
@@ -30,7 +30,12 @@ sub can ($c, $arg) {
 		my $text = DEFAULT_COURSE_INFO_TXT;
 		eval { $text = readFile($course_info_path) } if -f $course_info_path;
 
-		return $c->authz->hasPermissions($c->param('user'), 'access_instructor_tools')
+		# Note that the user parameter must be obtained in scalar context. In list context the param method
+		# returns the empty list when the parameter is not set, and that would silently remove the argument
+		# from the hasPermissions call below, making it croak about being given too few arguments.
+		my $user = $c->param('user');
+
+		return $c->authz->hasPermissions($user, 'access_instructor_tools')
 			|| $text ne DEFAULT_COURSE_INFO_TXT;
 	}
 


### PR DESCRIPTION
## Problem

`WeBWorK::Controller::param` returns via a bare `return` when the requested parameter is not set:

```perl
return unless exists $c->{paramcache}{$name};
```

A bare `return` yields the empty list in list context, so passing the result straight into another call does not pass `undef` — it removes the argument entirely. In `ProblemSets::can`:

```perl
return $c->authz->hasPermissions($c->param('user'), 'access_instructor_tools')
    || $text ne DEFAULT_COURSE_INFO_TXT;
```

When there is no `user` parameter, `hasPermissions` receives a single argument and its argument check croaks:

```
hasPermissions called with 1 arguments instead of the expected 2: 'access_instructor_tools'
    at lib/WeBWorK/ContentGenerator/ProblemSets.pm line 33
```

`can('info')` is reachable without a `user` parameter, so an unauthenticated request to a course page returns a server error rather than rendering. We hit this on a production server from ordinary unauthenticated crawler traffic.

## Change

Assign the parameter to a scalar first, which forces scalar context and is what the rest of this file already does (see `initialize`, which does `my $user = $c->param('user');`). An unset parameter is then passed through as `undef` and `hasPermissions` answers normally.

## Scope

The same "pass `param()` directly as an argument" pattern appears at a number of other `hasPermissions` call sites, for example in `Grades.pm`, `GatewayQuiz.pm`, and `Instructor/FileManager.pm`. Those are only reached once a `user` parameter is set, so they do not currently fail, but they are fragile for the same reason. I have kept this change to the one call site that actually breaks; happy to submit a follow-up sweep if you would prefer the whole pattern addressed at once, or to instead make `param` return `undef` rather than the empty list in list context — though that would change behaviour for callers that legitimately want a list.