### PR TITLE
Fix the set progress links for proctored tests.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -130,16 +130,19 @@ sub displaySets ($c) {
 			my $set;
 			my $vNum = 0;
 
-			# For versioned tests we might be displaying the test date and test time.
+			# For versioned tests we might be displaying the test date and test time,
+			# and we need to know if the test is proctored or not.
 			my $dateOfTest = '';
 			my $testTime   = '';
 			my $timeLeft   = '';
+			my $proctored  = 0;
 
 			if ($setIsVersioned) {
 				($setName, $vNum) = ($setName =~ /(.+),v(\d+)$/);
 				# Information from the set is needed to set up the display below. So get the merged user set as well.
 				$set        = $db->getMergedSetVersion($studentRecord->user_id, $setName, $vNum);
 				$dateOfTest = localtime($set->version_creation_time());
+				$proctored  = $set->assignment_type =~ /proctored/;
 				if ($set->version_last_attempt_time) {
 					$testTime = ($set->version_last_attempt_time - $set->open_date) / 60;
 					my $timeLimit = $set->version_time_limit / 60;
@@ -173,6 +176,7 @@ sub displaySets ($c) {
 
 			my $version_data = {
 				version                    => $vNum,
+				proctored                  => $proctored,
 				score                      => $score,
 				total                      => $total,
 				date                       => $dateOfTest,

--- a/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
@@ -253,7 +253,10 @@
 						% if ($rec->{total} != -1) {
 							% # Make a versioned set name format nicer and link to the test version.
 							% my $versionLink = link_to "version $rec->{version}" => $c->systemLink(
-								% url_for('gateway_quiz', setID => "$setID,v$rec->{version}"),
+								% url_for(
+									% $rec->{proctored} ? 'proctored_gateway_quiz' : 'gateway_quiz',
+									% setID => "$setID,v$rec->{version}",
+								% ),
 								% params => { effectiveUser => $rec->{record}{user_id} }
 							% );
 							%


### PR DESCRIPTION
Currently the link is always for the unproctored `gateway_quiz` route. Attempting to use the link on the set progress page for an in progress proctored test shows the page stating that the set is not valid for the user and that the test is proctored and valid proctor authentication has not been obtained.  It should be using the `proctored_gateway_quiz` route. This annoyingly requires proctor authentication for the instructor to view the test, but that is how it always is anytime an instructor tries to view an in progress proctored gateway quiz when acting as a student.

Note that the determination that the test is proctored must be made from the user set, not the global set.  The global set is always "proctored", but the user set, once graded, is no longer proctored. So this data needs to be extracted in the `StudentProgress.pm` module and passed to the template.

Note that I don't think this has ever worked right, so this is not being considered for a hotfix.