### PR TITLE
Move the version_id into its own field.

### DIFF
--- a/bin/dump-past-answers.pl
+++ b/bin/dump-past-answers.pl
@@ -159,7 +159,7 @@ sub write_past_answers_csv {
 					my $setID    = $_->set_id;
 					my @versions = $db->listSetVersions($userID, $setID);
 					for my $version (@versions) {
-						push(@sets, $db->getUserSet($userID, "$setID,v$version"));
+						push(@sets, $db->getSetVersion($userID, $setID, $version));
 					}
 				} else {
 					push(@sets, $_);

--- a/conf/defaults.config
+++ b/conf/defaults.config
@@ -680,10 +680,6 @@ $modelCoursesForCopy = ["modelCourse"];
 # responds affirmatively will be used.
 $authen{user_module} = 'WeBWorK::Authen::Basic_TheLastOption';
 
-# Select the authentication module to use for proctor logins.
-# A string or a hash is accepted, as above.
-$authen{proctor_module} = "WeBWorK::Authen::Proctor";
-
 # List of authentication modules that may be used to enter the admin course.
 # This is used instead of $authen{user_module} when logging into the admin course.
 $authen{admin_module} = ['WeBWorK::Authen::Basic_TheLastOption'];

--- a/htdocs/js/UserDetail/userdetail.js
+++ b/htdocs/js/UserDetail/userdetail.js
@@ -2,13 +2,13 @@
 	// Check or uncheck assignment checkboxes for versioned sets and their template to make it clear to the user what
 	// the backend will do with their selections.
 	document.querySelectorAll('input[type="checkbox"][name^="set."][name$=".assignment"]').forEach((checkbox) => {
-		const setID = checkbox.name.replace(/^set\.(.*).assignment$/, '$1');
-		if (/,v\d*$/.test(setID)) {
+		const setID = checkbox.dataset.setId;
+		if (checkbox.dataset.versioned !== undefined) {
 			// This is a versioned set.  If this is checked, make sure that the template set is also checked.
 			checkbox.addEventListener('change', () => {
 				if (checkbox.checked)
 					document.querySelector(
-						`input[type="checkbox"][name="set.${setID.replace(/,v\d*$/, '')}.assignment"]`
+						`input[type="checkbox"][data-set-id="${setID}"]:not([data-versioned])`
 					).checked = true;
 			});
 		} else {
@@ -17,7 +17,7 @@
 			checkbox.addEventListener('change', () => {
 				if (!checkbox.checked) {
 					document
-						.querySelectorAll(`input[type="checkbox"][name^="set.${setID},v"][name$=".assignment"]`)
+						.querySelectorAll(`input[type="checkbox"][data-set-id="${setID}"][data-versioned]`)
 						.forEach((versionCheckbox) => (versionCheckbox.checked = false));
 				}
 			});

--- a/lib/Caliper/Entity.pm
+++ b/lib/Caliper/Entity.pm
@@ -224,10 +224,9 @@ sub problem_user ($c, $set_id, $version_id, $problem_id, $user_id, $pg) {
 }
 
 sub answer ($c, $set_id, $version_id, $problem_id, $user_id, $pg, $start_time, $end_time) {
-	my $last_answer_id =
-		$c->db->latestProblemPastAnswer($user_id, ($version_id ? "$set_id,v$version_id" : $set_id), $problem_id);
-	my $last_answer = $c->db->getPastAnswer($last_answer_id);
-	my @answers     = split(/\t/, $last_answer->answer_string);
+	my $last_answer_id = $c->db->latestProblemPastAnswer($user_id, $set_id, $version_id // 0, $problem_id);
+	my $last_answer    = $c->db->getPastAnswer($last_answer_id);
+	my @answers        = split(/\t/, $last_answer->answer_string);
 
 	my $pg_answers_hash = {};
 	for my $key (keys %{ $pg->{answers} }) {
@@ -259,11 +258,10 @@ sub answer_attempt ($c, $set_id, $version_id, $problem_id, $user_id, $pg, $start
 		$version_id
 		? $c->db->getMergedProblemVersion($user_id, $set_id, $version_id, $problem_id)
 		: $c->db->getMergedProblem($user_id, $set_id, $problem_id);
-	my $last_answer_id =
-		$c->db->latestProblemPastAnswer($user_id, ($version_id ? "$set_id,v$version_id" : $set_id), $problem_id);
-	my $last_answer = $c->db->getPastAnswer($last_answer_id);
-	my $attempt     = $version_id ? $version_id : scalar $c->db->listProblemPastAnswers($user_id, $set_id, $problem_id);
-	my $score       = $problem_user->status || 0;
+	my $last_answer_id = $c->db->latestProblemPastAnswer($user_id, $set_id, $version_id // 0, $problem_id);
+	my $last_answer    = $c->db->getPastAnswer($last_answer_id);
+	my $attempt = $version_id ? $version_id : scalar $c->db->listProblemPastAnswers($user_id, $set_id, 0, $problem_id);
+	my $score   = $problem_user->status || 0;
 	$score = 0 if ($score > 1 || $score < 0);
 
 	my $answer_attempt = {
@@ -302,7 +300,7 @@ sub problem_set_attempt ($c, $set_id, $version_id, $user_id, $start_time, $end_t
 	} else {
 		my @problem_ids = $c->db->listGlobalProblems($set_id);
 		for my $problem_id (@problem_ids) {
-			$attempt += scalar $c->db->listProblemPastAnswers($user_id, $set_id, $problem_id);
+			$attempt += scalar $c->db->listProblemPastAnswers($user_id, $set_id, 0, $problem_id);
 		}
 	}
 

--- a/lib/WeBWorK.pm
+++ b/lib/WeBWorK.pm
@@ -36,6 +36,7 @@ use WeBWorK::ContentGenerator::Login;
 use WeBWorK::ContentGenerator::ForcePasswordChange;
 use WeBWorK::ContentGenerator::TwoFactorAuthentication;
 use WeBWorK::ContentGenerator::LoginProctor;
+use WeBWorK::Authen::Proctor;
 
 our %SeedCE;
 
@@ -190,14 +191,8 @@ async sub dispatch ($c) {
 			# we need to also check on the proctor.  Note that in the gateway quiz
 			# module this is double checked to be sure that someone isn't taking a
 			# proctored quiz but calling the unproctored ContentGenerator.
-			if ($c->current_route =~ /^(proctored_gateway_quiz|proctored_gateway_proctor_login)$/) {
-				my $proctor_authen_module = WeBWorK::Authen::class($ce, 'proctor_module');
-				runtime_use $proctor_authen_module;
-				my $authenProctor = $proctor_authen_module->new($c);
-				debug("Using proctor_authen_module $proctor_authen_module: $authenProctor\n");
-				my $procAuthOK = $authenProctor->verify();
-
-				if (!$procAuthOK) {
+			if ($c->current_route =~ /^(proctored_gateway_quiz|proctored_gateway_quiz_version)$/) {
+				if (!WeBWorK::Authen::Proctor->new($c)->verify()) {
 					await WeBWorK::ContentGenerator::LoginProctor->new($c)->go;
 					return 0;
 				}
@@ -208,6 +203,7 @@ async sub dispatch ($c) {
 				# current server time during a gateway quiz, and that definitely should not revoke proctor
 				# authorization.
 				delete $c->authen->session->{proctor_authorization_granted};
+				delete $c->authen->session->{proctor_authorization_version};
 				delete $c->authen->session->{acting_proctor};
 			}
 			return 1;

--- a/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
+++ b/lib/WeBWorK/AchievementItems/AddNewTestGW.pm
@@ -22,7 +22,7 @@ sub new ($class, $c) {
 sub can_use ($self, $set, $records, $c) {
 	return
 		$set->assignment_type =~ /gateway/
-		&& $set->set_id !~ /,v\d+$/
+		&& !$set->version_id
 		&& between($set->open_date, $set->due_date)
 		&& $set->versions_per_interval > 0;
 }

--- a/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
+++ b/lib/WeBWorK/AchievementItems/ExtendDueDateGW.pm
@@ -21,7 +21,7 @@ sub new ($class, $c) {
 sub can_use ($self, $set, $records, $c) {
 	return
 		$set->assignment_type =~ /gateway/
-		&& $set->set_id !~ /,v\d+$/
+		&& !$set->version_id
 		&& between($set->open_date, $set->due_date + $self->{time});
 }
 

--- a/lib/WeBWorK/Authen/Proctor.pm
+++ b/lib/WeBWorK/Authen/Proctor.pm
@@ -10,8 +10,7 @@ WeBWorK::Authen::Proctor - Authenticate gateway test proctors.
 use strict;
 use warnings;
 
-use WeBWorK::Utils     qw(x);
-use WeBWorK::DB::Utils qw(grok_vsetID);
+use WeBWorK::Utils qw(x);
 
 use constant GENERIC_ERROR_MESSAGE => x('Invalid user ID or password.');
 
@@ -23,13 +22,23 @@ sub verify {
 	my $self = shift;
 	my $c    = $self->{c};
 
-	# At this point the usual authentication has already occurred and the user has been verified.  If the
-	# use_grade_auth_proctor option is set to 'No', then proctor authorization is not needed.  So return
-	# 1 here to skip proctor authorization and proceed on to the GatewayQuiz module which will grade the test.
+	# At this point the usual authentication has already occurred and the user has been verified.  Note that this
+	# checks the permissions of the real user, not the effective user, since it is the real user who is attempting
+	# to access the proctored test (e.g., an instructor acting as a student, or a student grading their own test).
 	if ($c->req->body_params->param('submitAnswers')) {
-		my ($setName, $versionNum) = grok_vsetID($c->stash('setID'));
-		my $userSet = $c->db->getMergedSetVersion($c->param('effectiveUser'), $setName, $versionNum);
+		# If the use_grade_auth_proctor option is set to 'No', then proctor authorization is not needed.  So return
+		# 1 here to skip proctor authorization and proceed on to the GatewayQuiz module which will grade the test.
+		my $userSet =
+			$c->db->getMergedSetVersion($c->param('effectiveUser'), $c->stash->{setID}, $c->stash->{versionID});
 		return 1 if $userSet && $userSet->use_grade_auth_proctor eq 'No';
+
+		# A user with the proctor_quiz_grade permission does not need
+		# separate proctor authorization to grade a proctored test.
+		return 1 if $c->authz->hasPermissions($c->param('user'), 'proctor_quiz_grade');
+	} else {
+		# A user with the proctor_quiz_login permission does not need separate proctor authorization to enter
+		# (or view) a proctored test. They can simply use their own login.
+		return 1 if $c->authz->hasPermissions($c->param('user'), 'proctor_quiz_login');
 	}
 
 	return $self->SUPER::verify(@_);
@@ -44,7 +53,7 @@ sub get_credentials {
 	my ($self) = @_;
 	my $c = $self->{c};
 
-	my ($set_id, $version_id) = grok_vsetID($c->stash('setID'));
+	my $set_id = $c->stash('setID');
 
 	if (defined $c->req->body_params->param('proctor_user')) {
 		$self->{user_id}           = $c->req->body_params->param('proctor_user');
@@ -84,10 +93,12 @@ sub verify_normal_user {
 	if (
 		$self->{login_type} eq 'proctor_login'
 		&& $c->authen->session('proctor_authorization_granted')
+		&& $c->authen->session('proctor_authorization_granted') eq $c->stash('setID')
 		&& (
 			(
-				$c->stash('setID') =~ /,v\d+$/
-				&& $c->authen->session('proctor_authorization_granted') eq $c->stash('setID')
+				defined $c->stash('versionID')
+				&& defined $c->authen->session('proctor_authorization_version')
+				&& $c->authen->session('proctor_authorization_version') == $c->stash('versionID')
 			)
 			|| $c->authen->session('acting_proctor')
 		)
@@ -126,12 +137,12 @@ sub verify_normal_user {
 					return 0;
 				}
 				$c->authen->session('proctor_authorization_granted' => $c->stash('setID'));
+				$c->authen->session('proctor_authorization_version' => $c->stash('versionID'));
 			} else {
 				# A UserSet is needed to determine if it is configured to skip grade proctor authorization.  Require a
 				# grade_proctor permission level to start a quiz that skips authorization to grade it. This ensures that
 				# a grade proctor level of authorization is always required.
-				my ($setName, $versionNum) = grok_vsetID($c->stash('setID'));
-				my $userSet = $db->getMergedSet($c->param('effectiveUser'), $setName);
+				my $userSet = $db->getMergedSet($c->param('effectiveUser'), $c->stash('setID'));
 				unless (
 					$authz->hasPermissions($user_id, 'proctor_quiz_grade')
 					|| (($userSet->use_grade_auth_proctor eq 'Yes' || $userSet->restricted_login_proctor eq 'Yes')
@@ -161,10 +172,12 @@ sub verify_normal_user {
 					return 0;
 				}
 				$c->authen->session('proctor_authorization_granted' => $c->stash('setID'));
+				$c->authen->session('proctor_authorization_version' => $c->stash('versionID'));
 			}
 			return 1;
 		} else {
 			delete $c->authen->session->{'proctor_authorization_granted'};
+			delete $c->authen->session->{'proctor_authorization_version'};
 			if ($auth_result == 0) {
 				$self->{log_error} = "authentication failed";
 				$self->{error}     = $c->maketext(GENERIC_ERROR_MESSAGE);

--- a/lib/WeBWorK/Authz.pm
+++ b/lib/WeBWorK/Authz.pm
@@ -188,10 +188,20 @@ sub checkSet ($self) {
 	my $node_name = $c->current_route;
 
 	# First check to see if we have to worried about set-level access restrictions.
-	return 0 unless grep {/^$node_name$/} (qw(problem_list problem_detail gateway_quiz proctored_gateway_quiz));
+	return 0
+		unless grep {/^$node_name$/}
+		(qw(
+			problem_list
+			problem_detail
+			gateway_quiz
+			gateway_quiz_version
+			proctored_gateway_quiz
+			proctored_gateway_quiz_version
+		));
 
 	# To check set restrictions we need a set and a user.
 	my $setName           = $c->stash('setID');
+	my $setVersion        = $c->stash('versionID') // 0;
 	my $userName          = $c->param('user');
 	my $effectiveUserName = $c->param('effectiveUser');
 
@@ -201,21 +211,19 @@ sub checkSet ($self) {
 	# Do we have a cached set that we can use?
 	my $set = $self->{merged_set};
 
-	if ($setName =~ /,v(\d+)$/) {
-		my $verNum = $1;
-		$setName =~ s/,v\d+$//;
-
-		if ($set && $set->set_id eq $setName && $set->user_id eq $effectiveUserName && $set->version_id eq $verNum) {
+	if ($setVersion) {
+		if ($set && $set->set_id eq $setName && $set->user_id eq $effectiveUserName && $set->version_id == $setVersion)
+		{
 			# If we have all of this, then we can just use this set and skip the rest.
 		} elsif ($setName eq 'Undefined_Set' && $self->hasPermissions($userName, 'access_instructor_tools')) {
 			# This is the case of previewing a problem from a 'try it' link.
 			return 0;
 		} else {
-			if ($db->existsSetVersion($effectiveUserName, $setName, $verNum)) {
-				$set = $db->getMergedSetVersion($effectiveUserName, $setName, $verNum);
+			if ($db->existsSetVersion($effectiveUserName, $setName, $setVersion)) {
+				$set = $db->getMergedSetVersion($effectiveUserName, $setName, $setVersion);
 			} else {
 				return $c->maketext('Requested version ([_1]) of set "[_2]" is not assigned to user [_3].',
-					$verNum, $setName, $effectiveUserName);
+					$setVersion, $setName, $effectiveUserName);
 			}
 		}
 		if (!$set) {
@@ -224,8 +232,8 @@ sub checkSet ($self) {
 		}
 		# Don't allow versioned sets to be viewed from the problem-list page.
 		if ($node_name eq 'problem_list') {
-			return $c->maketext('Requested version ([_1]) of set "[_2]" cannot be directly accessed.', $verNum,
-				$setName);
+			return $c->maketext('Requested version ([_1]) of set "[_2]" cannot be directly accessed.',
+				$setVersion, $setName);
 		}
 	} else {
 		if ($set && $set->set_id eq $setName && $set->user_id eq $effectiveUserName) {
@@ -352,12 +360,9 @@ sub invalidIPAddress ($self, $set) {
 	my $c  = $self->{c};
 	my $db = $c->db;
 
-	# Make sure that the non-versioned set name is used.
-	my $setName = $set->set_id =~ s/,v\d+$//r;
-
 	my $restrictType      = $set->restrict_ip;
 	my @restrictAddresses = map { $db->listLocationAddresses($_) }
-		map { $_->location_id } $db->getAllMergedSetLocations($c->param('effectiveUser'), $setName);
+		map { $_->location_id } $db->getAllMergedSetLocations($c->param('effectiveUser'), $set->set_id);
 
 	my $clientIP = Net::IP->new($c->tx->remote_address);
 
@@ -398,7 +403,7 @@ sub invalidIPAddress ($self, $set) {
 
 	if ($set->assignment_type =~ /gateway/) {
 		if ($relaxRestrict eq 'AfterAnswerDate') {
-			my $userset = $db->getMergedSet($set->user_id, $setName);
+			my $userset = $db->getMergedSet($set->user_id, $set->set_id);
 			return !$userset || before($userset->answer_date) ? $badIP : 0;
 		} else {
 			return before($set->answer_date) ? $badIP : 0;

--- a/lib/WeBWorK/ContentGenerator.pm
+++ b/lib/WeBWorK/ContentGenerator.pm
@@ -484,7 +484,11 @@ sub links ($c) {
 	my $setID         = $c->stash('setID');
 	my $problemID     = $c->stash('problemID');
 	my $achievementID = $c->stash('achievementID');
-	my $globalSetID   = defined $setID ? $setID =~ s/,v\d+$//r : undef;
+
+	# If the set id is versioned then strip the version from the set id, and extract the version.
+	# The only route that still does this is the hardcopy route.
+	($setID, my $versionID) = defined $setID && $setID =~ /([^,]*),v(\d+)$/ ? ($1, $2) : ($setID, 0);
+	my $globalSetID = $setID;
 
 	# Determine if navigation is restricted for this user.
 	my $restricted_navigation = $authen->was_verified && !$authz->hasPermissions($userID, 'navigation_allowed');
@@ -543,6 +547,7 @@ sub links ($c) {
 		eUserID               => $eUserID,
 		urlUserID             => $c->stash('userID'),
 		setID                 => $setID,
+		versionID             => $versionID,
 		globalSetID           => $globalSetID,
 		prettySetID           => format_set_name_display($setID // $globalSetID // ''),
 		problemID             => $problemID,

--- a/lib/WeBWorK/ContentGenerator/API/CourseActions.pm
+++ b/lib/WeBWorK/ContentGenerator/API/CourseActions.pm
@@ -376,6 +376,7 @@ sub assignVisibleSets {
 		my $UserSet = $db->newUserSet;
 		$UserSet->user_id($userID);
 		$UserSet->set_id($setID);
+		$UserSet->version_id(0);
 		my @results;
 		my $set_assigned = 0;
 		eval { $db->addUserSet($UserSet) };

--- a/lib/WeBWorK/ContentGenerator/API/SetActions.pm
+++ b/lib/WeBWorK/ContentGenerator/API/SetActions.pm
@@ -132,6 +132,7 @@ sub updateSetProperties ($c) {
 			my $userSet = $db->newUserSet;
 			$userSet->user_id($user);
 			$userSet->set_id($c->req->param('set_id'));
+			$userSet->version_id(0);
 			$db->addUserSet($userSet);
 		}
 	}
@@ -211,6 +212,7 @@ sub createNewSet ($c) {
 		my $userSet = $db->newUserSet;
 		$userSet->user_id($c->req->param('user'));
 		$userSet->set_id($newSetName);
+		$userSet->version_id(0);
 		$db->addUserSet($userSet);
 		$message .= ' Set was assigned to ' . $c->req->param('user') . '.';
 	}
@@ -313,6 +315,7 @@ sub updateUserSet ($c) {
 			my $newSet = $c->db->newUserSet;
 			$newSet->user_id($userID);
 			$newSet->set_id($c->req->param('set_id'));
+			$newSet->version_id(0);
 			$newSet->open_date($c->req->param('open_date'));
 			$newSet->due_date($c->req->param('due_date'));
 			$newSet->answer_date($c->req->param('answer_date'));

--- a/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
+++ b/lib/WeBWorK/ContentGenerator/CourseAdmin.pm
@@ -1323,9 +1323,7 @@ sub upgrade_course_confirm ($c) {
 
 		# Report on database status
 		my ($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
-		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $rebuild_table_indexes,
-			$incorrect_type_database_fields, $db_report)
-			= $c->formatReportOnDatabaseTables($dbStatus, $upgrade_courseID);
+		my $dbReport = $c->formatReportOnDatabaseTables($dbStatus, $upgrade_courseID);
 
 		my $course_output = $c->c;
 
@@ -1351,9 +1349,9 @@ sub upgrade_course_confirm ($c) {
 		);
 		push(@$course_output, $c->tag('h2',  $c->maketext('Report for course [_1]:', $upgrade_courseID)));
 		push(@$course_output, $c->tag('div', class => 'mb-2', $c->maketext('Database:')));
-		push(@$course_output, $db_report);
+		push(@$course_output, $dbReport->{summary});
 
-		if ($extra_database_tables) {
+		if ($dbReport->{extra_database_tables}) {
 			$extra_database_tables_exist = 1;
 			push(
 				@$course_output,
@@ -1367,7 +1365,7 @@ sub upgrade_course_confirm ($c) {
 			);
 		}
 
-		if ($extra_database_fields) {
+		if ($dbReport->{extra_database_fields}) {
 			$extra_database_fields_exist = 1;
 			push(
 				@$course_output,
@@ -1383,7 +1381,7 @@ sub upgrade_course_confirm ($c) {
 			);
 		}
 
-		if ($rebuild_table_indexes) {
+		if ($dbReport->{rebuild_table_indexes}) {
 			push(
 				@$course_output,
 				$c->tag(
@@ -1398,7 +1396,7 @@ sub upgrade_course_confirm ($c) {
 			);
 		}
 
-		if ($incorrect_type_database_fields) {
+		if ($dbReport->{incorrect_type_database_fields}) {
 			$incorrect_type_database_fields_exist = 1;
 			push(
 				@$course_output,
@@ -1530,15 +1528,13 @@ sub do_upgrade_course ($c) {
 		# Analyze database status and prepare status report
 		($tables_ok, $dbStatus) = $CIchecker->checkCourseTables($upgrade_courseID);
 
-		my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $rebuild_table_indexes,
-			$incorrect_type_database_fields, $db_report)
-			= $c->formatReportOnDatabaseTables($dbStatus);
+		my $dbReport = $c->formatReportOnDatabaseTables($dbStatus);
 
 		# Prepend course name
-		$db_report = $c->c($c->tag('div', class => 'mb-2', $c->maketext('Database:')), $db_report);
+		my $db_report = $c->c($c->tag('div', class => 'mb-2', $c->maketext('Database:')), $dbReport->{summary});
 
 		# Report on databases and report summary
-		if ($extra_database_tables) {
+		if ($dbReport->{extra_database_tables}) {
 			push(
 				@$db_report,
 				$c->tag(
@@ -1548,7 +1544,7 @@ sub do_upgrade_course ($c) {
 				)
 			);
 		}
-		if ($extra_database_fields) {
+		if ($dbReport->{extra_database_fields}) {
 			push(
 				@$db_report,
 				$c->tag(
@@ -1560,7 +1556,7 @@ sub do_upgrade_course ($c) {
 			);
 		}
 
-		if ($incorrect_type_database_fields) {
+		if ($dbReport->{incorrect_type_database_fields}) {
 			push(
 				@$db_report,
 				$c->tag(
@@ -2768,13 +2764,14 @@ sub formatReportOnDatabaseTables ($c, $dbStatus, $courseID = undef) {
 		)
 	);
 
-	my $all_tables_ok                  = 1;
-	my $extra_database_tables          = 0;
-	my $extra_database_fields          = 0;
-	my $rebuild_table_indexes          = 0;
-	my $incorrect_type_database_fields = 0;
-
-	my $db_report = $c->c;
+	my $dbReport = {
+		all_tables_ok                  => 1,
+		extra_database_tables          => 0,
+		extra_database_fields          => 0,
+		rebuild_table_indexes          => 0,
+		incorrect_type_database_fields => 0,
+		summary                        => $c->c
+	};
 
 	for my $table (sort keys %$dbStatus) {
 		my $table_report = $c->c;
@@ -2783,9 +2780,9 @@ sub formatReportOnDatabaseTables ($c, $dbStatus, $courseID = undef) {
 		push(@$table_report, $table . ': ', $table_status_message{$table_status});
 
 		if ($table_status == WeBWorK::Utils::CourseDBIntegrityCheck::ONLY_IN_A) {
-			$all_tables_ok = 0;
+			$dbReport->{all_tables_ok} = 0;
 		} elsif ($table_status == WeBWorK::Utils::CourseDBIntegrityCheck::ONLY_IN_B) {
-			$extra_database_tables = 1;
+			$dbReport->{extra_database_tables} = 1;
 			push(
 				@$table_report,
 				$c->tag(
@@ -2809,9 +2806,9 @@ sub formatReportOnDatabaseTables ($c, $dbStatus, $courseID = undef) {
 
 				if ($field_status == WeBWorK::Utils::CourseDBIntegrityCheck::ONLY_IN_B) {
 					if ($fieldInfo{$key}[1]) {
-						$rebuild_table_indexes = 1;
+						$dbReport->{rebuild_table_indexes} = 1;
 					} else {
-						$extra_database_fields = 1;
+						$dbReport->{extra_database_fields} = 1;
 					}
 					if (defined $courseID) {
 						if ($fieldInfo{$key}[1]) {
@@ -2838,9 +2835,9 @@ sub formatReportOnDatabaseTables ($c, $dbStatus, $courseID = undef) {
 						}
 					}
 				} elsif ($field_status == WeBWorK::Utils::CourseDBIntegrityCheck::ONLY_IN_A) {
-					$all_tables_ok = 0;
+					$dbReport->{all_tables_ok} = 0;
 				} elsif ($field_status == WeBWorK::Utils::CourseDBIntegrityCheck::DIFFER_IN_A_AND_B) {
-					$incorrect_type_database_fields = 1;
+					$dbReport->{incorrect_type_database_fields} = 1;
 					if (defined $courseID) {
 						push(
 							@$field_report,
@@ -2870,18 +2867,17 @@ sub formatReportOnDatabaseTables ($c, $dbStatus, $courseID = undef) {
 			}
 			push(@$table_report, $c->tag('ul', $fields_report->join('')));
 		}
-		push(@$db_report, $c->tag('li', $table_report->join('')));
+		push(@{ $dbReport->{summary} }, $c->tag('li', $table_report->join('')));
 	}
 
-	$db_report = $c->c($c->tag('ul', $db_report->join('')));
+	$dbReport->{summary} = $c->c($c->tag('ul', $dbReport->{summary}->join('')));
 
-	push(@$db_report, $c->tag('p', class => 'text-success', $c->maketext('Database tables are ok'))) if $all_tables_ok;
+	push(@{ $dbReport->{summary} }, $c->tag('p', class => 'text-success', $c->maketext('Database tables are ok')))
+		if $dbReport->{all_tables_ok};
 
-	return (
-		$all_tables_ok, $extra_database_tables, $extra_database_fields, $rebuild_table_indexes,
-		$incorrect_type_database_fields,
-		$db_report->join('')
-	);
+	$dbReport->{summary} = $dbReport->{summary}->join('');
+
+	return $dbReport;
 }
 
 1;

--- a/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
+++ b/lib/WeBWorK/ContentGenerator/GatewayQuiz.pm
@@ -265,8 +265,7 @@ sub get_instructor_comment ($c, $problem) {
 
 	my $db = $c->db;
 	my $userPastAnswerID =
-		$db->latestProblemPastAnswer($problem->user_id, $problem->set_id . ',v' . $problem->version_id,
-			$problem->problem_id);
+		$db->latestProblemPastAnswer($problem->user_id, $problem->set_id, $problem->version_id, $problem->problem_id);
 
 	if ($userPastAnswerID) {
 		my $userPastAnswer = $db->getPastAnswer($userPastAnswerID);
@@ -313,11 +312,9 @@ async sub pre_header_initialize ($c) {
 	die "permission level record for $userID does not exist (but the user does? odd...)"
 		unless defined $permissionLevel;
 
-	# The $setID could be the versioned or nonversioned set.  Extract the version if it is provided.
-	my $requestedVersion = ($setID =~ /,v(\d+)$/) ? $1 : 0;
-	$setID =~ s/,v\d+$//;
-	# Note that if a version was provided the version needs to be checked.  That is done after it has
-	# been validated that the user is assigned the set.
+	# Get the version if it is provided.  Note that if a version was provided the version needs to be checked.  That is
+	# done after it has been validated that the user is assigned the set.
+	my $requestedVersion = $c->stash('versionID') // 0;
 
 	# Gateway set and problem collection
 
@@ -725,8 +722,13 @@ async sub pre_header_initialize ($c) {
 	}
 
 	if ($c->stash->{actingConfirmation}) {
-		# Store session while waiting for confirmation for proctored tests.
-		$c->authen->session(acting_proctor => 1) if $c->{assignment_type} eq 'proctored_gateway';
+		# Store session while waiting for confirmation for proctored tests.  This is needed because after confirmation a
+		# new set version may be created, and its version id can't be known (and so can't be matched against a granted
+		# proctor session until it exists).  Only do this for a user with the proctor_quiz_login permission, since
+		# otherwise real proctor authorization is still required for this action once it is confirmed.
+		$c->authen->session(acting_proctor => 1)
+			if $c->{assignment_type} eq 'proctored_gateway'
+			&& $authz->hasPermissions($userID, 'proctor_quiz_login');
 		return;
 	}
 	delete $c->authen->session->{acting_proctor};
@@ -734,9 +736,9 @@ async sub pre_header_initialize ($c) {
 	# If the proctor session key does not have a set version id, then add it.  This occurs when a student
 	# initially enters a proctored test, since the version id is not determined until just above.
 	if ($c->authen->session('proctor_authorization_granted')
-		&& $c->authen->session('proctor_authorization_granted') !~ /,v\d+$/)
+		&& !defined $c->authen->session('proctor_authorization_version'))
 	{
-		if ($setVersionNumber) { $c->authen->session(proctor_authorization_granted => "$setID,v$setVersionNumber"); }
+		if ($setVersionNumber) { $c->authen->session(proctor_authorization_version => $setVersionNumber); }
 		else                   { delete $c->authen->session->{proctor_authorization_granted}; }
 	}
 
@@ -744,6 +746,7 @@ async sub pre_header_initialize ($c) {
 	if ($c->{invalidSet} || $c->{actingCreationError}) {
 		if (defined $c->{assignment_type} && $c->{assignment_type} eq 'proctored_gateway') {
 			delete $c->authen->session->{proctor_authorization_granted};
+			delete $c->authen->session->{proctor_authorization_version};
 		}
 		return;
 	}
@@ -953,7 +956,6 @@ async sub pre_header_initialize ($c) {
 	$c->stash->{probOrder}       = \@probOrder;
 
 	my $versionID = $set->version_id;
-	my $setVName  = "$setID,v$versionID";
 
 	# Report everything with the request submit time. Convert the floating point
 	# value from Time::HiRes to an integer for use below. Truncate toward 0.
@@ -973,11 +975,14 @@ async sub pre_header_initialize ($c) {
 
 		# Deal with answers being submitted for a proctored exam.  If there are no attempts left, then delete the
 		# proctor session key so that it isn't possible to start another proctored test without being reauthorized.
-		delete $c->authen->session->{proctor_authorization_granted}
-			if ($c->{submitAnswers}
-				&& $c->{assignment_type} eq 'proctored_gateway'
-				&& $set->attempts_per_version > 0
-				&& $set->attempts_per_version - 1 - $problem->num_correct - $problem->num_incorrect <= 0);
+		if ($c->{submitAnswers}
+			&& $c->{assignment_type} eq 'proctored_gateway'
+			&& $set->attempts_per_version > 0
+			&& $set->attempts_per_version - 1 - $problem->num_correct - $problem->num_incorrect <= 0)
+		{
+			delete $c->authen->session->{proctor_authorization_granted};
+			delete $c->authen->session->{proctor_authorization_version};
+		}
 
 		my @pureProblems = $db->getAllProblemVersions($effectiveUserID, $setID, $versionID);
 		for my $i (0 .. $#problems) {
@@ -1113,7 +1118,7 @@ async sub pre_header_initialize ($c) {
 					$c->ce,
 					'answer_log',
 					join('',
-						'|', $problem->user_id, '|', $setVName, '|', ($i + 1), '|', $scores,
+						'|', $problem->user_id, '|', "$setID,v$versionID", '|', ($i + 1), '|', $scores,
 						"\t$timeNowInt\t", "$past_answers_string"),
 					$timeNowInt
 				);
@@ -1121,7 +1126,8 @@ async sub pre_header_initialize ($c) {
 				# Add to PastAnswer db
 				my $pastAnswer = $db->newPastAnswer();
 				$pastAnswer->user_id($problem->user_id);
-				$pastAnswer->set_id($setVName);
+				$pastAnswer->set_id($setID);
+				$pastAnswer->version_id($versionID);
 				$pastAnswer->problem_id($problem->problem_id);
 				$pastAnswer->timestamp($timeNowInt);
 				$pastAnswer->scores($scores);
@@ -1283,7 +1289,10 @@ sub path ($c, $args) {
 		$courseName => $navigation_allowed ? $c->url_for('set_list') : '',
 		$setID eq 'Undefined_Set'
 			|| $c->{invalidSet} || $c->{actingCreationError} || $c->stash->{actingConfirmation}
-		? ($setID =~ /^(.+),(v\d+)$/ ? ($1 => $c->url_for('problem_list', setID => $1), $2 => '') : ($setID => ''))
+		? (
+			defined $c->stash('versionID')
+			? ($setID => $c->url_for('problem_list', setID => $setID), 'v' . $c->stash('versionID') => '')
+			: ($setID => ''))
 		: (
 			$c->{set}->set_id           => $c->url_for('problem_list', setID => $c->{set}->set_id),
 			'v' . $c->{set}->version_id => ''
@@ -1307,15 +1316,14 @@ sub nav ($c, $args) {
 		my $setVersion = $c->{set}->version_id;
 
 		# Find all versions of this set that have been taken (excluding those taken by the current user).
-		my @userVersions =
-			$db->listSetVersionsWhere({ user_id => { '!=' => $userID }, set_id => { like => "$setID,v\%" } });
+		my @userVersions = $db->listSetVersionsWhere({ user_id => { '!=' => $userID }, set_id => $setID });
 
 		return '' unless @userVersions;
 
 		my %users = map { $_->[0] => 1 } @userVersions;
 		my %allUserRecords =
-			map  { $_->{user_id} => $_ }
-			grep { $users{ $_->{user_id} } }
+			map  { $_->user_id => $_ }
+			grep { $users{ $_->user_id } }
 			$c->db->getUsersWhere(
 				{ -and => { user_id => { not_like => 'set_id:%' } }, user_id => { '!=' => $userID } });
 

--- a/lib/WeBWorK/ContentGenerator/Grades.pm
+++ b/lib/WeBWorK/ContentGenerator/Grades.pm
@@ -151,8 +151,6 @@ sub displayStudentGrades ($c) {
 	}
 	my $effectiveUser = $studentRecord->user_id;
 
-	my $courseName = $ce->{courseName};
-
 	# First get all merged sets for this user ordered by set_id.
 	my @sets = $db->getMergedSetsWhere({ user_id => $studentID }, 'set_id');
 	# To be able to find the set objects later, make a handy hash of set ids to set objects.
@@ -173,8 +171,7 @@ sub displayStudentGrades ($c) {
 		if (defined $set->assignment_type && $set->assignment_type =~ /gateway/) {
 			# We have to have the merged set versions to know what each of their assignment types are
 			# (because proctoring can change this).
-			my @setVersions =
-				$db->getMergedSetVersionsWhere({ user_id => $studentID, set_id => { like => "$setID,v\%" } });
+			my @setVersions = $db->getMergedSetVersionsWhere({ user_id => $studentID, set_id => $setID });
 
 			# Add the set versions to our list of sets.
 			$setsByID{ $_->set_id . ',v' . $_->version_id } = $_ for (@setVersions);
@@ -199,11 +196,10 @@ sub displayStudentGrades ($c) {
 		# Determine if set is a test and if it is a test template or version.
 		my $setIsTest      = defined $set->assignment_type && $set->assignment_type =~ /gateway/;
 		my $setIsVersioned = $setIsTest                    && !defined $setVersionsCount{$setID};
-		my $setTemplateID  = $setID =~ s/,v\d+$//r;
 
 		# Initialize set item. Define link here. It will be adjusted for versioned tests later.
 		my $item = {
-			name              => format_set_name_display($setTemplateID),
+			name              => format_set_name_display($setID),
 			grade             => 0,
 			grade_total       => 0,
 			grade_total_right => 0,
@@ -239,17 +235,8 @@ sub displayStudentGrades ($c) {
 		# Tests need their link updated. Along with template sets need to add a version list.
 		# Also determines if grade and test problems should be shown.
 		if ($setIsTest) {
-			my $act_as_student_test_url = '';
-			if ($set->assignment_type eq 'proctored_gateway') {
-				$act_as_student_test_url = $item->{link} =~ s/($courseName)\//$1\/proctored_test_mode\//r;
-			} else {
-				$act_as_student_test_url = $item->{link} =~ s/($courseName)\//$1\/test_mode\//r;
-			}
-
 			# If this is a template gateway set, determine if there are any versions, then move on.
 			unless ($setIsVersioned) {
-				# Remove version from set url
-				$item->{link} =~ s/,v\d+//;
 				$item->{version_count} = $setVersionsCount{$setID};
 				if ($item->{version_count}) {
 					# Hide score initially unless there is a version the score can be seen.
@@ -262,17 +249,19 @@ sub displayStudentGrades ($c) {
 			}
 
 			# Only add link if the problems can be seen.
-			if ($set->hide_work eq 'N'
-				|| ($set->hide_work eq 'BeforeAnswerDate' && time >= $set->answer_date))
-			{
-				if ($set->assignment_type eq 'proctored_gateway') {
-					$item->{link} =~ s/($courseName)\//$1\/proctored_test_mode\//;
-				} else {
-					$item->{link} =~ s/($courseName)\//$1\/test_mode\//;
-				}
-			} else {
-				$item->{link} = '';
-			}
+			$item->{link} =
+				($set->hide_work eq 'N' || ($set->hide_work eq 'BeforeAnswerDate' && time >= $set->answer_date))
+				? $c->systemLink(
+					$c->url_for(
+						$set->assignment_type eq 'proctored_gateway'
+						? 'proctored_gateway_quiz_version'
+						: 'gateway_quiz_version',
+						setID     => $setID,
+						versionID => $set->version_id
+					),
+					params => { effectiveUser => $effectiveUser }
+				)
+				: '';
 
 			# If the set has hide_score set, then nothing left to do.
 			if (defined $set->hide_score && $set->hide_score eq 'Y'
@@ -281,8 +270,8 @@ sub displayStudentGrades ($c) {
 				next;
 			}
 			# This is a test version, and the scores can be shown, so also show score of template set.
-			$allItems{$setTemplateID}{message}    = '' if $allItems{$setTemplateID}{hide_score};
-			$allItems{$setTemplateID}{hide_score} = 0;
+			$allItems{$setID}{message}    = '' if $allItems{$setID}{hide_score};
+			$allItems{$setID}{hide_score} = 0;
 		}
 
 		my ($total_right, $total, $problem_scores, $problem_incorrect_attempts, $problem_records) =
@@ -341,7 +330,7 @@ sub displayStudentGrades ($c) {
 		# If this is a test version, update template set to the best grade a student hand.
 		if ($setIsVersioned) {
 			# Compare the score to the template set and update as needed.
-			my $templateItem = $allItems{$setTemplateID};
+			my $templateItem = $allItems{$setID};
 			if ($templateItem->{grade} == 0 || $item->{grade} > $templateItem->{grade}) {
 				$templateItem->{version_id}   = $set->version_id;
 				$templateItem->{version_link} = $item->{link};

--- a/lib/WeBWorK/ContentGenerator/Hardcopy.pm
+++ b/lib/WeBWorK/ContentGenerator/Hardcopy.pm
@@ -376,7 +376,7 @@ sub display_form ($c) {
 			# here, which probably is not very robust, and certainly is aesthetically displeasing.  Yuck.
 			push(@setVersions,
 				map { $_->set_id($_->set_id . ",v" . $_->version_id); $_ }
-					$db->getSetVersionsWhere({ user_id => $eUserID, set_id => { like => $v->set_id . ',v%' } }));
+					$db->getSetVersionsWhere({ user_id => $eUserID, set_id => $v->set_id }));
 		}
 
 		# Filter out global gateway sets.  Only the versioned sets may be printed.
@@ -945,8 +945,11 @@ async sub write_set_tex ($c, $FH, $TargetUser, $themeTree, $setID) {
 	if ($header eq 'defaultHeader') { $header = $ce->{webworkFiles}{hardcopySnippets}{setHeader}; }
 
 	# get list of problem IDs
-	my @problemIDs = map { $_->[2] }
-		$db->listUserProblemsWhere({ user_id => $MergedSet->user_id, set_id => $MergedSet->set_id }, 'problem_id');
+	my @problemIDs =
+		map { $_->[2] }
+		$db->listUserProblemsWhere(
+			{ user_id => $MergedSet->user_id, set_id => $MergedSet->set_id, version_id => $MergedSet->version_id },
+			'problem_id');
 
 	# for versioned sets (gateways), we might have problems in a random
 	# order; reset the order of the problemIDs if this is the case
@@ -1319,7 +1322,8 @@ async sub write_problem_tex ($c, $FH, $TargetUser, $MergedSet, $themeTree, $prob
 
 	if ($showComments) {
 		my $userPastAnswerID =
-			$db->latestProblemPastAnswer($MergedProblem->user_id, $versionName, $MergedProblem->problem_id);
+			$db->latestProblemPastAnswer($MergedProblem->user_id, $MergedSet->set_id, $MergedSet->version_id,
+				$MergedProblem->problem_id);
 
 		my $pastAnswer = $userPastAnswerID                          ? $db->getPastAnswer($userPastAnswerID) : 0;
 		my $comment    = $pastAnswer && $pastAnswer->comment_string ? $pastAnswer->comment_string           : "";

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemGrader.pm
@@ -45,7 +45,7 @@ async sub initialize ($c) {
 				user_id => [
 					map { $_->[0] } (
 						$c->stash->{set}->assignment_type =~ /gateway/
-						? $db->listSetVersionsWhere({ set_id => { like => "$setID,v\%" } })
+						? $db->listSetVersionsWhere({ set_id => $setID })
 						: $db->listUserSetsWhere({ set_id => $setID })
 					)
 				],
@@ -74,7 +74,7 @@ async sub initialize ($c) {
 		if ($c->stash->{set}->assignment_type =~ /gateway/) {
 			$user->{data} = [
 				map { { problem => $_ } } $db->getProblemVersionsWhere(
-					{ user_id => $user->user_id, problem_id => $problemID, set_id => { like => "$setID,v\%" } }
+					{ user_id => $user->user_id, problem_id => $problemID, set_id => $setID }
 				)
 			];
 		} else {
@@ -84,9 +84,8 @@ async sub initialize ($c) {
 
 		for (@{ $user->{data} }) {
 			next unless defined $_->{problem};
-			my $versionID = ref($_->{problem}) =~ /::ProblemVersion/ ? $_->{problem}->version_id : 0;
-			my $userPastAnswerID =
-				$db->latestProblemPastAnswer($user->user_id, $setID . ($versionID ? ",v$versionID" : ''), $problemID);
+			my $versionID        = ref($_->{problem}) =~ /::ProblemVersion/ ? $_->{problem}->version_id : 0;
+			my $userPastAnswerID = $db->latestProblemPastAnswer($user->user_id, $setID, $versionID, $problemID);
 			$_->{past_answer} = $db->getPastAnswer($userPastAnswerID) if ($userPastAnswerID);
 			($_->{problemNumber}, $_->{pageNumber}) = get_test_problem_position($db, $_->{problem}) if $versionID;
 
@@ -103,7 +102,7 @@ async sub initialize ($c) {
 		my %mergedSets;
 		if ($c->stash->{set}->assignment_type =~ /gateway/) {
 			$mergedSets{ $_->user_id }{ $_->version_id } = $_
-				for $db->getMergedSetVersionsWhere({ set_id => { like => "$setID,v\%" } });
+				for $db->getMergedSetVersionsWhere({ set_id => $setID });
 		} else {
 			%mergedSets = map { $_->user_id => { 0 => $_ } } $db->getMergedSetsWhere({ set_id => $setID });
 		}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ProblemSetDetail.pm
@@ -627,7 +627,7 @@ sub fieldTable ($c, $userID, $setID, $problemID, $globalRecord, $userRecord = un
 	my $extraFields = '';
 
 	# Are we editing a set version?
-	my $setVersion = defined($userRecord) && $userRecord->can('version_id') ? 1 : 0;
+	my $setVersion = defined($userRecord) && $userRecord->version_id;
 
 	# Needed for ip restrictions
 	my $ipFields     = '';
@@ -1064,7 +1064,7 @@ sub extraSetFields ($c, $userID, $setID, $globalRecord, $userRecord, $forUsers) 
 			# Don't show template gateway fields when editing set versions.
 			next
 				if (($gwfield eq "time_interval" || $gwfield eq "versions_per_interval")
-					&& ($forUsers && $userRecord->can('version_id')));
+					&& ($forUsers && $userRecord->version_id));
 
 			my @fieldData = $c->fieldHTML($userID, $setID, undef, $globalRecord, $userRecord, $gwfield);
 			if (@fieldData && defined($fieldData[0]) && $fieldData[0] ne '') {
@@ -1157,7 +1157,7 @@ sub extraSetFields ($c, $userID, $setID, $globalRecord, $userRecord, $forUsers) 
 	my $ipFields = '';
 
 	if (
-		(!defined $userRecord || (defined $userRecord && !$userRecord->can('version_id')))
+		(!defined $userRecord || (defined $userRecord && !$userRecord->version_id))
 		&& ((!$forUsers && $globalRecord->restrict_ip && $globalRecord->restrict_ip ne 'No')
 			|| ($forUsers && $userRecord->restrict_ip ne 'No'))
 		)
@@ -1313,7 +1313,6 @@ sub initialize ($c) {
 	my $ce    = $c->ce;
 	my $authz = $c->authz;
 	my $user  = $c->param('user');
-	my $setID = $c->stash('setID');
 
 	# Make sure these are defined for the templates.
 	$c->stash->{headers}             = HEADER_ORDER();
@@ -1325,13 +1324,11 @@ sub initialize ($c) {
 	$c->stash->{userProblems}        = {};
 	$c->stash->{userProblemVersions} = {};
 
-	# A set may be provided with a version number (as in setID,v#).
-	# If so obtain the template set id and version number.
-	my $editingSetVersion = 0;
-	if ($setID =~ /,v(\d+)$/) {
-		$editingSetVersion = $1;
-		$setID =~ s/,v(\d+)$//;
-	}
+	return unless ($authz->hasPermissions($user, 'access_instructor_tools'));
+	return unless ($authz->hasPermissions($user, 'modify_problem_sets'));
+
+	my $setID             = $c->stash('setID');
+	my $editingSetVersion = $c->stash('versionID') // 0;
 
 	$c->stash->{setID}             = $setID;
 	$c->stash->{editingSetVersion} = $editingSetVersion;
@@ -1339,9 +1336,6 @@ sub initialize ($c) {
 	my $setRecord = $db->getGlobalSet($setID);
 	$c->stash->{setRecord} = $setRecord;
 	return unless $setRecord;
-
-	return unless ($authz->hasPermissions($user, 'access_instructor_tools'));
-	return unless ($authz->hasPermissions($user, 'modify_problem_sets'));
 
 	my @editForUser = $c->param('editForUser');
 
@@ -2038,7 +2032,7 @@ sub initialize ($c) {
 		if ($editingSetVersion) {
 			$c->stash->{userProblemVersions} = {
 				map { $_->problem_id => $_ } $db->getProblemVersionsWhere(
-					{ user_id => $editForUser[0], set_id => "$setID,v$editingSetVersion" }
+					{ user_id => $editForUser[0], set_id => $setID, version_id => $editingSetVersion }
 				)
 			};
 		}

--- a/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/ShowAnswers.pm
@@ -35,6 +35,9 @@ async sub initialize ($c) {
 	my $selectedSets     = [ $c->param('selected_sets') ]     // [];
 	my $selectedProblems = [ $c->param('selected_problems') ] // [];
 
+	# Parse each selected_sets entry into a (setID, versionID) pair.
+	my @selectedSetPairs = map { [ $_ =~ /^([^,]+)(?:,v(\d+))?$/ ] } @$selectedSets;
+
 	my $instructor = $c->authz->hasPermissions($user, 'access_instructor_tools');
 
 	# If not instructor then force table to use current user-id
@@ -49,22 +52,11 @@ async sub initialize ($c) {
 	for my $studentUser (@$selectedUsers) {
 		my @sets;
 
-		# search for selected sets assigned to students
-		my @allSets = $db->listUserSets($studentUser);
-		for my $setName (@allSets) {
-			my $set = $db->getMergedSet($studentUser, $setName);
-			if (defined($set->assignment_type) && $set->assignment_type =~ /gateway/) {
-				my @versions = $db->listSetVersions($studentUser, $setName);
-				for my $version (@versions) {
-					if (grep {/^$setName,v$version$/} @$selectedSets) {
-						$set = $db->getUserSet($studentUser, "$setName,v$version");
-						push(@sets, $set);
-					}
-				}
-			} elsif (grep {/^$setName$/} @$selectedSets) {
-				push(@sets, $set);
-			}
-
+		# Get the merged set record for each selected (setID, versionID) pair.
+		for (@selectedSetPairs) {
+			my $set =
+				$_->[1] ? $db->getSetVersion($studentUser, $_->[0], $_->[1]) : $db->getMergedSet($studentUser, $_->[0]);
+			push(@sets, $set) if $set;
 		}
 
 		next unless @sets;
@@ -72,6 +64,9 @@ async sub initialize ($c) {
 		for my $setRecord (@sets) {
 			my @problemNumbers;
 			my $setName    = $setRecord->set_id;
+			my $setVersion = $setRecord->version_id;
+			# Distinguish set versions from each other for hash keys and display.
+			my $displaySetName = $setVersion ? "$setName,v$setVersion" : $setName;
 			my $isJitarSet = (defined($setRecord->assignment_type) && $setRecord->assignment_type eq 'jitar') ? 1 : 0;
 
 			# search for matching problems
@@ -82,7 +77,7 @@ async sub initialize ($c) {
 				if ($isJitarSet) {
 					$prettyProblemNumber = join('.', jitar_id_to_seq($problemNumber));
 				}
-				$prettyProblemNumbers{$setName}{$problemNumber} = $prettyProblemNumber;
+				$prettyProblemNumbers{$displaySetName}{$problemNumber} = $prettyProblemNumber;
 
 				if (grep {/^$prettyProblemNumber$/} @$selectedProblems) {
 					push(@problemNumbers, $problemNumber);
@@ -93,15 +88,20 @@ async sub initialize ($c) {
 
 			for my $problemNumber (@problemNumbers) {
 				my @pastAnswers = $db->getPastAnswersWhere(
-					{ user_id => $studentUser, set_id => $setName, problem_id => $problemNumber }, 'answer_id');
+					{
+						user_id    => $studentUser,
+						set_id     => $setName,
+						version_id => $setVersion,
+						problem_id => $problemNumber
+					},
+					'answer_id'
+				);
 				next unless @pastAnswers;
 
 				# Get answer types from the user problem.
 				my $problem;
 				if ($setRecord->assignment_type =~ /gateway/) {
-					my ($unversionedSetID, $versionID) = $setName =~ /^([^,]*),v(\d*)$/;
-					$problem =
-						$db->getMergedProblemVersion($studentUser, $unversionedSetID, $versionID, $problemNumber);
+					$problem = $db->getMergedProblemVersion($studentUser, $setName, $setVersion, $problemNumber);
 				} else {
 					$problem = $db->getMergedProblem($studentUser, $setName, $problemNumber);
 				}
@@ -117,14 +117,11 @@ async sub initialize ($c) {
 				# figure out what type the answers are.  This is usually only the case for the old type of flags value,
 				# which means this is a course restored from a course archive from a previous version of webwork2.
 				if (!@answerTypes) {
-					if (!defined $fallbackAnswerTypes{$setName}{$problemNumber}) {
-						my $set;
-						if ($setName =~ /,v[0-9]*$/) {
-							my ($unversionedSetID, $versionID) = $setName =~ /^([^,]*),v(\d*)$/;
-							$set = $db->getMergedSetVersion($studentUser, $unversionedSetID, $versionID);
-						} else {
-							$set = $db->getMergedSet($studentUser, $setName);
-						}
+					if (!defined $fallbackAnswerTypes{$displaySetName}{$problemNumber}) {
+						my $set =
+							$setVersion
+							? $db->getMergedSetVersion($studentUser, $setName, $setVersion)
+							: $db->getMergedSet($studentUser, $setName);
 						my $userRecord = $db->getUser($studentUser);
 
 						next unless defined $set && defined $userRecord;
@@ -147,17 +144,17 @@ async sub initialize ($c) {
 
 						for (@{ $pg->{flags}{ANSWER_ENTRY_ORDER} // [] }) {
 							push(
-								@{ $fallbackAnswerTypes{$setName}{$problemNumber} },
+								@{ $fallbackAnswerTypes{$displaySetName}{$problemNumber} },
 								$pg->{PG_ANSWERS_HASH}{$_}{rh_ans}{type} // 'undefined'
 							);
 						}
 					}
-					@answerTypes = @{ $fallbackAnswerTypes{$setName}{$problemNumber} }
-						if defined $fallbackAnswerTypes{$setName}{$problemNumber};
+					@answerTypes = @{ $fallbackAnswerTypes{$displaySetName}{$problemNumber} }
+						if defined $fallbackAnswerTypes{$displaySetName}{$problemNumber};
 				}
 
 				for my $pastAnswer (@pastAnswers) {
-					$records{$studentUser}{$setName}{$problemNumber}{ $pastAnswer->answer_id } = {
+					$records{$studentUser}{$displaySetName}{$problemNumber}{ $pastAnswer->answer_id } = {
 						time        => $pastAnswer->timestamp,
 						seed        => $pastAnswer->problem_seed,
 						answers     => [ split(/\t/, $pastAnswer->answer_string) ],

--- a/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/Stats.pm
@@ -168,9 +168,7 @@ sub set_stats ($c) {
 		my $noSkip = 0;
 		if ($c->{setRecord}->assignment_type =~ /gateway/) {
 			# Only use the quiz version with the best score.
-			my @setVersions =
-				$db->getMergedSetVersionsWhere(
-					{ user_id => $student, set_id => { like => $c->stash('setID') . ',v%' } });
+			my @setVersions = $db->getMergedSetVersionsWhere({ user_id => $student, set_id => $c->stash('setID') });
 			if (@setVersions) {
 				my $maxVersion = 1;
 				my $maxStatus  = 0;
@@ -362,10 +360,8 @@ sub problem_stats ($c) {
 		my $studentProblem;
 
 		if ($c->{setRecord}->assignment_type =~ /gateway/) {
-			my @problemRecords =
-				$db->getProblemVersionsWhere(
-					{ user_id => $student, problem_id => $problemID, set_id => { like => $c->stash('setID') . ',v%' } }
-				);
+			my @problemRecords = $db->getProblemVersionsWhere(
+				{ user_id => $student, problem_id => $problemID, set_id => $c->stash('setID') });
 			my $maxRecord = 0;
 			my $maxStatus = 0;
 			for (0 .. $#problemRecords) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/StudentProgress.pm
@@ -11,7 +11,7 @@ use WeBWorK::Utils                    qw(wwRound);
 use WeBWorK::Utils::DateTime          qw(after);
 use WeBWorK::Utils::FilterRecords     qw(getFiltersForClass filterRecords);
 use WeBWorK::Utils::JITAR             qw(jitar_id_to_seq);
-use WeBWorK::Utils::Sets              qw(grade_set list_set_versions format_set_name_display);
+use WeBWorK::Utils::Sets              qw(grade_set format_set_name_display);
 use WeBWorK::Utils::ProblemProcessing qw(compute_unreduced_score);
 
 sub initialize ($c) {
@@ -117,18 +117,18 @@ sub displaySets ($c) {
 	my @score_list;
 	my @user_set_list;
 
+	my $setName = $c->stash('setID');
+
 	for my $studentRecord (@student_records) {
 		my $studentName = $studentRecord->user_id;
-		my ($allSetVersionNames, $notAssignedSet) =
-			list_set_versions($db, $studentName, $c->stash('setID'), $setIsVersioned);
+		next unless $db->existsUserSet($studentName, $setName);
 
-		next if $notAssignedSet;
+		my @versionIDs = $setIsVersioned ? $db->listSetVersions($studentName, $setName) : (0);
 
 		my $max_version_data = {};
 
-		for my $setName (@$allSetVersionNames) {
+		for my $vNum (@versionIDs) {
 			my $set;
-			my $vNum = 0;
 
 			# For versioned tests we might be displaying the test date and test time,
 			# and we need to know if the test is proctored or not.
@@ -138,7 +138,6 @@ sub displaySets ($c) {
 			my $proctored  = 0;
 
 			if ($setIsVersioned) {
-				($setName, $vNum) = ($setName =~ /(.+),v(\d+)$/);
 				# Information from the set is needed to set up the display below. So get the merged user set as well.
 				$set        = $db->getMergedSetVersion($studentRecord->user_id, $setName, $vNum);
 				$dateOfTest = localtime($set->version_creation_time());
@@ -198,7 +197,7 @@ sub displaySets ($c) {
 			}
 		}
 
-		if ($showBestOnly || !@$allSetVersionNames) {
+		if ($showBestOnly || !@versionIDs) {
 			# If only the best score is to be shown or there were no set versions and the set was assigned to the user,
 			# then add the score to the list of scores and add the data to the set data list.
 			push(@score_list,
@@ -296,8 +295,6 @@ sub displayStudentStats ($c) {
 		return '';
 	}
 
-	my $courseName = $ce->{courseName};
-
 	# First get all merged sets for this user ordered by set_id.
 	my @sets = $db->getMergedSetsWhere({ user_id => $studentID }, 'set_id');
 	# To be able to find the set objects later, make a handy hash of set ids to set objects.
@@ -318,8 +315,7 @@ sub displayStudentStats ($c) {
 		if (defined $set->assignment_type && $set->assignment_type =~ /gateway/) {
 			# We have to have the merged set versions to know what each of their assignment types are
 			# (because proctoring can change this).
-			my @setVersions =
-				$db->getMergedSetVersionsWhere({ user_id => $studentID, set_id => { like => "$setID,v\%" } });
+			my @setVersions = $db->getMergedSetVersionsWhere({ user_id => $studentID, set_id => $setID });
 
 			# Add the set versions to our list of sets.
 			$setsByID{ $_->set_id . ',v' . $_->version_id } = $_ for (@setVersions);
@@ -367,29 +363,28 @@ sub displayStudentStats ($c) {
 
 	my $rows = $c->c;
 	for my $setID (@allSetIDs) {
-		my $act_as_student_set_url =
-			$c->systemLink($c->url_for('problem_list', setID => $setID), params => { effectiveUser => $effectiveUser });
 		my $set = $setsByID{$setID};
+
+		my $act_as_student_set_url = $c->systemLink($c->url_for('problem_list', setID => $set->set_id),
+			params => { effectiveUser => $effectiveUser });
 
 		# Determine if set is a test and create the test url.
 		my $setIsVersioned          = 0;
 		my $act_as_student_test_url = '';
 		if (defined $set->assignment_type && $set->assignment_type =~ /gateway/) {
 			$setIsVersioned = 1;
-			if ($set->assignment_type eq 'proctored_gateway') {
-				$act_as_student_test_url = $act_as_student_set_url =~ s/($courseName)\//$1\/proctored_test_mode\//r;
-			} else {
-				$act_as_student_test_url = $act_as_student_set_url =~ s/($courseName)\//$1\/test_mode\//r;
-			}
-			# Remove version from set url
-			$act_as_student_set_url =~ s/,v\d+//;
+			# This is an instructor-only link, so use the plain (non-proctored) route regardless of the test's
+			# assignment type. GatewayQuiz.pm is responsible for checking permissions.
+			$act_as_student_test_url = $c->systemLink(
+				$c->url_for('gateway_quiz_version', setID => $set->set_id, versionID => $set->version_id),
+				params => { effectiveUser => $effectiveUser });
 		}
 
 		# Format set name based on set visibility.
 		my $setName = $c->tag(
 			'span',
 			class => $set->visible ? 'font-visible' : 'font-hidden',
-			format_set_name_display($setID =~ s/,v\d+$//r)
+			format_set_name_display($set->set_id)
 		);
 
 		# If the set is a template gateway set and there are no versions, we acknowledge that the set exists and the
@@ -518,9 +513,8 @@ sub displayStudentStats ($c) {
 		# If its a gateway set, then in order to mimic the scoring done in Scoring Tools we need to use the best score a
 		# student had.  Otherwise we just add the set to the running course total.
 		if ($setIsVersioned) {
-			$setID =~ /(.+),v(\d+)$/;
-			my $gatewayName    = $1;
-			my $currentVersion = $2;
+			my $gatewayName    = $set->set_id;
+			my $currentVersion = $set->version_id;
 
 			# If we are just starting a new gateway then set variables to look for the max.
 			if ($currentVersion == 1) {

--- a/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserDetail.pm
@@ -7,7 +7,6 @@ WeBWorK::ContentGenerator::Instructor::UserDetail - Detailed User specific infor
 
 =cut
 
-use WeBWorK::DB::Utils         qw(grok_versionID_from_vsetID_sql);
 use WeBWorK::Utils             qw(x);
 use WeBWorK::Utils::Instructor qw(assignSetToUser);
 use WeBWorK::Debug             qw(debug);
@@ -88,29 +87,28 @@ sub initialize ($c) {
 				# If the set is a gateway set, also check to see if we're resetting the dates for any of the assigned
 				# set versions, or if a version is to be deleted.
 				if ($setRecord->assignment_type =~ /gateway/) {
-					my @setVer =
-						$db->getSetVersionsWhere({ user_id => $editForUserID, set_id => { like => "$setID,v\%" } });
+					my @setVer = $db->getSetVersionsWhere({ user_id => $editForUserID, set_id => $setID });
 					for my $setVersionRecord (@setVer) {
 						my $ver    = $setVersionRecord->version_id;
-						my $action = $c->param("set.$setID,v$ver.assignment");
+						my $action = $c->param("set.$setID.$ver.assignment");
 						if (defined $action) {
 							if ($action eq 'assigned') {
 								# This version is not to be deleted.
 								# Check to see if the dates have been changed for this version.
 								# Note that dates are never reset (set to NULL) for a set version.
-								my $rh_dates = $c->checkDates($setVersionRecord, "$setID,v$ver");
+								my $rh_dates = $c->checkDates($setVersionRecord, $setID, $ver);
 								unless ($rh_dates->{error}) {
 									for my $field (@{ DATE_FIELDS_ORDER() }) {
 										$setVersionRecord->$field($rh_dates->{$field})
-											if ($c->param("set.$setID,v$ver.$field")
-												&& $c->param("set.$setID,v$ver.$field") ne '');
+											if ($c->param("set.$setID.$ver.$field")
+												&& $c->param("set.$setID.$ver.$field") ne '');
 									}
 									$db->putSetVersion($setVersionRecord);
 								}
 								# Reset the date inputs to the date in the database if they were empty.
 								for my $field (@{ DATE_FIELDS_ORDER() }) {
-									$c->param("set.$setID,v$ver.$field", $setVersionRecord->$field)
-										unless $c->param("set.$setID,v$ver.$field");
+									$c->param("set.$setID.$ver.$field", $setVersionRecord->$field)
+										unless $c->param("set.$setID.$ver.$field");
 								}
 							} elsif ($action eq 'delete') {
 								# Delete this version.
@@ -131,9 +129,7 @@ sub initialize ($c) {
 	# This must be done after saving so that the updated data is obtained.
 
 	# Create a hash of set ids to set records, and a hash of set ids to merged set records for this user.
-	$c->{userSetRecords} =
-		{ map { $_->set_id => $_ }
-			$db->getUserSetsWhere({ user_id => $editForUserID, set_id => { not_like => '%,v%' } }) };
+	$c->{userSetRecords}   = { map { $_->set_id => $_ } $db->getUserSetsWhere({ user_id => $editForUserID }) };
 	$c->{mergedSetRecords} = { map { $_->set_id => $_ } $db->getMergedSetsWhere({ user_id => $editForUserID }) };
 
 	# Get all versions and merged versions for gateway sets.
@@ -141,32 +137,27 @@ sub initialize ($c) {
 		next unless $set->assignment_type =~ /gateway/;
 		my $setID = $set->set_id;
 
-		$c->{setVersions}{$setID} = [
-			$db->getSetVersionsWhere(
-				{ user_id => $editForUserID, set_id => { like => "$setID,v\%" } }, 'version_id'
-			)
-		];
-		$c->{mergedVersions}{$setID} = [
-			$db->getMergedSetVersionsWhere(
-				{ user_id => $editForUserID, set_id => { like => "$setID,v\%" } },
-				\grok_versionID_from_vsetID_sql($db->{set_version_merged}->sql->_quote('set_id'))
-			)
-		];
+		$c->{setVersions}{$setID} =
+			[ $db->getSetVersionsWhere({ user_id => $editForUserID, set_id => $setID }, 'version_id') ];
+		$c->{mergedVersions}{$setID} =
+			[ $db->getMergedSetVersionsWhere({ user_id => $editForUserID, set_id => $setID }, 'version_id') ];
 	}
 
 	return;
 }
 
-sub checkDates ($c, $setRecord, $setID) {
+sub checkDates ($c, $setRecord, $setID, $setVersion = 0) {
+	my $fullSetID = $setVersion ? "$setID.$setVersion" : $setID;
+
 	# For each of the dates, use the override date if set.  Otherwise use the value from the global set.
 	# Except in the case that this is a set version. In that case use 0 which will result in an error below.
 	# This will prevent the dates for the set version from being changed to invalid values in that case.
 	my %dates;
 	for my $field (@{ DATE_FIELDS_ORDER() }) {
 		$dates{$field} =
-			($c->param("set.$setID.$field") && $c->param("set.$setID.$field") ne '')
-			? $c->param("set.$setID.$field")
-			: ($setID =~ /,v\d+$/ ? 0 : $setRecord->$field);
+			($c->param("set.$fullSetID.$field") && $c->param("set.$fullSetID.$field") ne '')
+			? $c->param("set.$fullSetID.$field")
+			: ($setVersion ? 0 : $setRecord->$field);
 	}
 
 	my ($open_date, $reduced_scoring_date, $due_date, $answer_date) = map { $dates{$_} } @{ DATE_FIELDS_ORDER() };

--- a/lib/WeBWorK/ContentGenerator/LoginProctor.pm
+++ b/lib/WeBWorK/ContentGenerator/LoginProctor.pm
@@ -9,7 +9,6 @@ GatewayQuiz proctored tests.
 =cut
 
 use WeBWorK::Utils::Rendering qw(renderPG);
-use WeBWorK::DB::Utils        qw(grok_vsetID);
 
 async sub initialize ($c) {
 	my $ce = $c->ce;
@@ -23,7 +22,7 @@ async sub initialize ($c) {
 	# The user set is needed to check for a set-restricted login proctor, and to show and possibly save the submission
 	# time.  To get the user set, the set name and version number are needed.  Attempt to obtain those from the url path
 	# setID.  Otherwise, use the highest version number.
-	($c->stash->{setID}, my $versionNum) = grok_vsetID($c->stash('setID'));
+	my $versionNum    = $c->stash->{versionID};
 	my $noSetVersions = 0;
 	if (!$versionNum) {
 		# Get a list of all available versions.

--- a/lib/WeBWorK/ContentGenerator/Problem.pm
+++ b/lib/WeBWorK/ContentGenerator/Problem.pm
@@ -1252,7 +1252,7 @@ sub output_comments ($c) {
 	my $db = $c->db;
 
 	my $userPastAnswerID =
-		$db->latestProblemPastAnswer($c->param('effectiveUser'), $c->stash('setID'), $c->stash('problemID'));
+		$db->latestProblemPastAnswer($c->param('effectiveUser'), $c->stash('setID'), 0, $c->stash('problemID'));
 
 	# If there is a comment then display it.
 	if ($userPastAnswerID) {

--- a/lib/WeBWorK/ContentGenerator/ProblemSet.pm
+++ b/lib/WeBWorK/ContentGenerator/ProblemSet.pm
@@ -14,7 +14,6 @@ use WeBWorK::Utils::DateTime  qw(after);
 use WeBWorK::Utils::Files     qw(path_is_subdir);
 use WeBWorK::Utils::Rendering qw(renderPG);
 use WeBWorK::Utils::Sets      qw(is_restricted grade_set format_set_name_display);
-use WeBWorK::DB::Utils        qw(grok_versionID_from_vsetID_sql);
 use WeBWorK::Localize;
 use WeBWorK::AchievementItems;
 use WeBWorK::HTML::StudentNav qw(studentNav);
@@ -91,12 +90,8 @@ async sub initialize ($c) {
 	# Import problem records for assignments or test version records for tests now. Then initialize all
 	# achievement item data to have access to the updated records if an achievement item was used.
 	if ($c->{set}->assignment_type =~ /gateway/) {
-		$c->{setVersions} = [
-			$db->getMergedSetVersionsWhere(
-				{ user_id => $eUserID, set_id => { like => $c->{set}->set_id . ',v%' } },
-				\grok_versionID_from_vsetID_sql($db->{set_version_merged}->sql->_quote('set_id'))
-			)
-		];
+		$c->{setVersions} =
+			[ $db->getMergedSetVersionsWhere({ user_id => $eUserID, set_id => $c->{set}->set_id }, 'version_id') ];
 		$c->{achievementItems} = WeBWorK::AchievementItems::UserItems($c, $eUserID, $c->{set}, $c->{setVersions});
 	} else {
 		$c->{setProblems} =
@@ -187,10 +182,8 @@ sub siblings ($c) {
 	# Restrict navigation to other problem sets if not allowed.
 	return '' unless $authz->hasPermissions($user, 'navigation_allowed');
 
-	# Note that listUserSets does not list versioned sets, but listUserSetsWhere does.  On the other hand, listUserSets
-	# cannot sort in the database, while listUserSetsWhere can.
-	my @setIDs =
-		map { $_->[1] } $db->listUserSetsWhere({ user_id => $eUserID, set_id => { not_like => '%,v%' } }, 'set_id');
+	# Note that listUserSets cannot sort in the database, while listUserSetsWhere can.
+	my @setIDs = map { $_->[1] } $db->listUserSetsWhere({ user_id => $eUserID }, 'set_id');
 
 	# Do not show hidden siblings unless user is allowed to view hidden sets.
 	unless ($authz->hasPermissions($user, 'view_hidden_sets')) {

--- a/lib/WeBWorK/DB.pm
+++ b/lib/WeBWorK/DB.pm
@@ -81,7 +81,6 @@ use Mojo::JSON     qw(encode_json decode_json);
 use WeBWorK::DB::Database;
 use WeBWorK::DB::Schema;
 use WeBWorK::DB::Layout qw(databaseLayout);
-use WeBWorK::DB::Utils  qw(grok_vsetID);
 use WeBWorK::Utils      qw(runtime_use);
 
 # How these exceptions should be used:
@@ -683,7 +682,7 @@ sub getKeys {
 }
 
 sub addKey {
-	my ($self, $Key) = shift->checkArgs(\@_, qw/VREC:key/);
+	my ($self, $Key) = shift->checkArgs(\@_, qw/REC:key/);
 
 	WeBWorK::DB::Ex::DependencyNotFound->throw(error => 'addKey: user ' . $Key->user_id . ' not found')
 		unless $Key->key eq "nonce" || $self->{user}->exists($Key->user_id);
@@ -695,7 +694,7 @@ sub addKey {
 }
 
 sub putKey {
-	my ($self, $Key) = shift->checkArgs(\@_, qw/VREC:key/);
+	my ($self, $Key) = shift->checkArgs(\@_, qw/REC:key/);
 	my $keyCopy = $self->newKey($Key);
 	$keyCopy->session(encode_json($Key->session)) if ref($Key->session) eq 'HASH';
 	my $rows = $self->{key}->put($keyCopy);    # DBI returns 0E0 for 0.
@@ -1021,12 +1020,12 @@ BEGIN {
 sub countProblemPastAnswers { return scalar shift->listPastAnswers(@_) }
 
 sub listProblemPastAnswers {
-	my ($self, $userID, $setID, $problemID);
+	my ($self, $userID, $setID, $versionID, $problemID);
 	$self = shift;
-	$self->checkArgs(\@_, qw/user_id set_id problem_id/);
+	$self->checkArgs(\@_, qw/user_id set_id version_id problem_id/);
 
-	($userID, $setID, $problemID) = @_;
-	my $where = [ user_id_eq_set_id_eq_problem_id_eq => $userID, $setID, $problemID ];
+	($userID, $setID, $versionID, $problemID) = @_;
+	my $where = [ user_id_eq_set_id_eq_version_id_eq_problem_id_eq => $userID, $setID, $versionID, $problemID ];
 
 	my $order = ['answer_id'];
 
@@ -1038,12 +1037,12 @@ sub listProblemPastAnswers {
 }
 
 sub latestProblemPastAnswer {
-	my ($self, $userID, $setID, $problemID);
+	my ($self, $userID, $setID, $versionID, $problemID);
 	$self = shift;
-	$self->checkArgs(\@_, qw/user_id set_id problem_id/);
+	$self->checkArgs(\@_, qw/user_id set_id version_id problem_id/);
 
-	($userID, $setID, $problemID) = @_;
-	my @answerIDs = $self->listProblemPastAnswers($userID, $setID, $problemID);
+	($userID, $setID, $versionID, $problemID) = @_;
+	my @answerIDs = $self->listProblemPastAnswers($userID, $setID, $versionID, $problemID);
 
 	#array should already be returned from lowest id to greatest.  Latest answer is greatest
 	return $answerIDs[-1];
@@ -1072,7 +1071,8 @@ sub addPastAnswer {
 			. $pastAnswer->set_id . ' '
 			. $pastAnswer->problem_id
 			. ' not found')
-		unless $self->{problem_user}->exists($pastAnswer->user_id, $pastAnswer->set_id, $pastAnswer->problem_id);
+		unless $self->{problem_user}
+		->exists($pastAnswer->user_id, $pastAnswer->set_id, $pastAnswer->version_id, $pastAnswer->problem_id);
 
 	return $self->{past_answer}->add($pastAnswer);
 }
@@ -1416,8 +1416,6 @@ sub getUserSets {
 	return $self->{set_user}->gets(@userSetIDs);
 }
 
-# the code from addUserSet() is duplicated in large part following in
-# addVersionedUserSet; changes here should accordingly be propagated down there
 sub addUserSet {
 	my ($self, $UserSet) = shift->checkArgs(\@_, qw/REC:set_user/);
 	WeBWorK::DB::Ex::DependencyNotFound->throw(error => 'addUserSet: user ' . $UserSet->user_id . ' not found')
@@ -1427,8 +1425,6 @@ sub addUserSet {
 	return $self->{set_user}->add($UserSet);
 }
 
-# the code from putUserSet() is duplicated in large part in the following
-# putVersionedUserSet; c.f. that routine
 sub putUserSet {
 	my ($self, $UserSet) = shift->checkArgs(\@_, qw/REC:set_user/);
 	my $rows = $self->{set_user}->put($UserSet);    # DBI returns 0E0 for 0.
@@ -1476,7 +1472,7 @@ sub getMergedSets {
 }
 
 ################################################################################
-# set_version functions (NEW)
+# set_version functions
 ################################################################################
 
 BEGIN {
@@ -1719,7 +1715,7 @@ sub getAllUserSetLocations {
 
 sub addUserSetLocation {
 	# VERSIONING - accept versioned ID fields
-	my ($self, $UserSetLocation) = shift->checkArgs(\@_, qw/VREC:set_locations_user/);
+	my ($self, $UserSetLocation) = shift->checkArgs(\@_, qw/REC:set_locations_user/);
 	WeBWorK::DB::Ex::DependencyNotFound->throw(error => 'addUserSetLocation: user set '
 			. $UserSetLocation->set_id
 			. ' for user '
@@ -1730,10 +1726,8 @@ sub addUserSetLocation {
 }
 
 # FIXME: we won't ever use this because all fields are key fields
-# versioned_ok is an optional argument which lets us slip versioned setIDs through checkArgs.
 sub putUserSetLocation {
-	my $V = $_[2] ? "V" : "";
-	my ($self, $UserSetLocation, undef) = shift->checkArgs(\@_, "${V}REC:set_locations_user", "versioned_ok!?");
+	my ($self, $UserSetLocation, undef) = shift->checkArgs(\@_, "REC:set_locations_user", "!?");
 
 	my $rows = $self->{set_locations_user}->put($UserSetLocation);    # DBI returns 0E0 for 0.
 	WeBWorK::DB::Ex::RecordNotFound->throw(
@@ -1878,7 +1872,7 @@ sub listUserProblems {
 
 sub existsUserProblem {
 	my ($self, $userID, $setID, $problemID) = shift->checkArgs(\@_, qw/user_id set_id problem_id/);
-	return $self->{problem_user}->exists($userID, $setID, $problemID);
+	return $self->{problem_user}->exists_where({ user_id => $userID, set_id => $setID, problem_id => $problemID });
 }
 
 sub getUserProblem {
@@ -1886,9 +1880,14 @@ sub getUserProblem {
 	return ($self->getUserProblems([ $userID, $setID, $problemID ]))[0];
 }
 
+# Note that this cannot simply pass its list of keyparts on to the schema's generic "gets" method, since that maps
+# keyparts positionally onto the table's keyfields, and the version_id keyfield (which is not one of the keyparts
+# accepted here) sits between set_id and problem_id in that list.
 sub getUserProblems {
 	my ($self, @userProblemIDs) = shift->checkArgsRefList(\@_, qw/user_id set_id problem_id/);
-	return $self->{problem_user}->gets(@userProblemIDs);
+	return map {
+		$self->{problem_user}->get_records_where({ user_id => $_->[0], set_id => $_->[1], problem_id => $_->[2] })
+	} @userProblemIDs;
 }
 
 sub getAllUserProblems {
@@ -1898,29 +1897,27 @@ sub getAllUserProblems {
 }
 
 sub addUserProblem {
-	# VERSIONING - accept versioned ID fields
-	my ($self, $UserProblem) = shift->checkArgs(\@_, qw/VREC:problem_user/);
+	my ($self, $UserProblem) = shift->checkArgs(\@_, qw/REC:problem_user/);
 
 	WeBWorK::DB::Ex::DependencyNotFound->throw(error => 'addUserProblem: user set '
 			. $UserProblem->set_id
 			. ' for user '
 			. $UserProblem->user_id
 			. ' not found')
-		unless $self->{set_user}->exists($UserProblem->user_id, $UserProblem->set_id);
+		unless $self->{set_user}->exists($UserProblem->user_id, $UserProblem->set_id, $UserProblem->version_id);
 
-	my ($nv_set_id, $versionNum) = grok_vsetID($UserProblem->set_id);
-
-	WeBWorK::DB::Ex::DependencyNotFound->throw(
-		error => 'addUserProblem: problem ' . $UserProblem->problem_id . ' in set $nv_set_id not found')
-		unless $self->{problem}->exists($nv_set_id, $UserProblem->problem_id);
+	WeBWorK::DB::Ex::DependencyNotFound->throw(error => 'addUserProblem: problem '
+			. $UserProblem->problem_id
+			. ' in set '
+			. $UserProblem->set_id
+			. ' not found')
+		unless $self->{problem}->exists($UserProblem->set_id, $UserProblem->problem_id);
 
 	return $self->{problem_user}->add($UserProblem);
 }
 
-# versioned_ok is an optional argument which lets us slip versioned setIDs through checkArgs.
 sub putUserProblem {
-	my $V = $_[2] ? "V" : "";
-	my ($self, $UserProblem, undef) = shift->checkArgs(\@_, "${V}REC:problem_user", "versioned_ok!?");
+	my ($self, $UserProblem, undef) = shift->checkArgs(\@_, "REC:problem_user", "!?");
 
 	my $rows = $self->{problem_user}->put($UserProblem);    # DBI returns 0E0 for 0.
 	WeBWorK::DB::Ex::RecordNotFound->throw(
@@ -1933,7 +1930,11 @@ sub deleteUserProblem {
 	# userID, setID, and problemID can be undefined if being called from this package
 	my $U = caller eq __PACKAGE__ ? "!" : "";
 	my ($self, $userID, $setID, $problemID) = shift->checkArgs(\@_, "user_id$U", "set_id$U", "problem_id$U");
-	return $self->{problem_user}->delete($userID, $setID, $problemID);
+	my %where;
+	$where{user_id}    = $userID    if defined $userID;
+	$where{set_id}     = $setID     if defined $setID;
+	$where{problem_id} = $problemID if defined $problemID;
+	return $self->{problem_user}->delete_where(\%where);
 }
 
 ################################################################################
@@ -1959,9 +1960,14 @@ sub getMergedProblem {
 	return ($self->getMergedProblems([ $userID, $setID, $problemID ]))[0];
 }
 
+# Note that unlike most of the "gets" methods, this cannot simply pass its list of keyparts on to the schema's
+# generic "gets" method, since that maps keyparts positionally onto the table's keyfields, and the version_id
+# keyfield (which is not one of the keyparts accepted here) sits between set_id and problem_id in that list.
 sub getMergedProblems {
 	my ($self, @userProblemIDs) = shift->checkArgsRefList(\@_, qw/user_id set_id problem_id/);
-	return $self->{problem_merged}->gets(@userProblemIDs);
+	return map {
+		$self->{problem_merged}->get_records_where({ user_id => $_->[0], set_id => $_->[1], problem_id => $_->[2] })
+	} @userProblemIDs;
 }
 
 sub getAllMergedUserProblems {
@@ -2055,8 +2061,11 @@ sub addProblemVersion {
 			. ' of set '
 			. $ProblemVersion->set_id
 			. ' not found for user ')
-		unless $self->{problem_user}
-		->exists($ProblemVersion->user_id, $ProblemVersion->set_id, $ProblemVersion->problem_id);
+		unless $self->{problem_user}->exists_where({
+			user_id    => $ProblemVersion->user_id,
+			set_id     => $ProblemVersion->set_id,
+			problem_id => $ProblemVersion->problem_id
+		});
 
 	return $self->{problem_version}->add($ProblemVersion);
 }
@@ -2130,11 +2139,8 @@ sub check_user_id {    #  (valid characters are [-a-zA-Z0-9_.,@])
 	}
 }
 
-# The (optional) second argument to checkKeyfields is to support versioned
-# (gateway) sets, which may include commas in certain fields (in particular,
-# set names (e.g., setDerivativeGateway,v1)).
 sub checkKeyfields {
-	my ($Record, $versioned) = @_;
+	my ($Record) = @_;
 	foreach my $keyfield ($Record->KEYFIELDS) {
 		my $value     = $Record->$keyfield;
 		my $fielddata = $Record->FIELD_DATA;
@@ -2145,15 +2151,14 @@ sub checkKeyfields {
 		croak "empty '$keyfield' field"
 			unless $value ne "";
 
-		validateKeyfieldValue($keyfield, $value, $versioned);
+		validateKeyfieldValue($keyfield, $value);
 	}
 
 	return;
 }
 
 sub validateKeyfieldValue {
-
-	my ($keyfield, $value, $versioned) = @_;
+	my ($keyfield, $value) = @_;
 
 	if ($keyfield eq "problem_id" || $keyfield eq 'problemID') {
 		croak "invalid characters in '"
@@ -2162,14 +2167,6 @@ sub validateKeyfieldValue {
 			. encode_entities($value)
 			. "' (valid characters are [0-9])"
 			unless $value =~ m/^[0-9]*$/;
-	} elsif ($versioned && ($keyfield eq "set_id" || $keyfield eq 'setID')) {
-		croak "invalid characters in '"
-			. encode_entities($keyfield)
-			. "' field: '"
-			. encode_entities($value)
-			. "' (valid characters are [-a-zA-Z0-9_.,])"
-			unless $value =~ m/^[-a-zA-Z0-9_.,]*$/;
-		# } elsif ($versioned and $keyfield eq "user_id") {
 	} elsif ($keyfield eq "user_id" || $keyfield eq 'userID') {
 		check_user_id($value);    #  (valid characters are [-a-zA-Z0-9_.,]) see above.
 	} elsif ($keyfield eq "ip_mask") {
@@ -2195,14 +2192,13 @@ sub validateKeyfieldValue {
 # is_list = "*"
 # item = item_name undef_ok? optional?
 # item_name = record_item | bare_item
-# record_item = is_versioned? "REC:" table
-# is_versioned = "V"
+# record_item = "REC:" table
 # table = \w+
 # bare_item = \w+
 # undef_ok = "!"
 # optional = "?"
 #
-# [[V]REC:]foo[!][?][*]
+# [REC:]foo[!][?][*]
 
 sub checkArgs {
 	my ($self, $args, @spec) = @_;
@@ -2213,9 +2209,7 @@ sub checkArgs {
 		$min_args = 0;
 	} else {
 		foreach my $i (0 .. $#spec) {
-			#print "$i - $spec[$i]\n";
 			if ($spec[$i] =~ s/\?$//) {
-				#print "$i - matched\n";
 				$min_args = $i unless defined $min_args;
 			}
 		}
@@ -2235,10 +2229,10 @@ sub checkArgs {
 		}
 	}
 
-	my ($name, $versioned, $table);
+	my ($name, $table);
 	if ($is_list) {
 		$name = $spec[0];
-		($versioned, $table) = $name =~ /^(V?)REC:(.*)/;
+		($table) = $name =~ /^REC:(.*)/;
 	}
 
 	foreach my $i (0 .. @$args - 1) {
@@ -2247,14 +2241,14 @@ sub checkArgs {
 
 		unless ($is_list) {
 			$name = $spec[$i];
-			($versioned, $table) = $name =~ /^(V?)REC:(.*)/;
+			($table) = $name =~ /^REC:(.*)/;
 		}
 
 		if (defined $table) {
 			my $class = $self->{$table}{record};
 			croak "argument $pos must be of type $class"
 				unless blessed $arg && $arg->isa($class);
-			eval { checkKeyfields($arg, $versioned) };
+			eval { checkKeyfields($arg) };
 			croak "argument $pos contains $@" if $@;
 		} else {
 			if ($name !~ /!$/) {

--- a/lib/WeBWorK/DB/Record/PastAnswer.pm
+++ b/lib/WeBWorK/DB/Record/PastAnswer.pm
@@ -12,10 +12,11 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		answer_id      => { type => "INT AUTO_INCREMENT",    key => 1 },
-		user_id        => { type => "VARCHAR(100) NOT NULL", key => 1 },
-		set_id         => { type => "VARCHAR(100) NOT NULL", key => 1 },
-		problem_id     => { type => "INT NOT NULL",          key => 1 },
+		answer_id      => { type => "INT AUTO_INCREMENT",     key => 1 },
+		user_id        => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		set_id         => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		version_id     => { type => "INT NOT NULL DEFAULT 0", key => 1 },
+		problem_id     => { type => "INT NOT NULL",           key => 1 },
 		source_file    => { type => "TEXT" },
 		timestamp      => { type => "BIGINT" },
 		scores         => { type => "TINYTEXT" },

--- a/lib/WeBWorK/DB/Record/UserProblem.pm
+++ b/lib/WeBWorK/DB/Record/UserProblem.pm
@@ -13,9 +13,10 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id     => { type => "VARCHAR(100) NOT NULL", key => 1 },
-		set_id      => { type => "VARCHAR(100) NOT NULL", key => 1 },
-		problem_id  => { type => "INT NOT NULL",          key => 1 },
+		user_id     => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		set_id      => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		version_id  => { type => "INT NOT NULL DEFAULT 0", key => 1 },
+		problem_id  => { type => "INT NOT NULL",           key => 1 },
 		source_file => { type => "TEXT" },
 		# FIXME i think value should be able to hold decimal values...
 		value              => { type => "INT" },

--- a/lib/WeBWorK/DB/Record/UserSet.pm
+++ b/lib/WeBWorK/DB/Record/UserSet.pm
@@ -12,8 +12,9 @@ use warnings;
 
 BEGIN {
 	__PACKAGE__->_fields(
-		user_id                   => { type => "VARCHAR(100) NOT NULL", key => 1 },
-		set_id                    => { type => "VARCHAR(100) NOT NULL", key => 1 },
+		user_id                   => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		set_id                    => { type => "VARCHAR(100) NOT NULL",  key => 1 },
+		version_id                => { type => "INT NOT NULL DEFAULT 0", key => 1 },
 		psvn                      => { type => "INT UNIQUE NOT NULL AUTO_INCREMENT" },
 		set_header                => { type => "TEXT" },
 		hardcopy_header           => { type => "TEXT" },

--- a/lib/WeBWorK/DB/Schema/NewSQL.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL.pm
@@ -25,7 +25,7 @@ sub where_DEFAULT {
 	return {};
 }
 
-# can be used for user,password,permission,key,set_user,problem_user,vset_user
+# can be used for user,password,permission,key,set_user,problem_user
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
 	return { user_id => $user_id };
@@ -46,6 +46,12 @@ sub where_answer_id_eq {
 sub where_user_id_eq_set_id_eq_problem_id_eq {
 	my ($self, $flags, $user_id, $set_id, $problem_id) = @_;
 	return { user_id => $user_id, set_id => $set_id, problem_id => $problem_id };
+}
+
+# can be used for past answers
+sub where_user_id_eq_set_id_eq_version_id_eq_problem_id_eq {
+	my ($self, $flags, $user_id, $set_id, $version_id, $problem_id) = @_;
+	return { user_id => $user_id, set_id => $set_id, version_id => $version_id, problem_id => $problem_id };
 }
 
 # can be used for user,password,permission,key,set_user,problem_user

--- a/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/NonVersioned.pm
@@ -7,45 +7,53 @@ WeBWorK::DB::Schema::NewSQL::NonVersioned - provide access to non-versioned sets
 
 =cut
 
-use WeBWorK::DB::Utils qw(make_vsetID);
-
 use constant TABLES => qw(set_user problem_user);
 
-################################################################################
-# where clause
-################################################################################
-
-# Override where clause generators that can be used with non-versioned sets so
-# that they only match non-versioned sets.
+# Override where clause generators that can be used with non-versioned sets or problems so that they
+# only match non-versioned sets or problems (those are sets or problems with version_id equal to 0).
 
 sub where_DEFAULT {
 	my ($self, $flags) = @_;
-	return { set_id => { NOT_LIKE => make_vsetID("%", "%") } };
+	return { version_id => 0 };
 }
 
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
-	return { user_id => $user_id, set_id => { NOT_LIKE => make_vsetID("%", "%") } };
+	return { user_id => $user_id, version_id => 0 };
 }
 
 sub where_user_id_like {
 	my ($self, $flags, $user_id) = @_;
-	return { user_id => { LIKE => $user_id }, set_id => { NOT_LIKE => make_vsetID("%", "%") } };
+	return { user_id => { LIKE => $user_id }, version_id => 0 };
 }
 
-################################################################################
-# override keyparts_to_where to limit scope of where clauses
-################################################################################
+sub where_set_id_eq {
+	my ($self, $flags, $set_id) = @_;
+	return { set_id => $set_id, version_id => 0 };
+}
+
+sub where_set_id_eq_problem_id_eq {
+	my ($self, $flags, $set_id, $problem_id) = @_;
+	return { set_id => $set_id, problem_id => $problem_id, version_id => 0 };
+}
+
+sub where_user_id_eq_set_id_eq {
+	my ($self, $flags, $user_id, $set_id) = @_;
+	return { user_id => $user_id, set_id => $set_id, version_id => 0 };
+}
+
+# Override generic where clause methods to insist on a version_id of 0.
+
+sub conv_where {
+	my ($self, $where) = @_;
+	$where->{version_id} = 0 if ref($where) eq 'HASH' && !exists $where->{version_id};
+	return $self->SUPER::conv_where($where);
+}
 
 sub keyparts_to_where {
 	my ($self, @keyparts) = @_;
-
 	my $where = $self->SUPER::keyparts_to_where(@keyparts);
-
-	unless (exists $where->{set_id}) {
-		$where->{set_id} = { NOT_LIKE => make_vsetID("%", "%") };
-	}
-
+	$where->{version_id} = 0 unless exists $where->{version_id};
 	return $where;
 }
 

--- a/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
+++ b/lib/WeBWorK/DB/Schema/NewSQL/Versioned.pm
@@ -3,268 +3,69 @@ use Mojo::Base 'WeBWorK::DB::Schema::NewSQL::Std';
 
 =head1 NAME
 
-WeBWorK::DB::Schema::NewSQL::Versioned - provide access to versioned sets.
+WeBWorK::DB::Schema::NewSQL::Versioned - provide access to versioned sets and problems.
 
 =cut
 
-use WeBWorK::DB::Utils qw(make_vsetID make_vsetID_sql grok_setID_from_vsetID_sql grok_versionID_from_vsetID_sql);
-
 use constant TABLES => qw(set_version problem_version);
 
-################################################################################
-# where clause
-################################################################################
-
-# Override where clause generators that can be used with versioned sets so that
-# they only match versioned sets.
+# Override where clause generators that can be used with versioned sets or problems so that they only match versioned
+# sets or problems (those are sets or problems with a version_id that is greater than zero).
 
 sub where_DEFAULT {
 	my ($self, $flags) = @_;
-	return { set_id => { LIKE => make_vsetID("%", "%") } };
+	return { version_id => { '>' => 0 } };
 }
 
-# replaces where_versionedset_user_id_eq in NewSQL
 sub where_user_id_eq {
 	my ($self, $flags, $user_id) = @_;
-	return { user_id => $user_id, set_id => { LIKE => make_vsetID("%", "%") } };
+	return { user_id => $user_id, version_id => { '>' => 0 } };
 }
 
 sub where_user_id_like {
 	my ($self, $flags, $user_id) = @_;
-	return { user_id => { LIKE => $user_id }, set_id => { LIKE => make_vsetID("%", "%") } };
+	return { user_id => { LIKE => $user_id }, version_id => { '>' => 0 } };
 }
 
 sub where_set_id_eq {
 	my ($self, $flags, $set_id) = @_;
-	return { set_id => { LIKE => make_vsetID($set_id, "%") } };
+	return { set_id => $set_id, version_id => { '>' => 0 } };
 }
 
-# replaces where_versionedset_user_id_eq_set_id_eq in NewSQL
 sub where_user_id_eq_set_id_eq {
 	my ($self, $flags, $user_id, $set_id) = @_;
-	return { user_id => $user_id, set_id => { LIKE => make_vsetID($set_id, "%") } };
-}
-
-# replaces where_versionedset_user_id_eq_set_id_eq_version_id_le in NewSQL
-sub where_user_id_eq_set_id_eq_version_id_le {
-	my ($self, $flags, $user_id, $set_id, $version_id) = @_;
-	if ($version_id >= 1) {
-		my @vsetIDs = map { make_vsetID($set_id, $_) } 1 .. $version_id;
-		return { user_id => $user_id, set_id => \@vsetIDs };
-	} else {
-		# nothing matches an invalid version id
-		return { -and => \("0==1") };
-	}
+	return { user_id => $user_id, set_id => $set_id, version_id => { '>' => 0 } };
 }
 
 sub where_user_id_eq_set_id_eq_version_id_eq {
 	my ($self, $flags, $user_id, $set_id, $version_id) = @_;
 	if ($version_id >= 1) {
-		return { user_id => $user_id, set_id => make_vsetID($set_id, $version_id) };
+		return { user_id => $user_id, set_id => $set_id, version_id => $version_id };
 	} else {
 		# nothing matches an invalid version id
 		return { -and => \("0==1") };
 	}
 }
 
-# for problem versions only (set versions don't have a problem_id field)
+# For problem versions only (set versions don't have a problem_id field).
 sub where_user_id_eq_set_id_eq_problem_id_eq {
 	my ($self, $flags, $user_id, $set_id, $problem_id) = @_;
-	return { user_id => $user_id, set_id => { LIKE => make_vsetID($set_id, "%") }, problem_id => $problem_id };
+	return { user_id => $user_id, set_id => $set_id, version_id => { '>' => 0 }, problem_id => $problem_id };
 }
 
-################################################################################
-# override sql_field_expression to return SUBSTRING(...) expressions
-################################################################################
+# Override generic where clause methods to insist on version_id's greater than 0.
 
-# FIXME the rest of the places in this class that generate field lists (basically
-# anywhere that calls grok_*_from_vsetID_sql), should call this method instead.
-sub sql_field_expression {
-	my ($self, $field, $table) = @_;
-
-	if ($field eq "set_id" or $field eq "version_id") {
-		# this value will already be properly quoted
-		my $sql_field_name = $self->SUPER::sql_field_expression("set_id", $table);
-
-		if ($field eq "set_id") {
-			return grok_setID_from_vsetID_sql($sql_field_name);
-		} elsif ($field eq "version_id") {
-			return grok_versionID_from_vsetID_sql($sql_field_name);
-		}
-	} else {
-		return $self->SUPER::sql_field_expression($field, $table);
-	}
+sub conv_where {
+	my ($self, $where) = @_;
+	$where->{version_id} = { '>' => 0 } if ref($where) eq 'HASH' && !exists $where->{version_id};
+	return $self->SUPER::conv_where($where);
 }
-
-# FIXME sql_field_expression will work in WHERE clauses, but do we need an
-# analogous routine for SET lvalues?
-
-################################################################################
-# override keyparts_to_where to limit scope of where clauses
-################################################################################
 
 sub keyparts_to_where {
 	my ($self, @keyparts) = @_;
-
 	my $where = $self->SUPER::keyparts_to_where(@keyparts);
-
-	if (exists $where->{set_id} and exists $where->{version_id}) {
-		$where->{set_id} = make_vsetID($where->{set_id}, $where->{version_id});
-		delete $where->{version_id};
-	} else {
-		my $set_id_part     = exists $where->{set_id}     ? $where->{set_id}     : "%";
-		my $version_id_part = exists $where->{version_id} ? $where->{version_id} : "%";
-		$where->{set_id} = { LIKE => make_vsetID($set_id_part, $version_id_part) };
-		delete $where->{version_id};
-	}
-
+	$where->{version_id} = { '>' => 0 } unless exists $where->{version_id};
 	return $where;
-}
-
-################################################################################
-# overrides to fake version_id field
-################################################################################
-
-# replace the virtual set_id and version_id fields with expressions that extract
-# the set and version IDs from the real set_id field
-sub _get_fields_where_prepex {
-	my ($self, $fields, $where, $order) = @_;
-
-	if (ref $fields eq "ARRAY") {
-		my @fields = @$fields;    # don't want to mess up caller's copy
-		foreach my $field (@fields) {
-			if (lc $field eq "set_id") {
-				# FIXME use sql_field_expression here
-				$field =
-					grok_setID_from_vsetID_sql($self->sql->_quote("set_id")) . " AS " . $self->sql->_quote("set_id");
-			} elsif (lc $field eq "version_id") {
-				# FIXME use sql_field_expression here
-				$field = grok_versionID_from_vsetID_sql($self->sql->_quote("set_id")) . " AS "
-					. $self->sql->_quote("version_id");
-			} else {
-				$field = $self->sql->_quote($field);
-			}
-		}
-		$fields = join(", ", @fields);
-	}
-
-	return $self->SUPER::_get_fields_where_prepex($fields, $where, $order);
-}
-
-# modify the INSERT expression so that it looks like this:
-# INSERT ... SET (..., set_id, ...) VALUES (..., CONCAT(?,',v',?), ...)
-# this is mostly a copy of Std::_insert_fields_prep
-sub _insert_fields_prep {
-	my ($self, $fields) = @_;
-
-	# we'll use dummy values to determine bind order
-	my %values;
-	@values{@$fields} = (0 .. @$fields - 1);
-
-	# VERSIONING
-	if (exists $values{set_id} and exists $values{version_id}) {
-		# the array form allows raw SQL and bind values
-		$values{set_id} = [ make_vsetID_sql("?", "?"), @values{qw/set_id version_id/} ];
-		delete $values{version_id};
-	} elsif (exists $values{set_id} or exists $values{version_id}) {
-		die "can't re-create versioned set_id field without virtual set_id and version_id fields";
-	} else {
-		# neither set_id nor version_id present, so that's fine
-		# (fine with us that is, mysql will complain that keys are missing)
-	}
-
-	my ($stmt, @order) = $self->sql->insert($self->table, \%values);
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
-	return $sth, @order;
-}
-
-# where clause is already in native format (see where subroutines above)
-# fieldvals (a hashref) might contain decomposed set_id/version_id fields
-# set_id value:
-#   +set_id, +version_id => CONCAT(?, ',v', ?) BIND: set_id, version_id
-#   +set_id, -version_id => CONCAT(?, ',v', grok_versionID_from_vsetID_sql("set_id")) BIND: set_id
-#   -set_id, +version_id => CONCAT(grok_setID_from_vsetID_sql("set_id", ',v', ?) BIND: version_id
-#   -set_id, -version_id => not included
-sub update_where {
-	my ($self, $fieldvals, $where) = @_;
-
-	my %fieldvals = %$fieldvals;    # don't want to mess up the caller's version
-
-	if (exists $fieldvals{set_id} or exists $fieldvals{version_id}) {
-		my ($set_id_part, $version_id_part, @bind);
-		if (exists $fieldvals{set_id}) {
-			$set_id_part = "?";
-			push @bind, $fieldvals{set_id};
-		} else {
-			# FIXME use sql_field_expression here?
-			$set_id_part = grok_setID_from_vsetID_sql($self->sql->_quote("set_id"));
-		}
-		if (exists $fieldvals{version_id}) {
-			$version_id_part = "?";
-			push @bind, $fieldvals{version_id};
-		} else {
-			# FIXME use sql_field_expression here?
-			$version_id_part = grok_versionID_from_vsetID_sql($self->sql->_quote("set_id"));
-		}
-		$fieldvals{set_id} = [ make_vsetID_sql($set_id_part, $version_id_part), @bind ];
-		delete $fieldvals{version_id};
-	}
-
-	return $self->SUPER::update_where(\%fieldvals, $where);
-}
-
-# this is mostly a copy of Std::_update_fields_prep
-sub _update_fields_prep {
-	my ($self, $fields) = @_;
-
-	# get hashes to pass to update() and where()
-	# (dies if any keyfield is missing from @$fields)
-	my ($values, $where) = $self->gen_update_hashes($fields);
-
-	# grab bind order for set_id/version_id virtual fields
-	my $set_id_index     = $where->{set_id};
-	my $version_id_index = $where->{version_id};
-	delete @$where{qw/set_id version_id/};
-
-	# do the where clause separately so we get a separate bind list (cute substr trick, huh?)
-	my ($stmt, @val_order) = $self->sql->update($self->table, $values);
-	(substr($stmt, length($stmt), 0), my @where_order) = $self->sql->where($where);
-
-	# append physical set_id match clause
-	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?", "?");
-	push @where_order, $set_id_index, $version_id_index;
-
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
-	return $sth, \@val_order, \@where_order;
-}
-
-# don't need to override delete_where, since it'll get a pre-converted where clause
-#sub delete_where;
-
-# pretty much the same modification as _update_fields_prep
-# this is mostly a copy of Std::_delete_fields_prep
-sub _delete_fields_prep {
-	my ($self, $fields) = @_;
-
-	# get hashes to pass to update() and where()
-	# (dies if any keyfield is missing from @$fields)
-	my (undef, $where) = $self->gen_update_hashes($fields);
-
-	# grab bind order for set_id/version_id virtual fields
-	my $set_id_index     = $where->{set_id};
-	my $version_id_index = $where->{version_id};
-	delete @$where{qw/set_id version_id/};
-
-	# do the where clause separately so we get a separate bind list (cute substr trick, huh?)
-	my ($stmt, @order) = $self->sql->delete($self->table, $where);
-
-	# append physical set_id match clause
-	$stmt .= " AND " . $self->sql->_quote("set_id") . " = " . make_vsetID_sql("?", "?");
-	push @order, $set_id_index, $version_id_index;
-
-	print STDERR "stmt=$stmt\norder=@order\n";
-	my $sth = $self->dbh->prepare_cached($stmt, undef, 3);    # 3: see DBI docs
-	return $sth, @order;
 }
 
 1;

--- a/lib/WeBWorK/DB/Utils.pm
+++ b/lib/WeBWorK/DB/Utils.pm
@@ -17,11 +17,6 @@ our @EXPORT_OK = qw(
 	fake_set
 	fake_set_version
 	fake_problem
-	make_vsetID
-	make_vsetID_sql
-	grok_vsetID
-	grok_setID_from_vsetID_sql
-	grok_versionID_from_vsetID_sql
 	parse_dsn
 );
 
@@ -51,6 +46,7 @@ sub user2global {
 sub initializeUserProblem {
 	my ($userProblem, $seed) = @_;
 	$seed = int rand 5000 unless defined $seed;
+	$userProblem->version_id(0) unless defined $userProblem->version_id;
 	$userProblem->status(0.0);
 	$userProblem->attempted(0);
 	$userProblem->num_correct(0);
@@ -112,6 +108,7 @@ sub fake_problem {
 	my $problem = $db->newGlobalProblem();
 	$problem = global2user($db->{problem_user}{record}, $problem);
 	$problem->set_id(fakeSetName);
+	$problem->version_id(0);
 	$problem->value('');
 	$problem->max_attempts(-1);
 	$problem->showMeAnother(-1);
@@ -127,43 +124,6 @@ sub fake_problem {
 	$problem->prCount(-10);       # Negative to detect fake problems and disable problem randomization.
 
 	return ($problem);
-}
-
-################################################################################
-# versioning utilities
-################################################################################
-
-sub make_vsetID {
-	my ($setID, $versionID) = @_;
-	return "$setID,v$versionID";
-}
-
-# does not quote $setID and $versionID, because they could be strings, qualified
-# or unqualified field names, or complex expression
-sub make_vsetID_sql {
-	my ($setID, $versionID) = @_;
-	return "CONCAT($setID,',v',$versionID)";
-}
-
-sub grok_vsetID {
-	my ($vsetID) = @_;
-	my ($setID, $versionID) = $vsetID =~ /([^,]+)(?:,v(.*))?/;
-	return $setID, $versionID;
-}
-
-# does not quote $field, because it could be a string, a qualified or
-# unqualified field name, or a complex expression
-sub grok_setID_from_vsetID_sql {
-	my ($field) = @_;
-	return "SUBSTRING($field,1,INSTR($field,',v')-1)";
-}
-
-# does not quote $field, because it could be a string, a qualified or
-# unqualified field name, or a complex expression
-sub grok_versionID_from_vsetID_sql {
-	my ($field) = @_;
-	# the "+0" casts the resulting value as a number
-	return "(SUBSTRING($field,INSTR($field,',v')+2)+0)";
 }
 
 sub parse_dsn {

--- a/lib/WeBWorK/HTML/SingleProblemGrader.pm
+++ b/lib/WeBWorK/HTML/SingleProblemGrader.pm
@@ -28,10 +28,9 @@ sub new ($class, $c, $pg, $userProblem, $mergedSet) {
 	my $recordedScore = $userProblem->status;
 
 	# Retrieve the latest past answer and comment (if any).
-	my $userPastAnswerID =
-		$db->latestProblemPastAnswer($studentID, $setID . ($versionID ? ",v$versionID" : ''), $problemID);
-	my $pastAnswer = $userPastAnswerID ? $db->getPastAnswer($userPastAnswerID) : 0;
-	my $comment    = $pastAnswer       ? $pastAnswer->comment_string           : '';
+	my $userPastAnswerID = $db->latestProblemPastAnswer($studentID, $setID, $versionID, $problemID);
+	my $pastAnswer       = $userPastAnswerID ? $db->getPastAnswer($userPastAnswerID) : 0;
+	my $comment          = $pastAnswer       ? $pastAnswer->comment_string           : '';
 
 	my $self = {
 		pg             => $pg,

--- a/lib/WeBWorK/Utils/CourseDBIntegrityCheck.pm
+++ b/lib/WeBWorK/Utils/CourseDBIntegrityCheck.pm
@@ -10,6 +10,8 @@ with database schema.
 use strict;
 use warnings;
 
+use Iterator::Util;
+
 use WeBWorK::Utils::CourseManagement qw(listCourses);
 
 # Developer note:  This file should not format messages in html.  Instead return an array of tuples.  Each tuple should
@@ -195,13 +197,17 @@ sub checkTableFields {
 	my $table_name =
 		exists $db->{$table}{params}{tableOverride} ? $db->{$table}{params}{tableOverride} : $table;
 	warn "$table_name is a non native table" if $db->{$table}{params}{non_native};
+
+	my @schema_key_fields  = $db->{$table}{record}->KEYFIELDS;
+	my %schema_key_fields  = map { $_ => 1 } @schema_key_fields;
 	my @schema_field_names = $db->{$table}{record}->FIELDS;
 	my %schema_field_names = map { $_ => 1 } @schema_field_names;
+
 	for my $field (@schema_field_names) {
 		if ($db->{$table}->tableFieldExists($field)) {
 			$fieldStatus{$field} = [SAME_IN_A_AND_B];
 		} else {
-			$fieldStatus{$field} = [ONLY_IN_A];
+			$fieldStatus{$field} = [ ONLY_IN_A, $schema_key_fields{$field} // () ];
 			$fields_ok = 0;
 		}
 	}
@@ -252,18 +258,25 @@ sub updateTableFields {
 
 	my $schema_obj = $db->{$table};
 
+	my %newKeyFields;
+
 	# Add fields
 	for my $field_name (keys %$fieldStatus) {
 		if ($fieldStatus->{$field_name}[0] == ONLY_IN_A) {
 			if ($schema_obj->can('add_column_field') && $schema_obj->add_column_field($field_name)) {
-				push(@messages, [ "Added column '$field_name' to table '$table'", 1 ]);
+				if ($fieldStatus->{$field_name}[1]) {
+					push(@messages, [ "Added primary key column '$field_name' to table '$table'", 1 ]);
+					$newKeyFields{$field_name} = 1;
+				} else {
+					push(@messages, [ "Added column '$field_name' to table '$table'", 1 ]);
+				}
 			}
 		}
 	}
 
 	# Rebuild indexes for the table if a previous key field column is going to be dropped.
 	if ($schema_obj->can('rebuild_indexes')
-		&& (grep { $fieldStatus->{$_} && $fieldStatus->{$_}[1] } @$delete_field_names))
+		&& ((grep { $fieldStatus->{$_} && $fieldStatus->{$_}[1] } @$delete_field_names) || %newKeyFields))
 	{
 		my $result = eval { $schema_obj->rebuild_indexes };
 		if ($@ || !$result) {
@@ -300,7 +313,48 @@ sub updateTableFields {
 		}
 	}
 
+	$self->migrateSetIdToSetIdVersionId($table)
+		if $newKeyFields{version_id} && $table =~ /^((set|problem)_user|past_answer)$/;
+
 	return @messages;
+}
+
+sub migrateSetIdToSetIdVersionId {
+	my ($self, $table) = @_;
+	my $record = $self->db->{$table};
+
+	my @fields = $record->fields;
+	my %values;
+	@values{@fields} = (0 .. $#fields);
+
+	my @keyfields = $record->keyfields;
+	my %where;
+	@where{@keyfields} = map { $values{$_} } @keyfields;
+
+	my ($stmt, @val_order) = $record->sql->update($record->table, \%values);
+	(substr($stmt, length($stmt), 0), my @where_order) = $record->sql->where(\%where);
+
+	my $rows_i = $record->get_fields_where_i([ $record->fields ], { set_id => { like => '%,v%' } });
+	my $sth    = $record->dbh->prepare_cached($stmt, undef, 3);
+
+	my @results;
+
+	until ($rows_i->is_exhausted) {
+		my $fieldValues = $rows_i->value;
+
+		my @bind_vals = @$fieldValues[@where_order];
+
+		($fieldValues->[ $values{set_id} ], $fieldValues->[ $values{version_id} ]) =
+			$fieldValues->[ $values{set_id} ] =~ /([^,]+)(?:,v(.*))?/;
+
+		unshift(@bind_vals, @$fieldValues[@val_order]);
+
+		$record->dbh->debug_stmt($sth, @bind_vals);
+		push @results, $sth->execute(@bind_vals);
+	}
+	$sth->finish;
+
+	return @results;
 }
 
 # Database locking utilities

--- a/lib/WeBWorK/Utils/Instructor.pm
+++ b/lib/WeBWorK/Utils/Instructor.pm
@@ -52,6 +52,7 @@ sub assignSetToUser {
 	my $UserSet = $db->newUserSet;
 	$UserSet->user_id($userID);
 	$UserSet->set_id($setID);
+	$UserSet->version_id(0);
 
 	eval { $db->addUserSet($UserSet) };
 	die $@ if $@ && !WeBWorK::DB::Ex::RecordExists->caught;
@@ -229,12 +230,12 @@ sub assignProblemToUserSetVersion {
 
 	# Assign the problem.
 	my $UserProblem = $db->newProblemVersion;
+	initializeUserProblem($UserProblem, $seed);
 	$UserProblem->user_id($userID);
 	$UserProblem->set_id($userSet->set_id);
 	$UserProblem->version_id($userSet->version_id);
 	$UserProblem->problem_id($GlobalProblem->problem_id);
 	$UserProblem->source_file($GlobalProblem->source_file);
-	initializeUserProblem($UserProblem, $seed);
 
 	eval { $db->addProblemVersion($UserProblem) };
 	die $@ if $@ && !WeBWorK::DB::Ex::RecordExists->caught;
@@ -288,6 +289,7 @@ sub assignSetToGivenUsers {
 		my $userSet = $db->newUserSet;
 		$userSet->user_id($userID);
 		$userSet->set_id($setID);
+		$userSet->version_id(0);
 
 		push(@userSetsToAdd, $userSet);
 		debug("Scheduled $setID: adding UserSet for $userID");

--- a/lib/WeBWorK/Utils/ProblemProcessing.pm
+++ b/lib/WeBWorK/Utils/ProblemProcessing.pm
@@ -79,6 +79,7 @@ async sub process_and_log_answer ($c) {
 			my $pastAnswer = $db->newPastAnswer();
 			$pastAnswer->user_id($problem->user_id);
 			$pastAnswer->set_id($problem->set_id);
+			$pastAnswer->version_id($problem->version_id);
 			$pastAnswer->problem_id($problem->problem_id);
 			$pastAnswer->timestamp($timestamp);
 			$pastAnswer->scores($scores2);

--- a/lib/WeBWorK/Utils/Routes.pm
+++ b/lib/WeBWorK/Utils/Routes.pm
@@ -47,9 +47,10 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
  achievements_leaderboard            /$courseID/achievements/leaderboard
  feedback                            /$courseID/feedback
  gateway_quiz                        /$courseID/test_mode/$setID
+ gateway_quiz_version                /$courseID/test_mode/$setID/$versionID
 
  proctored_gateway_quiz              /$courseID/proctored_test_mode/$setID
- proctored_gateway_proctor_login     /$courseID/proctored_test_mode/$setID/proctor_login
+ proctored_gateway_quiz_version      /$courseID/proctored_test_mode/$setID/$versionID
 
  hardcopy                            /$courseID/hardcopy
  hardcopy_preselect_set              /$courseID/hardcopy/$setID
@@ -64,6 +65,7 @@ PLEASE FOR THE LOVE OF GOD UPDATE THIS IF YOU CHANGE THE ROUTES BELOW!!!
  instructor_set_list                 /$courseID/instructor/sets
 
  instructor_set_detail               /$courseID/instructor/sets/$setID
+ instructor_versioned_set_detail     /$courseID/instructor/sets/$setID/$versionID
  instructor_users_assigned_to_set    /$courseID/instructor/sets/$setID/users
 
  instructor_problem_grader           /$courseID/instructor/grader/$setID/$problemID
@@ -349,22 +351,29 @@ my %routeParameters = (
 	},
 	gateway_quiz => {
 		title        => x('Test [_2]'),
+		children     => [qw(gateway_quiz_version)],
 		module       => 'GatewayQuiz',
 		path         => '/test_mode/#setID',
+		unrestricted => 1
+	},
+	gateway_quiz_version => {
+		title        => x('Test [_2]'),
+		module       => 'GatewayQuiz',
+		path         => '/<versionID:num>',
 		unrestricted => 1
 	},
 
 	proctored_gateway_quiz => {
 		title        => x('Proctored Test [_2]'),
-		children     => [qw(proctored_gateway_proctor_login)],
+		children     => [qw(proctored_gateway_quiz_version)],
 		module       => 'ProctoredGatewayQuiz',
 		path         => '/proctored_test_mode/#setID',
 		unrestricted => 1
 	},
-	proctored_gateway_proctor_login => {
-		title        => x('Proctored Test [_2] Proctor Login'),
-		module       => 'LoginProctor',
-		path         => '/proctor_login',
+	proctored_gateway_quiz_version => {
+		title        => x('Proctored Test [_2]'),
+		module       => 'ProctoredGatewayQuiz',
+		path         => '/<versionID:num>',
 		unrestricted => 1
 	},
 
@@ -425,9 +434,14 @@ my %routeParameters = (
 	},
 	instructor_set_detail => {
 		title    => x('Set Detail for set [_2]'),
-		children => [qw(instructor_users_assigned_to_set)],
+		children => [qw(instructor_users_assigned_to_set instructor_versioned_set_detail)],
 		module   => 'Instructor::ProblemSetDetail',
 		path     => '/#setID'
+	},
+	instructor_versioned_set_detail => {
+		title  => x('Set Detail for set [_2]'),
+		module => 'Instructor::ProblemSetDetail',
+		path   => '/<versionID:num>'
 	},
 	instructor_users_assigned_to_set => {
 		title  => x('Users Assigned to Set [_2]'),

--- a/lib/WeBWorK/Utils/Sets.pm
+++ b/lib/WeBWorK/Utils/Sets.pm
@@ -16,7 +16,6 @@ our @EXPORT_OK = qw(
 	grade_all_sets
 	is_restricted
 	get_test_problem_position
-	list_set_versions
 	restricted_set_message
 );
 
@@ -110,7 +109,7 @@ sub grade_set ($db, $set, $studentName, $setIsVersioned = 0, $wantProblemDetails
 sub grade_gateway ($db, $setName, $studentName) {
 	my $bestSetData = [ 0, 0, [] ];
 
-	my @setVersions = $db->getSetVersionsWhere({ user_id => $studentName, set_id => { like => "$setName,v\%" } });
+	my @setVersions = $db->getSetVersionsWhere({ user_id => $studentName, set_id => $setName });
 	for (@setVersions) {
 		my @setData = grade_set($db, $_, $studentName, 1);
 		$bestSetData = \@setData if $setData[0] > $bestSetData->[0];
@@ -177,8 +176,7 @@ sub is_restricted ($db, $set, $studentName) {
 			my $restrictor_set = $db->getGlobalSet($restrictor);
 
 			if ($restrictor_set->assignment_type =~ /gateway/) {
-				my @versions =
-					$db->getSetVersionsWhere({ user_id => $studentName, set_id => { like => $restrictor . ',v%' } });
+				my @versions = $db->getSetVersionsWhere({ user_id => $studentName, set_id => $restrictor });
 				for (@versions) {
 					my $v_score = grade_set($db, $_, $studentName, 1);
 
@@ -234,26 +232,6 @@ sub get_test_problem_position ($db, $problem) {
 	}
 
 	return ($problemNumber, $pageNumber);
-}
-
-sub list_set_versions ($db, $studentName, $setName, $setIsVersioned = 0) {
-	croak 'list_set_versions requires a database reference as the first element' unless ref($db) =~ /DB/;
-
-	my @allSetNames;
-	my $notAssignedSet = 0;
-
-	if ($setIsVersioned) {
-		my @setVersions = $db->listSetVersions($studentName, $setName);
-		@allSetNames = map {"$setName,v$_"} @setVersions;
-		# If there are not any set versions, it may be because the user is not assigned the set,
-		# or because the user hasn't completed any versions.
-		$notAssignedSet = 1 if !@setVersions && !$db->existsUserSet($studentName, $setName);
-	} else {
-		@allSetNames    = ($setName);
-		$notAssignedSet = 1 if !$db->existsUserSet($studentName, $setName);
-	}
-
-	return (\@allSetNames, $notAssignedSet);
 }
 
 sub restricted_set_message($c, $set, $status) {
@@ -391,16 +369,6 @@ Usage: C<get_test_problem_position($db, $problem)>
 Given C<$problem> which should be a problem version, get_test_problem_position
 returns the 0 based problem number for the problem on the test, and the 1 based
 page number for the page on the test that the problem is on.
-
-=head2 list_set_versions
-
-Usage: C<list_set_versions($db, $studentName, $setName, $setIsVersioned)>
-
-Construct a list of versioned sets for this student user.  This returns a
-reference to an array of names of set versions and whether or not the user is
-assigned to the set.  The list of names will be a list of set versions if the
-set is versioned (i.e., if C<setIsVersioned> is true), and a list containing
-only the original set id otherwise.
 
 =head2 restricted_set_message
 

--- a/templates/ContentGenerator/Base/links.html.ep
+++ b/templates/ContentGenerator/Base/links.html.ep
@@ -20,24 +20,24 @@
 			<li class="list-group-item nav-item">
 				<ul class="nav flex-column">
 					% # Set link. The set record is needed to determine the assignment type.
-					% my $setRecord = $db->getGlobalSet($setID =~ s/,v\d+$//r);
+					% my $setRecord = $db->getGlobalSet($setID);
 					% if ($setRecord->assignment_type eq 'jitar' && defined $problemID) {
 						% $prettyProblemID = join('.', jitar_id_to_seq($problemID));
 					% }
 					%
 					<li class="list-group-item nav-item">
-						% if ($setRecord->assignment_type =~ /proctor/ && $setID =~ /,v(\d)+$/) {
+						% if ($setRecord->assignment_type =~ /proctor/ && $versionID) {
 							<%= $makelink->(
-								'proctored_gateway_quiz',
-								text       => $prettySetID,
-								captures   => { setID => $setID },
+								'proctored_gateway_quiz_version',
+								text       => "$prettySetID,v$versionID",
+								captures   => { setID => $setID, versionID => $versionID },
 								link_attrs => { dir   => 'ltr' }
 							) %>
-						% } elsif ($setRecord->assignment_type =~ /gateway/ && $setID =~ /,v(\d)+$/) {
+						% } elsif ($setRecord->assignment_type =~ /gateway/ && $versionID) {
 							<%= $makelink->(
-								'gateway_quiz',
-								text       => $prettySetID,
-								captures   => { setID => $setID },
+								'gateway_quiz_version',
+								text       => "$prettySetID,v$versionID",
+								captures   => { setID => $setID, versionID => $versionID },
 								link_attrs => { dir   => 'ltr' }
 							) %>
 						% } else {
@@ -124,8 +124,8 @@
 			% }
 			% # Sets Manager
 			<li class="list-group-item nav-item"><%= $makelink->('instructor_set_list') %></li>
-			% # Editor link.  Only shown for non-versioned sets
-			% if (defined $globalSetID || defined $setID && $setID !~ /,v\d+$/) {
+			% # Editor link.
+			% if (defined $globalSetID || defined $setID) {
 				<li class="list-group-item nav-item">
 					<ul class="nav flex-column">
 						<li class="nav-item">
@@ -229,9 +229,8 @@
 						<li class="nav-item" dir="ltr">
 							<%= $makelink->(
 								'instructor_set_statistics',
-								# Make sure a versioned set id is not used for the statistics link.
-								text     => $prettySetID =~ s/,v\d+$//r,
-								captures => { setID => $globalSetID // $setID =~ s/,v\d+$//r }
+								text     => $prettySetID,
+								captures => { setID => $globalSetID // $setID }
 							) %>
 						</li>
 						% if (defined $problemID) {
@@ -242,7 +241,7 @@
 											'instructor_problem_statistics',
 											text     => maketext('Problem [_1]', $prettyProblemID),
 											captures => {
-												setID     => $globalSetID // $setID =~ s/,v\d+$//r,
+												setID     => $globalSetID // $setID,
 												problemID => $problemID
 											}
 										) =%>
@@ -283,9 +282,8 @@
 							<li class="nav-item" dir="ltr">
 								<%= $makelink->(
 									'instructor_set_progress',
-									# Make sure a versioned set id is not used for the progress link.
-									text     => $prettySetID =~ s/,v\d+$//r,
-									captures => { setID => $globalSetID // $setID =~ s/,v\d+$//r },
+									text     => $prettySetID,
+									captures => { setID => $globalSetID // $setID },
 								) %>
 							</li>
 						% }

--- a/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/archive_course_confirm.html.ep
@@ -6,30 +6,28 @@
 		<p class="<%= $_->[1] ? 'text-success' : 'text-danger' %> fw-bold my-0"><%= $_->[0] %></p>
 	% }
 % }
-% my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $rebuild_table_indexes,
-	% $incorrect_type_database_fields, $db_report)
-	% = $c->formatReportOnDatabaseTables($dbStatus);
-<%= $db_report %>
-% if ($extra_database_tables) {
+% my $dbReport = $c->formatReportOnDatabaseTables($dbStatus);
+<%= $dbReport->{summary} %>
+% if ($dbReport->{extra_database_tables}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database tables which are not defined in the schema.  '
 				. 'These can be deleted when upgrading the course.') =%>
 	</p>
 % }
-% if ($extra_database_fields) {
+% if ($dbReport->{extra_database_fields}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database fields which are not defined in the schema for at least one table.  '
 				. 'They can be removed when upgrading the course.') =%>
 	</p>
 % }
-% if ($rebuild_table_indexes) {
+% if ($dbReport->{rebuild_table_indexes}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database fields which are not defined in the schema and were part of the key '
 				. 'for at least one table. These fields need to be deleted and the table indexes need to be rebuilt. '
 				. 'This will be done when upgrading the course.') =%>
 	</p>
 % }
-% if ($incorrect_type_database_fields) {
+% if ($dbReport->{incorrect_type_database_fields}) {
 	<p class="text-danger fw-bold">
 		<%= maketext(
 			'There are database fields that do not have the same type as the field defined in the schema for '
@@ -38,7 +36,7 @@
 				. 'field can corrupt the table.') =%>
 	</p>
 % }
-% if (!$all_tables_ok) {
+% if (!$dbReport->{all_tables_ok}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('The course database must be upgraded before archiving this course.') =%>
 	</p>
@@ -82,7 +80,7 @@
 	</p>
 % }
 <hr>
-% if ($all_tables_ok && param('delete_course')) {
+% if ($dbReport->{all_tables_ok} && param('delete_course')) {
 	<p class="text-danger fw-bold">
 		<%== maketext('Are you sure that you want to delete the course [_1] after archiving? This cannot be undone!',
 			tag('b', $archive_courseID)) =%>
@@ -97,7 +95,7 @@
 		<%= hidden_field archive_courseIDs => $_ =%>
 	% }
 	%
-	% if ($all_tables_ok && $directories_ok && $links_ok) {
+	% if ($dbReport->{all_tables_ok} && $directories_ok && $links_ok) {
 		% # No missing tables, missing fields, missing directories, or missing/bad links
 		% # Warn about overwriting an existing archive
 		% my $archive_path = "$ce2->{webworkDirs}{courses}/$ce2->{admin_course_id}/archives/$archive_courseID.tar.gz";
@@ -131,7 +129,7 @@
 			<%= submit_button maketext(q{Don't Archive}),
 				name  => 'decline_archive_course',
 				class => 'btn btn-primary' =%>
-			<%= submit_button $all_tables_ok
+			<%= submit_button $dbReport->{all_tables_ok}
 				? maketext('Attempt to upgrade directories and links')
 				: maketext('Upgrade Course Tables'),
 				name  => 'upgrade_course_tables',

--- a/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
+++ b/templates/ContentGenerator/CourseAdmin/rename_course_confirm.html.ep
@@ -6,30 +6,28 @@
 		<p class="<%= $_->[1] ? 'text-success' : 'text-danger' %> fw-bold my-0"><%= $_->[0] %></p>
 	% }
 % }
-% my ($all_tables_ok, $extra_database_tables, $extra_database_fields, $rebuild_table_indexes,
-	% $incorrect_type_database_fields, $db_report)
-	% = $c->formatReportOnDatabaseTables($dbStatus);
-<%= $db_report =%>
-% if ($extra_database_tables) {
+% my $dbReport = $c->formatReportOnDatabaseTables($dbStatus);
+<%= $dbReport->{summary} =%>
+% if ($dbReport->{extra_database_tables}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database tables which are not defined in the schema.  '
 				. 'These can be deleted when upgrading the course.') =%>
 	</p>
 % }
-% if ($extra_database_fields) {
+% if ($dbReport->{extra_database_fields}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database fields which are not defined in the schema for at least one table.  '
 				. 'They can be removed when upgrading the course.') =%>
 	</p>
 % }
-% if ($rebuild_table_indexes) {
+% if ($dbReport->{rebuild_table_indexes}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('There are extra database fields which are not defined in the schema and were part of the key '
 				. 'for at least one table. These fields need to be deleted and the table indexes need to be rebuilt. '
 				. 'This will be done when upgrading the course.') =%>
 	</p>
 % }
-% if ($incorrect_type_database_fields) {
+% if ($dbReport->{incorrect_type_database_fields}) {
 	<p class="text-danger fw-bold">
 		<%= maketext(
 			'There are database fields that do not have the same type as the field defined in the schema for '
@@ -38,7 +36,7 @@
 				. 'field can corrupt the table.') =%>
 	</p>
 % }
-% if (!$all_tables_ok) {
+% if (!$dbReport->{all_tables_ok}) {
 	<p class="text-danger fw-bold">
 		<%= maketext('The course database must be upgraded before renaming this course.') =%>
 	</p>
@@ -94,7 +92,7 @@
 		rename_oldCourseInstitution => $rename_oldCourseInstitution,
 		id                          => 'hidden_rename_oldCourseInstitution' =%>
 	%
-	% if ($all_tables_ok && $directories_ok && $links_ok) {
+	% if ($dbReport->{all_tables_ok} && $directories_ok && $links_ok) {
 		% # No missing tables, missing fields, missing directories, or missing/bad links
 		<div class="text-start">
 			<h3><%= maketext('Rename [_1] to [_2]', $rename_oldCourseID, $rename_newCourseID) %></h3>
@@ -123,7 +121,7 @@
 			<%= submit_button maketext(q{Don't Rename}),
 				name  => 'decline_rename_course',
 				class => 'btn btn-primary' =%>
-			<%= submit_button $all_tables_ok
+			<%= submit_button $dbReport->{all_tables_ok}
 				? maketext('Attempt to upgrade directories and links')
 				: maketext('Upgrade Course Tables'),
 				name  => 'upgrade_course_tables',

--- a/templates/ContentGenerator/GatewayQuiz.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz.html.ep
@@ -95,10 +95,8 @@
 				params => { effectiveUser => $effectiveUserID, user => $userID, submit_for_student_ok => 1 }
 				),
 				class => 'btn btn-primary' =%>
-			<%= link_to maketext('Cancel') => $c->systemLink(
-				url_for('problem_list', setID => $setID =~ s/,v\d+$//r),
-				params => { effectiveUser => $effectiveUserID, user => $userID }
-				),
+			<%= link_to maketext('Cancel') => $c->systemLink(url_for('problem_list', setID => $setID),
+				params => { effectiveUser => $effectiveUserID, user => $userID }),
 				class => 'btn btn-primary' =%>
 		</div>
 	</div>
@@ -387,16 +385,6 @@
 	% }
 % }
 %
-% my $action = url_for;
-%
-% # This is a hack to get a URL that will not require a proctor login if a proctored test has been submitted for the
-% # last time.  The assignment type has already been reset in this case, so use that to decide if we should give a path
-% # to an unproctored test.
-% $action =~ s/proctored_test_mode/test_mode/ if $c->{set}->assignment_type eq 'gateway';
-%
-% # Make sure that if this is a set, then the 'action' in the form points to the same set.
-% $action =~ s/(test_mode\/$setID)\/?$/$1,v$setVersionID\//;
-%
 % if (!$c->{can}{recordAnswersNextTime} && !$c->{can}{showWork}) {
 	% # Problems cannot be shown.
 	<div class="gwProblem">
@@ -422,6 +410,15 @@
 			</div>
 		</div>
 	% }
+	%
+	% # Make sure that the 'action' in the form points to the same set version. Using the assignment type (rather than
+	% # the current route) also gets a URL that will not require a proctor login if a proctored test has been submitted
+	% # for the last time, since the assignment type has already been reset to 'gateway' in that case.
+	% my $action = url_for(
+		% $c->{set}->assignment_type =~ /proctored/ ? 'proctored_gateway_quiz_version' : 'gateway_quiz_version',
+		% setID     => $setID,
+		% versionID => $setVersionID
+	% );
 	%
 	<%= form_for $action, name => 'gwquiz', method => 'POST', class => 'problem-main-form mt-0', begin =%>
 		<%= $c->hidden_authen_fields =%>

--- a/templates/ContentGenerator/GatewayQuiz/nav.html.ep
+++ b/templates/ContentGenerator/GatewayQuiz/nav.html.ep
@@ -12,7 +12,7 @@
 			% if ($eUserID ne $userID) {
 				% if ($prevTest) {
 					<%= link_to $c->systemLink(
-						url_for('gateway_quiz', setID => "$setID,v$prevTest->{setVersion}"),
+						url_for('gateway_quiz_version', setID => $setID, versionID => $prevTest->{setVersion}),
 						params => {
 							effectiveUser => $prevTest->user_id,
 							currentPage   => $pageNumber,
@@ -49,7 +49,7 @@
 						<li>
 							<%= link_to maketext('[_1] (version [_2])', $_->{displayName}, $_->{setVersion}) =>
 								$c->systemLink(
-									url_for('gateway_quiz', setID => "$setID,v$_->{setVersion}"),
+									url_for('gateway_quiz_version', setID => $setID, versionID => $_->{setVersion}),
 									params => {
 										effectiveUser => $_->user_id,
 										currentPage   => $pageNumber,
@@ -66,7 +66,7 @@
 			% if ($eUserID ne $userID) {
 				% if ($nextTest) {
 					<%= link_to $c->systemLink(
-						url_for('gateway_quiz', setID => "$setID,v$nextTest->{setVersion}"),
+						url_for('gateway_quiz_version', setID => $setID, versionID => $nextTest->{setVersion}),
 						params => {
 							effectiveUser => $nextTest->user_id,
 							currentPage   => $pageNumber,
@@ -98,7 +98,7 @@
 					% if ($filter) {
 						<li>
 							<%= link_to maketext('Show all tests') => $c->systemLink(
-								url_for('gateway_quiz', setID => "$setID,v$setVersion"),
+								url_for('gateway_quiz_version', setID => $setID, versionID => $setVersion),
 								params => { effectiveUser => param('effectiveUser'), currentPage => $pageNumber }
 								),
 								class => 'dropdown-item' =%>
@@ -107,7 +107,7 @@
 					% for (sort keys %$filters) {
 						<li>
 							<%= link_to $filters->{$_}[0] => $c->systemLink(
-								url_for('gateway_quiz', setID => "$setID,v$filters->{$_}[2]"),
+								url_for('gateway_quiz_version', setID => $setID, versionID => $filters->{$_}[2]),
 								params => {
 									effectiveUser    => $filters->{$_}[1],
 									currentPage      => $pageNumber,

--- a/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemGrader.html.ep
@@ -141,9 +141,14 @@
 						% my @answerTypes = split(',', $_->{problem}->flags =~ s/:needs_grading$//r);
 						% my $problemLink;
 						% if ($versionID) {
-							% $problemLink = $c->systemLink(url_for('gateway_quiz', setID => "$setID,v$versionID"),
-								% params => { effectiveUser => $userID, currentPage => $_->{pageNumber} })
-								% ->fragment("prob$_->{problemNumber}");
+							% $problemLink = $c->systemLink(
+								% url_for(
+									% 'gateway_quiz_version',
+									% setID     => $setID,
+									% versionID => $versionID
+								% ),
+								% params => { effectiveUser => $userID, currentPage => $_->{pageNumber} }
+							% )->fragment("prob$_->{problemNumber}");
 						% } else {
 							% $problemLink =
 								% $c->systemLink(url_for('problem_detail'), params => { effectiveUser => $userID })

--- a/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
+++ b/templates/ContentGenerator/Instructor/ProblemSetDetail.html.ep
@@ -80,7 +80,7 @@
 		</div>
 	% }
 	%
-	% my $setDetailPage = url_for(setID => $setID);
+	% my $setDetailPage = url_for('instructor_set_detail', setID => $setID);
 	%
 	% # Calculate links for the users being edited.
 	% my $userLinks = c;
@@ -117,13 +117,10 @@
 	<div class="border border-dark-subtle mb-2 rounded">
 		<div class="row p-2 align-items-center">
 			<div class="col-md-6">
+				% my $versionText = $editingSetVersion ? ' ' . maketext('(version [_1])', $editingSetVersion) : '';
 				<%== maketext(
 					'Editing problem set [_1] for these students: [_2]',
-					tag(
-						'strong',
-						dir => 'ltr',
-						format_set_name_display($setID . ($editingSetVersion ? ",v$editingSetVersion" : ''))
-					),
+					tag('strong', dir => 'ltr', format_set_name_display($setID) . $versionText),
 					c(tag('br'), tag('strong', $userLinks->join(tag('br'))))->join('')
 				) =%>
 			</div>
@@ -565,9 +562,9 @@
 													% get_test_problem_position($db, $problemToShow);
 												% $problemLink = $c->systemLink(
 													% url_for(
-														% 'gateway_quiz',
-														% setID => $problemToShow->set_id . ',v'
-															% . $problemToShow->version_id,
+														% 'gateway_quiz_version',
+														% setID     => $problemToShow->set_id,
+														% versionID => $problemToShow->version_id,
 														% problemID => $problemToShow->problem_id
 													% ),
 													% params => {

--- a/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
+++ b/templates/ContentGenerator/Instructor/StudentProgress/set_progress.html.ep
@@ -251,14 +251,12 @@
 					<tr>
 						% # If total is -1, then this is a user that hasn't taken any tests.
 						% if ($rec->{total} != -1) {
-							% # Make a versioned set name format nicer and link to the test version.
+							% # Make a versioned set name format nicer and link to the test version. This is an
+							% # instructor-only link, so use the plain (non-proctored) route regardless of the test's
+							% # assignment type. GatewayQuiz.pm is responsible for checking permissions.
 							% my $versionLink = link_to "version $rec->{version}" => $c->systemLink(
-								% url_for(
-									% $rec->{proctored} ? 'proctored_gateway_quiz' : 'gateway_quiz',
-									% setID => "$setID,v$rec->{version}",
-								% ),
-								% params => { effectiveUser => $rec->{record}{user_id} }
-							% );
+								% url_for('gateway_quiz_version', setID => $setID, versionID => $rec->{version}),
+								% params => { effectiveUser => $rec->{record}{user_id} });
 							%
 							<td>
 								% if ($rec->{record}{user_id} eq $prevUserID) {

--- a/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_date_table.html.ep
@@ -1,9 +1,8 @@
 % my $setID = $globalRecord->set_id;
 %
-% # Modify set id to include the version if this is a versioned set.
 % my $isGateway   = $globalRecord->assignment_type =~ /gateway/;
-% my $isVersioned = $isGateway && defined $mergedRecord && $mergedRecord->can('version_id');
-% $setID .= ',v' . $mergedRecord->version_id if $isVersioned;
+% my $isVersioned = $isGateway && defined $mergedRecord && $mergedRecord->version_id;
+% my $fullSetID   = $isVersioned ? "$setID." . $mergedRecord->version_id : $setID;
 %
 <table>
 	<tr>
@@ -41,21 +40,21 @@
 		%
 		<tr>
 			<td class="px-1 text-nowrap">
-				<%= label_for "set.$setID.$field"
+				<%= label_for "set.$fullSetID.$field"
 					. (defined $userRecord ? '_id' : '.class_value') => maketext($fieldLabels->{$field}),
 					class                                            => 'form-label mb-0' =%>
 			</td>
 			% unless ($isVersioned) {
 				<td class="px-1 text-nowrap">
 					<%= text_field
-						"set.$setID.$field.class_value" =>
+						"set.$fullSetID.$field.class_value" =>
 						$c->formatDateTime($globalRecord->$field, 'datetime_format_short'),
-						id       => "set.$setID.$field.class_value",
+						id       => "set.$fullSetID.$field.class_value",
 						readonly => undef,
 						dir      => 'ltr',
 						class    => 'form-control-plaintext form-control-sm w-auto',
 						size     => 16,
-						defined $userRecord ? ('aria-labelledby' => "set.$setID.${field}_id") : (),
+						defined $userRecord ? ('aria-labelledby' => "set.$fullSetID.${field}_id") : (),
 						data => { class_value => $globalRecord->$field } =%>
 				</td>
 			% }
@@ -63,8 +62,8 @@
 				<td class="px-1 text-nowrap">
 					<div class="input-group input-group-sm flex-nowrap flatpickr">
 						<%= text_field
-							"set.$setID.$field" => $userRecord->$field,
-							id                  => "set.$setID.${field}_id",
+							"set.$fullSetID.$field" => $userRecord->$field,
+							id                      => "set.$fullSetID.${field}_id",
 							class => 'form-control w-auto' . ($field eq 'open_date' ? ' datepicker-group' : ''),
 							placeholder => $isGateway
 							? ($isVersioned && $field ne 'reduced_scoring_date'

--- a/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
+++ b/templates/ContentGenerator/Instructor/UserDetail/set_row.html.ep
@@ -11,10 +11,14 @@
 					<i class="icon fa-solid fa-list-check" title="<%= maketext('Test/Quiz') %>"></i>
 					<span class="visually-hidden"><%= maketext('Test/Quiz') %></span>
 				% }
-				<%= link_to format_set_name_display($version ? "$setID (version $version)" : $setID) =>
-					$c->systemLink(
-						url_for('instructor_set_detail', setID => $setID . ($version ? ",v$version" : '')),
-						params => { editForUser => $userID }) =%>
+				<%= link_to format_set_name_display($version ? "$setID (version $version)" : $setID) => $c->systemLink(
+					url_for(
+						$version ? 'instructor_versioned_set_detail' : 'instructor_set_detail',
+						setID     => $setID,
+						versionID => $version
+					),
+					params => { editForUser => $userID }
+				) =%>
 			</span>
 		% } else {
 			<span dir="ltr">
@@ -28,11 +32,12 @@
 	</th>
 	<td class="text-center">
 		<label class="form-check-label">
-			<%= check_box $version ? "set.$setID,v$version.assignment" : "set.$setID.assignment" => 'assigned',
-				class                                                                            => 'form-check-input',
+			<%= check_box $version ? "set.$setID.$version.assignment" : "set.$setID.assignment" => 'assigned',
+				class                                                                           => 'form-check-input',
+				data => { set_id => $setID, $version ? (versioned => undef) : () },
 				defined $mergedSet ? (checked => undef) : () =%>
 			% if (defined $mergedSet && $version) {
-				<%= hidden_field "set.$setID,v$version.assignment" => 'delete' =%>
+				<%= hidden_field "set.$setID.$version.assignment" => 'delete' =%>
 			% }
 		</label>
 	</td>

--- a/templates/ContentGenerator/ProblemSet/version_list.html.ep
+++ b/templates/ContentGenerator/ProblemSet/version_list.html.ep
@@ -74,8 +74,8 @@
 	% }
 	%
 	<div class="mb-3">
-		<%= link_to maketext('Continue Open Test') =>
-			$c->systemLink(url_for($routeName, setID => $set->set_id . ',v' . $continueVersion->version_id)),
+		<%= link_to maketext('Continue Open Test') => $c->systemLink(
+			url_for("${routeName}_version", setID => $set->set_id, versionID => $continueVersion->version_id)),
 			class => 'btn btn-primary' =%>
 	</div>
 % } elsif (($timeNow >= $set->open_date || $authz->hasPermissions($user, 'view_hidden_sets'))
@@ -182,8 +182,9 @@
 						% if ($authz->hasPermissions($user, 'view_hidden_work') || $ver->{show_link}) {
 							<% $interactive = link_to
 								$interactive => $c->systemLink(url_for(
-									$ver->{proctored} ? 'proctored_gateway_quiz' : 'gateway_quiz',
-									setID => $ver->{id}
+									$ver->{proctored} ? 'proctored_gateway_quiz_version' : 'gateway_quiz_version',
+									setID     => $set->set_id,
+									versionID => $ver->{version}
 								)),
 								class => 'set-id-tooltip text-nowrap',
 								data  => {
@@ -204,10 +205,8 @@
 							% $interactive = label_for $ver->{id} => $interactive;
 						% } elsif ($ver->{show_download}) {
 							% # Only display download option if answers are available.
-							<% $control = link_to $c->systemLink(
-								url_for('hardcopy_preselect_set', setID => $ver->{id}),
-								params => { selected_sets => $ver->{id} }
-								),
+							<% $control =
+								link_to $c->systemLink(url_for('hardcopy_preselect_set', setID => $ver->{id})),
 								class => 'hardcopy-link',
 								begin =%>
 								<i


### PR DESCRIPTION
The `version_id` field has been added to the `set_user`, `problem_user`, and `past_answers` tables. If a user set has type "default" or "jitar" then it has version 0.  If a user set has type "gateway" or "proctored_gateway" then it has version 0 if it is the user's template set.  Otherwise it is a versioned set. The same is true for user problems associated with those sets.

When a course database is upgraded the old `<setID>,v<versionID>` in the `set_id` field is separated into the `set_id` without the version, and the `version_id` in its own field. This is done anytime it is detected that the previous database table did not have the `version_id` and it is one of the tables that field has been added to.

This makes database interaction for versioned sets much cleaner and straight forward. Since a `version_id` is an actual database table column, you can use it directly in where and order clauses without hackery.  All of the "groking" for a set version is eliminated.

Note that it is now the case that when a user with the `proctor_quiz_login` permission attempts to enter a proctored test (either their own or to view another user's test when acting as that user), the user will not need to enter the proctor credentials (and will skip the proctor login page entirely).  Also, a user with the `proctor_quiz_grade` permission will not see the proctor login page when grading a test (again for either their own test or when allowed to grade a test when acting as another user).

Note that the `$authen{proctor_module}` option has been removed from the `defaults.config` file.  There is only one proctor authentication module `WeBWorK::Authen::Proctor`, and it is now hardcoded.  No need for the option.

Other than the change to the proctor login noted above, everything else should work the same as before.