### PR TITLE
Fix LMS roster synchronization for large classes. (hotfix of #3181)

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
+++ b/lib/WeBWorK/ContentGenerator/Instructor/UserList.pm
@@ -551,245 +551,260 @@ async sub lms_roster_sync_handler ($c) {
 		|| $ce->{LTIVersion} ne 'v1p3'
 		|| !$ce->{LTI}{v1p3}{preferred_source_of_username};
 
+	# FIXME: This should be moved to the job queue. If the class is large, this can be an intensive process.
 	my $namesRolesServiceURL = $db->getSettingValue('LTINamesRolesServiceURL');
 	return (0, $c->maketext('The LTI names/roles service URL is not available.')) unless $namesRolesServiceURL;
 
 	my $accessToken = await WeBWorK::Authen::LTIAdvantage::SubmitGrade->new($c)->get_access_token;
 	return (0, $c->maketext('Unable to obtain access token.')) unless $accessToken;
 
-	my $namesRolesServiceRequest = await Mojo::UserAgent->new->get_p($namesRolesServiceURL,
-		{ Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })->catch(sub ($err) {
-		return $err;
-		});
-	return (0, $c->maketext("Error communicating with the names and roles service URL: $namesRolesServiceRequest\n"))
-		unless ref $namesRolesServiceRequest;
+	my @namesRoles;
 
-	my $namesRolesServiceResult = $namesRolesServiceRequest->result;
-	if ($namesRolesServiceResult->is_success) {
-		my $namesRoles = $namesRolesServiceResult->json->{members};
-		return (0, $c->maketext('Invalid data received from the LMS.')) unless ref $namesRoles eq 'ARRAY';
+	while (1) {
+		my $namesRolesServiceRequest = await Mojo::UserAgent->new->get_p($namesRolesServiceURL,
+			{ Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })->catch(sub ($err) {
+			return $err;
+			});
+		return (0,
+			$c->maketext("Error communicating with the names and roles service URL: $namesRolesServiceRequest\n"))
+			unless ref $namesRolesServiceRequest;
 
-		my (@addedUsers, @userAchievementRecordsToAdd, @globalAchievementRecordsToAdd, %usersInLMSCourse);
-		my $updatedUsers = 0;
+		my $namesRolesServiceResult = $namesRolesServiceRequest->result;
+		if ($namesRolesServiceResult->is_success) {
+			my $namesRoles = $namesRolesServiceResult->json->{members};
+			return (0, $c->maketext('Invalid data received from the LMS.')) unless ref $namesRoles eq 'ARRAY';
+			push(@namesRoles, @$namesRoles);
 
-		my @achievements = $db->getAchievementsWhere({ enabled => 1 }, ['achievement_id']);
-
-		my $preferredSourceOfUsername = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
-			|| $ce->{LTI}{v1p3}{preferred_source_of_username};
-		my $fallbackPasswordSource = $ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
-			|| $ce->{LTI}{v1p3}{fallback_source_of_username};
-		my $preferredSourceOfStudentId = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_student_id}
-			|| $ce->{LTI}{v1p3}{preferred_source_of_student_id};
-
-		for my $user (@$namesRoles) {
-			my ($userIdSource, $typeOfSource) = ('', '');
-			my $userId = $user->{$preferredSourceOfUsername};
-			if (defined $userId) {
-				$userIdSource = $preferredSourceOfUsername;
-				$typeOfSource =
-					"$userIdSource which was "
-					. ($ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
-						? 'namesroles_service_preferred_source_of_username'
-						: 'preferred_source_of_username');
-			} elsif ($fallbackPasswordSource && !defined $userId && defined $user->{$fallbackPasswordSource}) {
-				$userIdSource = $fallbackPasswordSource;
-				$typeOfSource =
-					"$userIdSource which was"
-					. ($ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
-						? 'namesroles_service_fallback_source_of_username'
-						: 'fallback_source_of_username');
-				$userId = $user->{$fallbackPasswordSource};
+			if ($namesRolesServiceResult->headers->link
+				&& $namesRolesServiceResult->headers->link =~ /<([^>]*)>;\s*rel="next"/)
+			{
+				$namesRolesServiceURL = $1;
+			} else {
+				last;
 			}
+		} else {
+			return (
+				0,
+				$c->maketext(
+					'There was an error obtaining the list of users from the LMS: [_1]',
+					$namesRolesServiceResult->message
+				)
+			);
+		}
+	}
 
-			unless (defined $userId) {
-				warn "=====================================\n"
-					. "Unable to determine a webwork user id for LMS user:\n"
-					. $c->dumper($user)
-					. "\n=====================================\n"
-					if $ce->{debug_lti_parameters};
-				next;
-			}
+	my (@addedUsers, @userAchievementRecordsToAdd, @globalAchievementRecordsToAdd, %usersInLMSCourse);
+	my $updatedUsers = 0;
 
-			$userId =~ s/@.*$//   if $userIdSource eq 'email' && $ce->{LTI}{v1p3}{strip_domain_from_email};
-			$userId = lc($userId) if $ce->{LTI}{v1p3}{lowercase_username};
+	my @achievements = $db->getAchievementsWhere({ enabled => 1 }, ['achievement_id']);
 
-			my $studentId = $preferredSourceOfStudentId ? ($user->{$preferredSourceOfStudentId} // '') : '';
+	my $preferredSourceOfUsername = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
+		|| $ce->{LTI}{v1p3}{preferred_source_of_username};
+	my $fallbackPasswordSource = $ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
+		|| $ce->{LTI}{v1p3}{fallback_source_of_username};
+	my $preferredSourceOfStudentId = $ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_student_id}
+		|| $ce->{LTI}{v1p3}{preferred_source_of_student_id};
 
-			if ($ce->{debug_lti_parameters}) {
-				warn "=========== USER SUMMARY ============\n";
-				warn "----------- LMS USER DATA -----------\n";
-				warn $c->dumper($user);
-				warn "\n-------------------------------------\n";
-				warn "User id is |$userId| (obtained from $typeOfSource)\n";
-				warn "User email address is |$user->{email}|\n";
-				warn "Student id is |$studentId|\n";
-				warn "=====================================\n";
-			}
+	for my $user (@namesRoles) {
+		my ($userIdSource, $typeOfSource) = ('', '');
+		my $userId = $user->{$preferredSourceOfUsername};
+		if (defined $userId) {
+			$userIdSource = $preferredSourceOfUsername;
+			$typeOfSource =
+				"$userIdSource which was "
+				. ($ce->{LTI}{v1p3}{namesroles_service_preferred_source_of_username}
+					? 'namesroles_service_preferred_source_of_username'
+					: 'preferred_source_of_username');
+		} elsif ($fallbackPasswordSource && !defined $userId && defined $user->{$fallbackPasswordSource}) {
+			$userIdSource = $fallbackPasswordSource;
+			$typeOfSource =
+				"$userIdSource which was"
+				. ($ce->{LTI}{v1p3}{namesroles_service_fallback_source_of_username}
+					? 'namesroles_service_fallback_source_of_username'
+					: 'fallback_source_of_username');
+			$userId = $user->{$fallbackPasswordSource};
+		}
 
-			$usersInLMSCourse{$userId} = 1;
-
-			if ($userId eq $c->param('user')) {
-				warn "Skipping $userId because this is you.\n" if $ce->{debug_lti_parameters};
-				next;
-			}
-
-			# Note that the only reliably obtained roles here are the membership roles. The issue is that these roles
-			# are allowed to be abbreviated (i.e., the http://purl.imsglobal.org/... part may be entirely omitted
-			# according to the specification). Moodle does this, but Canvas does not. However, both seem to add a prefix
-			# for non-membership roles. Also, "institution" roles are not sent, so it is not even possible to honor the
-			# $ce->{LTI}{v1p3}{AllowInstitutionRoles} setting.
-			my @LTIroles = map {s|^http://purl.imsglobal.org/vocab/lis/v2/membership#||r} @{ $user->{roles} };
-
-			warn "The LTI roles defined for $userId are: \n-- " . join("\n-- ", @LTIroles) . "\n"
+		unless (defined $userId) {
+			warn "=====================================\n"
+				. "Unable to determine a webwork user id for LMS user:\n"
+				. $c->dumper($user)
+				. "\n=====================================\n"
 				if $ce->{debug_lti_parameters};
+			next;
+		}
 
-			if (!defined($ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } })) {
-				warn "Skipping $userId. Cannot find a WeBWorK role that corresponds to the "
-					. "LMS role of $LTIroles[0] for this user.\n"
-					if $ce->{debug_lti_parameters};
-				next;
+		$userId =~ s/@.*$//   if $userIdSource eq 'email' && $ce->{LTI}{v1p3}{strip_domain_from_email};
+		$userId = lc($userId) if $ce->{LTI}{v1p3}{lowercase_username};
+
+		my $studentId = $preferredSourceOfStudentId ? ($user->{$preferredSourceOfStudentId} // '') : '';
+
+		if ($ce->{debug_lti_parameters}) {
+			warn "=========== USER SUMMARY ============\n";
+			warn "----------- LMS USER DATA -----------\n";
+			warn $c->dumper($user);
+			warn "\n-------------------------------------\n";
+			warn "User id is |$userId| (obtained from $typeOfSource)\n";
+			warn "User email address is |$user->{email}|\n";
+			warn "Student id is |$studentId|\n";
+			warn "=====================================\n";
+		}
+
+		$usersInLMSCourse{$userId} = 1;
+
+		if ($userId eq $c->param('user')) {
+			warn "Skipping $userId because this is you.\n" if $ce->{debug_lti_parameters};
+			next;
+		}
+
+		# Note that the only reliably obtained roles here are the membership roles. The issue is that these roles
+		# are allowed to be abbreviated (i.e., the http://purl.imsglobal.org/... part may be entirely omitted
+		# according to the specification). Moodle does this, but Canvas does not. However, both seem to add a prefix
+		# for non-membership roles. Also, "institution" roles are not sent, so it is not even possible to honor the
+		# $ce->{LTI}{v1p3}{AllowInstitutionRoles} setting.
+		my @LTIroles = map {s|^http://purl.imsglobal.org/vocab/lis/v2/membership#||r} @{ $user->{roles} };
+
+		warn "The LTI roles defined for $userId are: \n-- " . join("\n-- ", @LTIroles) . "\n"
+			if $ce->{debug_lti_parameters};
+
+		if (!defined($ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } })) {
+			warn "Skipping $userId. Cannot find a WeBWorK role that corresponds to the "
+				. "LMS role of $LTIroles[0] for this user.\n"
+				if $ce->{debug_lti_parameters};
+			next;
+		}
+
+		my $permissionLevel = $ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } };
+		if (@LTIroles > 1) {
+			for (@LTIroles[ 1 .. $#LTIroles ]) {
+				my $wwRole = $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{$_};
+				next unless defined $wwRole;
+				$permissionLevel = $ce->{userRoles}{$wwRole} if $permissionLevel < $ce->{userRoles}{$wwRole};
 			}
+		}
+		if ($permissionLevel > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }) {
+			warn "Skipping $userId. User has a role above the LTI "
+				. "account creation cutoff of $ce->{LTIAccountCreationCutoff}.\n"
+				if $ce->{debug_lti_parameters};
+			next;
+		}
 
-			my $permissionLevel = $ce->{userRoles}{ $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{ $LTIroles[0] } };
-			if (@LTIroles > 1) {
-				for (@LTIroles[ 1 .. $#LTIroles ]) {
-					my $wwRole = $ce->{LTI}{v1p3}{LMSrolesToWeBWorKroles}{$_};
-					next unless defined $wwRole;
-					$permissionLevel = $ce->{userRoles}{$wwRole} if $permissionLevel < $ce->{userRoles}{$wwRole};
+		if ($c->{allUsers}{$userId}) {
+			next unless $ce->{LMSManageUserData};
+
+			# Create a temporary user with the LMS credentials and compare the user to the existing user.
+			my $tempUser = $db->newUser(
+				user_id        => $userId,
+				lis_source_did => $user->{user_id},
+				last_name      => $user->{family_name} =~ s/\+/ /gr,
+				first_name     => $user->{given_name}  =~ s/\+/ /gr,
+				email_address  => $user->{email},
+				status         => $user->{status} eq 'Active' ? 'C' : 'D',
+				comment        => $c->formatDateTime(time),
+				student_id     => $studentId,
+				section        => '',
+				recitation     => ''
+			);
+
+			my $change_made = 0;
+			for my $element (qw(last_name first_name email_address status student_id)) {
+				if ($c->{allUsers}{$userId}->$element ne $tempUser->$element) {
+					$change_made = 1;
+					warn "WeBWorK user has $element: "
+						. $c->{allUsers}{$userId}->$element
+						. ", but LMS user has $element: "
+						. $tempUser->$element . "\n"
+						if $ce->{debug_lti_parameters};
+					$c->{allUsers}{$userId}->$element($tempUser->$element);
 				}
 			}
-			if ($permissionLevel > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }) {
-				warn "Skipping $userId. User has a role above the LTI "
-					. "account creation cutoff of $ce->{LTIAccountCreationCutoff}.\n"
-					if $ce->{debug_lti_parameters};
-				next;
-			}
 
-			if ($c->{allUsers}{$userId}) {
-				next unless $ce->{LMSManageUserData};
-
-				# Create a temporary user with the LMS credentials and compare the user to the existing user.
-				my $tempUser = $db->newUser(
-					user_id        => $userId,
-					lis_source_did => $user->{user_id},
-					last_name      => $user->{family_name} =~ s/\+/ /gr,
-					first_name     => $user->{given_name}  =~ s/\+/ /gr,
-					email_address  => $user->{email},
-					status         => $user->{status} eq 'Active' ? 'C' : 'D',
-					comment        => $c->formatDateTime(time),
-					student_id     => $studentId,
-					section        => '',
-					recitation     => ''
-				);
-
-				my $change_made = 0;
-				for my $element (qw(last_name first_name email_address status student_id)) {
-					if ($c->{allUsers}{$userId}->$element ne $tempUser->$element) {
-						$change_made = 1;
-						warn "WeBWorK user has $element: "
-							. $c->{allUsers}{$userId}->$element
-							. ", but LMS user has $element: "
-							. $tempUser->$element . "\n"
-							if $ce->{debug_lti_parameters};
-						# Update the data for this page.
-						$c->{allUsers}{$userId}->$element($tempUser->$element);
-					}
-				}
-
-				if ($change_made) {
-					++$updatedUsers;
-					$tempUser->comment($c->formatDateTime(time));
-					eval { $db->putUser($tempUser) };
-					if ($@) {
-						$c->log->error("Failed to update user $userId when importing LMS user: $@");
-						warn "Failed to update user $userId.\n" if $ce->{debug_lti_parameters};
-					} else {
-						warn "Updated user $userId.\n" if $ce->{debug_lti_parameters};
-					}
+			if ($change_made) {
+				++$updatedUsers;
+				$tempUser->comment($c->formatDateTime(time));
+				eval { $db->putUser($tempUser) };
+				if ($@) {
+					$c->log->error("Failed to update user $userId when importing LMS user: $@");
+					warn "Failed to update user $userId.\n" if $ce->{debug_lti_parameters};
 				} else {
-					warn "$userId not changed.\n" if $ce->{debug_lti_parameters};
+					warn "Updated user $userId.\n" if $ce->{debug_lti_parameters};
 				}
 			} else {
-				warn "Adding user $userId with permission level $permissionLevel.\n" if $ce->{debug_lti_parameters};
-				push(@addedUsers, $userId);
-
-				my $newUser = $db->newUser(
-					user_id        => $userId,
-					lis_source_did => $user->{user_id},
-					last_name      => $user->{family_name} =~ s/\+/ /gr,
-					first_name     => $user->{given_name}  =~ s/\+/ /gr,
-					email_address  => $user->{email},
-					status         => $user->{status} eq 'Active' ? 'C' : 'D',
-					comment        => $c->formatDateTime(time),
-					student_id     => $studentId,
-					section        => '',
-					recitation     => ''
-				);
-				$db->addUser($newUser);
-
-				$db->addPermissionLevel($db->newPermissionLevel(user_id => $userId, permission => $permissionLevel));
-
-				for (@achievements) {
-					push(@userAchievementRecordsToAdd,
-						$db->newUserAchievement(user_id => $userId, achievement_id => $_->achievement_id));
-				}
-				push(@globalAchievementRecordsToAdd,
-					$db->newGlobalUserAchievement(user_id => $userId, achievement_points => 0));
-
-				# Update the data for this page.
-				$newUser->{permission}        = $permissionLevel;
-				$newUser->{passwordExists}    = 0;
-				$c->{allUsers}{$userId}       = $newUser;
-				$c->{visibleUserIDs}{$userId} = 1;
-				$c->{userIsEditable}{$userId} = 1;
+				warn "$userId not changed.\n" if $ce->{debug_lti_parameters};
 			}
+		} else {
+			warn "Adding user $userId with permission level $permissionLevel.\n" if $ce->{debug_lti_parameters};
+			push(@addedUsers, $userId);
+
+			my $newUser = $db->newUser(
+				user_id        => $userId,
+				lis_source_did => $user->{user_id},
+				last_name      => $user->{family_name} =~ s/\+/ /gr,
+				first_name     => $user->{given_name}  =~ s/\+/ /gr,
+				email_address  => $user->{email},
+				status         => $user->{status} eq 'Active' ? 'C' : 'D',
+				comment        => $c->formatDateTime(time),
+				student_id     => $studentId,
+				section        => '',
+				recitation     => ''
+			);
+			$db->addUser($newUser);
+
+			$db->addPermissionLevel($db->newPermissionLevel(user_id => $userId, permission => $permissionLevel));
+
+			for (@achievements) {
+				push(@userAchievementRecordsToAdd,
+					$db->newUserAchievement(user_id => $userId, achievement_id => $_->achievement_id));
+			}
+			push(@globalAchievementRecordsToAdd,
+				$db->newGlobalUserAchievement(user_id => $userId, achievement_points => 0));
+
+			# Update the data for this page.
+			$newUser->{permission}        = $permissionLevel;
+			$newUser->{passwordExists}    = 0;
+			$c->{allUsers}{$userId}       = $newUser;
+			$c->{visibleUserIDs}{$userId} = 1;
+			$c->{userIsEditable}{$userId} = 1;
 		}
-
-		# Assign visible sets to the added users.
-		assignSetsToUsers($db, $ce, [ map { $_->[0] } $db->listGlobalSetsWhere({ visible => 1 }) ], \@addedUsers)
-			if @addedUsers;
-
-		# Assign achievements to the added users.
-		$db->UserAchievement->insert_records(\@userAchievementRecordsToAdd) if @userAchievementRecordsToAdd;
-		$db->GlobalUserAchievement->insert_records(\@globalAchievementRecordsToAdd)
-			if @globalAchievementRecordsToAdd;
-
-		# Mark all users not in the LMS roster and at or below the LTIAccountCreationCutoff as dropped.
-		my @droppedUsers;
-		for my $user (values %{ $c->{allUsers} }) {
-			next
-				if $usersInLMSCourse{ $user->user_id }
-				|| $user->{permission} > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }
-				|| $user->status eq 'D';
-			$user->status('D');
-			push(@droppedUsers, $user);
-		}
-		$db->User->update_records(\@droppedUsers) if @droppedUsers;
-
-		return (
-			1,
-			$ce->{LMSManageUserData}
-			? $c->maketext(
-				'[_1] [plural,_1,user] added, [_2] [plural,_2,user] updated, '
-					. '[_3] [plural,_3,user] not in LMS [plural,_3,was,were] dropped',
-				scalar(@addedUsers),
-				$updatedUsers,
-				scalar(@droppedUsers)
-				)
-			: $c->maketext(
-				'[_1] [plural,_1,user] added, [_2] [plural,_2,user] not in LMS [plural,_2,was,were] dropped',
-				scalar(@addedUsers), scalar(@droppedUsers)
-			)
-		);
-	} else {
-		return (
-			0,
-			$c->maketext(
-				'There was an error obtaining the list of users from the LMS: [_1]',
-				$namesRolesServiceResult->message
-			)
-		);
 	}
+
+	# Assign visible sets to the added users.
+	assignSetsToUsers($db, $ce, [ map { $_->[0] } $db->listGlobalSetsWhere({ visible => 1 }) ], \@addedUsers)
+		if @addedUsers;
+
+	# Assign achievements to the added users.
+	$db->UserAchievement->insert_records(\@userAchievementRecordsToAdd) if @userAchievementRecordsToAdd;
+	$db->GlobalUserAchievement->insert_records(\@globalAchievementRecordsToAdd)
+		if @globalAchievementRecordsToAdd;
+
+	# Mark all users not in the LMS roster and at or below the LTIAccountCreationCutoff as dropped.
+	my @droppedUsers;
+	for my $user (values %{ $c->{allUsers} }) {
+		next
+			if $usersInLMSCourse{ $user->user_id }
+			|| $user->{permission} > $ce->{userRoles}{ $ce->{LTIAccountCreationCutoff} }
+			|| $user->status eq 'D'
+			|| !$c->{userIsEditable}{ $user->user_id };
+		$user->status('D');
+		push(@droppedUsers, $user);
+	}
+	$db->User->update_records(\@droppedUsers) if @droppedUsers;
+
+	return (
+		1,
+		$ce->{LMSManageUserData}
+		? $c->maketext(
+			'[_1] [plural,_1,user] added, [_2] [plural,_2,user] updated, '
+				. '[_3] [plural,_3,user] not in LMS [plural,_3,was,were] dropped',
+			scalar(@addedUsers),
+			$updatedUsers,
+			scalar(@droppedUsers)
+			)
+		: $c->maketext(
+			'[_1] [plural,_1,user] added, [_2] [plural,_2,user] not in LMS [plural,_2,was,were] dropped',
+			scalar(@addedUsers), scalar(@droppedUsers)
+		)
+	);
 }
 
 sub cancel_edit_handler ($c) {


### PR DESCRIPTION
The names and role provisioning services specification states that a platform does not need to return all users in a single request to the names and roles URL, and apparently Canvas (and probably others) does not return all of them at once if there are enough of them (50 seems to be the limit that Canvas uses in my testing).  If the first request contains a `rel="next"` URL in its `link` header, that means that there are more users to be fetched.  So the LMS roster synchronization handler needs to follow that returned link as many times as it is returned from the previous request until all users are obtained.

Since the current code just stops after the first request, and for a large class does not have all users, this results in the remaining users being dropped from the webwork course.

I tested this with my Canvas instance with 300 users in a course. That took about 25 seconds for the initial roster import.  So this also reveals that this really should be a job queue process, and not in the current request.  Although, that is not done at this point, and is left for another pull request and the next release. However, if we feel this is pressing enough, it can be done now as a hotfix.