### PR TITLE
Remove dead code for deleting the proctor key at logout.

### DIFF
--- a/lib/WeBWorK/ContentGenerator/Logout.pm
+++ b/lib/WeBWorK/ContentGenerator/Logout.pm
@@ -21,23 +21,6 @@ sub pre_header_initialize ($c) {
 	$authen->killSession;
 	$authen->write_log_entry('LOGGED OUT');
 
-	# Check to see if there is a proctor key associated with this login.  If there is a proctor user, then there must be
-	# a proctored test.  So try and delete the key.
-	my $proctorID = $c->param('proctor_user');
-	if ($proctorID) {
-		my $userID = $c->param('user_id');
-
-		eval { $db->deleteKey("$userID,$proctorID"); };
-		if ($@) {
-			$c->addbadmessage("Error when clearing proctor key: $@");
-		}
-		# There may also be a proctor key from grading the test.
-		eval { $db->deleteKey("$userID,$proctorID,g"); };
-		if ($@) {
-			$c->addbadmessage("Error when clearing proctor grading key: $@");
-		}
-	}
-
 	if ($authen->{redirect}) {
 		$c->reply_with_redirect($authen->{redirect});
 	} elsif ($c->param('show_login')) {


### PR DESCRIPTION
The proctor user no longer has its own key in the key table.  Instead it is stored in the session.  So this code is not doing anything anymore.