### PR TITLE
Move the RPC render problem iframe theme chooser JavaScript to its own file.

### DIFF
--- a/htdocs/js/RenderProblem/iframe-child.js
+++ b/htdocs/js/RenderProblem/iframe-child.js
@@ -1,0 +1,7 @@
+(() => {
+	window.parent.postMessage('render-iframe-ready');
+	window.addEventListener('message', (event) => {
+		if (!event.data || !event.data.theme) return;
+		document.documentElement.dataset.bsTheme = event.data.theme;
+	});
+})();

--- a/templates/RPCRenderFormats/default.html.ep
+++ b/templates/RPCRenderFormats/default.html.ep
@@ -13,13 +13,7 @@
 			course: <%= $courseID %>
 		</title>
 		<link href="<%= "$ce->{webworkURLs}{htdocs}/images/favicon.ico" %>" rel="shortcut icon">
-		<script>
-			window.parent.postMessage('render-iframe-ready');
-			window.addEventListener('message', (event) => {
-				if (!event.data || !event.data.theme) return;
-				document.documentElement.dataset.bsTheme = event.data.theme;
-			});
-		</script>
+		%= javascript getAssetURL($ce, 'js/RenderProblem/iframe-child.js'), defer => undef
 		% # Add third party css and javascript as well as css and javascript requested by the problem.
 		% for (@$third_party_css) {
 			%= stylesheet $_


### PR DESCRIPTION
This inline script was added in #3145 to support PG dark mode, and most likely @taniwallach will want this not to be inline with the `Content-Security-Policy` headers he is using.