### PR TITLE
Make sure to account for an undefined `ANSWER_ENTRY_ORDER` in the single problem grader.

### DIFF
--- a/templates/HTML/SingleProblemGrader/grader.html.ep
+++ b/templates/HTML/SingleProblemGrader/grader.html.ep
@@ -17,7 +17,7 @@
 		% my $rawCurrentScore = 0;
 		%
 		% # Subscores for each answer in the problem.
-		% if (@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1) {
+		% if (@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} // [] } > 1) {
 			% # Determine the scores and weights for each part of the problem.
 			% my $total = 0;
 			% my (@scores, @weights);
@@ -77,7 +77,7 @@
 				</div>
 			% }
 			% $currentScore = wwRound(0, $rawCurrentScore);
-		% } elsif (@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} }) {
+		% } elsif (@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} // [] }) {
 			% $rawCurrentScore = $grader->{pg}{answers}{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER}[0] }{score} * 100;
 			% $currentScore    = wwRound(0, $rawCurrentScore);
 			<%= hidden_field
@@ -111,7 +111,7 @@
 								)
 							)
 							. (
-								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1 ? tag(
+								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} // [] } > 1 ? tag(
 									'p',
 									class => 'mt-2 mb-0',
 									maketext(
@@ -185,7 +185,7 @@
 								maketext('The initial value is the currently saved score for this student.')
 							)
 							. (
-								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} } > 1 ? tag(
+								@{ $grader->{pg}{flags}{ANSWER_ENTRY_ORDER} // [] } > 1 ? tag(
 									'p',
 									class => 'mt-2 mb-0',
 									maketext(


### PR DESCRIPTION
Previously the problem grader could only be made visible when the problem successfully rendered.  Now that it is always visible, a little more care is needed.  The `ANSWER_ENTRY_ORDER` array in the PG flags will not be defined if the problem does not successfully render.

This fixes issue #3194.