### PR TITLE
Get all sets when performing LTI date synchronization.

### DIFF
--- a/lib/Mojolicious/WeBWorK/Tasks/LTISetDateSync.pm
+++ b/lib/Mojolicious/WeBWorK/Tasks/LTISetDateSync.pm
@@ -52,25 +52,37 @@ async sub synchronizeSetDates ($job, $setIDs, $syncToLMS) {
 
 	my $ua = Mojo::UserAgent->new;
 
-	my $lineitemsRequest =
-		await $ua->get_p($lineitemsURL, { Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })
-		->catch(sub ($err) {
-			return $err;
-		});
+	my %lineitems;
+	while (1) {
+		my $lineitemsRequest =
+			await $ua->get_p($lineitemsURL,
+				{ Authorization => "$accessToken->{token_type} $accessToken->{access_token}" })->catch(sub ($err) {
+				return $err;
+				});
 
-	return $job->fail(
-		$job->maketext('There was an error communicating with the lineitems URL: [_1]', $lineitemsRequest))
-		unless ref $lineitemsRequest;
+		return $job->fail(
+			$job->maketext('There was an error communicating with the lineitems URL: [_1]', $lineitemsRequest))
+			unless ref $lineitemsRequest;
 
-	my $lineitemsResult = $lineitemsRequest->result;
+		my $lineitemsResult = $lineitemsRequest->result;
 
-	return $job->fail($job->maketext(
-		'There was an error obtaining the current lineitems from the LMS: [_1]',
-		$lineitemsResult->message
-	))
-		unless $lineitemsResult->is_success;
+		return $job->fail($job->maketext(
+			'There was an error obtaining the current lineitems from the LMS: [_1]',
+			$lineitemsResult->message
+		))
+			unless $lineitemsResult->is_success;
 
-	my %lineitems = map { $_->{resourceId} => $_ } grep { defined $_->{resourceId} } @{ $lineitemsResult->json };
+		for (@{ $lineitemsResult->json }) {
+			next unless defined $_->{resourceId};
+			$lineitems{ $_->{resourceId} } = $_;
+		}
+
+		if ($lineitemsResult->headers->link && $lineitemsResult->headers->link =~ /<([^>]*)>;\s*rel="next"/) {
+			$lineitemsURL = $1;
+		} else {
+			last;
+		}
+	}
 
 	my @messages;
 


### PR DESCRIPTION
After the issue with the names and role service URL and realizing that the `next` link needs to be utilized to get all names and roles from the URL, I figured I had better check the spec for the `lineitems` URL used for set date synchronization to see if it works the same, and in fact, it does.  See https://www.imsglobal.org/spec/lti-ags/v2p0#container-request-filters. So this makes sure that all sets are obtained from the `lineitems` URL in the same way.

In testing this with Canvas, it turns out that Canvas only sends 10 sets at once.  So if a course has more than 10 sets, then only 10 sets will be retrieved from the lineitems URL in the first request.  Note that date synchronization will not necessarily fail though, as in the next phase of the job queue task, requests are sent to the individual lineitem URLs for the sets if the data was not received from the lineitems URL for the set assuming that the lineitem URL for the set has been obtained (webwork will have it if content item selection was used, or if a user has entered the set directly from the LMS).  However, this results in extra network communication that is unnecessary.