### PR TITLE
Fix PG color scheme selection with explicit 'Auto' mode set.

### DIFF
--- a/htdocs/js/PGProblemEditor/pgproblemeditor.js
+++ b/htdocs/js/PGProblemEditor/pgproblemeditor.js
@@ -595,10 +595,14 @@
 
 	window.addEventListener('message', (event) => {
 		if (event.data !== 'render-iframe-ready' || iframe.contentWindow !== event.source) return;
+		const storedTheme = localStorage.getItem('WW.color-scheme');
 		iframe.contentWindow.postMessage({
 			theme:
-				localStorage.getItem('WW.color-scheme') ??
-				(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+				storedTheme && storedTheme !== 'auto'
+					? storedTheme
+					: window.matchMedia('(prefers-color-scheme: dark)').matches
+						? 'dark'
+						: 'light'
 		});
 	});
 

--- a/htdocs/js/RenderProblem/renderproblem.js
+++ b/htdocs/js/RenderProblem/renderproblem.js
@@ -3,12 +3,16 @@
 
 	window.addEventListener('message', (event) => {
 		if (event.data !== 'render-iframe-ready') return;
+		const storedTheme = localStorage.getItem('WW.color-scheme');
 		renderedIframes
 			.find((i) => i.contentWindow === event.source)
 			?.contentWindow.postMessage({
 				theme:
-					localStorage.getItem('WW.color-scheme') ??
-					(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light')
+					storedTheme && storedTheme !== 'auto'
+						? storedTheme
+						: window.matchMedia('(prefers-color-scheme: dark)').matches
+							? 'dark'
+							: 'light'
 			});
 	});
 


### PR DESCRIPTION
When the color scheme selector at the top of the page is used and "Auto" is selected, and the browser is set to dark mode, problems are rendered incorrectly in light mode.  This is because the `renderproblem.js` and 'pgproblemeditor.js' JavaScript send the "auto" setting from local storage and the iframe child JavaScript sets the `data-bs-theme` attribute of the iframe page to that.  Since that value means nothing in terms of color scheme selection for bootstrap, the page renders in the default bootstrap light mode. So if the theme in local storage is 'auto', detect the browser setting and use that to select 'dark' or 'light' to send to the iframe child.