### PR TITLE
Adjust the `scroll-margin-top` for anchors on pages with the student nav. (hotfix of #3203)

### DIFF
--- a/htdocs/js/System/system.js
+++ b/htdocs/js/System/system.js
@@ -93,6 +93,19 @@
 		});
 	}
 
+	// Account for the height of the sticky nav (if present) in scroll-margin-top, so
+	// that utilizing a URL fragment doesn't obscure anchors behind the sticky nav.
+	const stickyNav = document.querySelector('.sticky-nav');
+	if (stickyNav) {
+		const updateStickyNavHeight = () =>
+			document.documentElement.style.setProperty(
+				'--sticky-nav-height',
+				`calc(${stickyNav.offsetHeight}px + 1rem)`
+			);
+		new ResizeObserver(updateStickyNavHeight).observe(stickyNav);
+		updateStickyNavHeight();
+	}
+
 	// Make elements with role="button" (that have been given the class below) activate upon use of the spacebar.
 	for (const btn of document.querySelectorAll('.spacebar-activatable')) {
 		btn.addEventListener('keydown', (e) => {

--- a/htdocs/js/System/system.scss
+++ b/htdocs/js/System/system.scss
@@ -236,7 +236,7 @@ $site-nav-width: 250px !default;
 	width: calc(100% - $site-nav-width);
 
 	*[id] {
-		scroll-margin-top: $masthead-height;
+		scroll-margin-top: calc($masthead-height + var(--sticky-nav-height, 0px));
 	}
 
 	&.toggle-width {
@@ -250,7 +250,7 @@ $site-nav-width: 250px !default;
 		margin-left: auto;
 
 		*[id] {
-			scroll-margin-top: 0.75 * $masthead-height;
+			scroll-margin-top: calc(0.75 * $masthead-height + var(--sticky-nav-height, 0px));
 		}
 	}
 }


### PR DESCRIPTION
This makes the `scroll-margin-top` setting for elements with an `id` attribute (used as anchors via a URL fragment) account for the height of the student/problem nav if it is present on the page.  Basically, the value of the `--sticky-nav-height` css variable is always added to the `scroll-margin-top` for these elements.  If the sticky student/problem nav is present on the page, then JavaScript sets the value of that css variable to the height of the sticky nav plus `1rem`.  Thus when a URL fragment is used the id element is not obscured behind the sticky nav.

One place where this is prominent is when viewing a problem in a test from either the set detail page for the test when editing a set version for a user, or from the manual problem grader when grading a problem in a test.

@somiaj mentioned this in #3202, and I have observed this for a while now. Note that @somiaj adds `outline: none` to these test div elements with an `id` which also improves the initial appearance when the page loads.