### PR TITLE
Fix how parserRadioMultiAnswer.pl answers are counted as unanswered when grading a test (hotfix of #3208)

### DIFF
--- a/htdocs/js/GatewayQuiz/gateway.js
+++ b/htdocs/js/GatewayQuiz/gateway.js
@@ -248,6 +248,16 @@
 			for (const input of inputs.filter(
 				(i) => /Q\d{4}_/.test(i.name) && !/^MaThQuIlL_/.test(i.name) && !/^previous_/.test(i.name)
 			)) {
+				// The sub-answer blanks of a RadioMultiAnswer are only required to be
+				// answered if they belong to the currently selected radio button.
+				if (/RaDiOMuLtIaNsWeR_/.test(input.name)) {
+					const radioContent = input.closest('.radio-content');
+					const checkedRadio = radioContent?.dataset.radio
+						? Array.from(document.getElementsByName(radioContent.dataset.radio)).find((r) => r.checked)
+						: undefined;
+					if (!checkedRadio || checkedRadio.value !== radioContent.dataset.index) continue;
+				}
+
 				const answered =
 					input.type === 'radio' || input.type === 'checkbox' ? !!input.checked : /\S/.test(input.value);
 				const match = /Q(\d{4})_/.exec(input.name);


### PR DESCRIPTION
Currently the javascript considers all of the inputs.  However, the inputs in the unchecked parts of a `RadioMultiAnswer` will not have an answer, and should not affect whether a question is determined to be answered or not. So the part sub answers for the unchecked radio buttons are ignored, and only the checked radio button answers considered.